### PR TITLE
Fix obvious problems with Windows

### DIFF
--- a/download/_windows.md
+++ b/download/_windows.md
@@ -38,9 +38,20 @@ start /w vs_community.exe --passive --wait --norestart --nocache ^
 del /q vs_community.exe
 ~~~
 
-1. Download the [latest package release](/download).
+0. Install Swift:
 
-2. Run the package installer, which will install a Swift toolchain into `%SystemDrive%\Library\Developer\Toolchains`.
+Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
+
+* Using the official installer:
+  1. Download the [latest package release](/download).
+  1. Run the package installer.
+
+* Using the Windows Package Manager:
+  ~~~ cmd
+  winget install Swift.Toolchain
+  ~~~
+
+A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.
 
 #### Traditional Installation
 
@@ -64,7 +75,7 @@ The following additional Visual Studio components are **recommended**:
 | Git for Windows | Microsoft.VisualStudio.Component.Git |
 | Python 3 64-bit (3.7.8) | Component.CPython.x64 |
 
-The following additional Visual Studio components are **suggested** for Swift 5.3:
+The following additional Visual Studio component is **suggested**:
 
 | Component | Visual Studio ID |
 |-----------|------------------|

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -60,7 +60,7 @@ The following additional Visual Studio components are **recommended**:
 | Git for Windows | Microsoft.VisualStudio.Component.Git |
 | Python 3 64-bit (3.7.8) | Component.CPython.x64 |
 
-The following additional Visual Studio components are **suggested**:
+The following additional Visual Studio components are **suggested** for Swift 5.3:
 
 | Component | Visual Studio ID |
 |-----------|------------------|

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -26,7 +26,7 @@ The platform dependencies cannot be installed through the Windows Package Manage
 
 ~~~ cmd
 winget install Git.Git
-winget install Python.Python.3 --version 3.7.8
+winget install Python.Python.3 --version 3.7.8150.0
 
 curl -sOL https://aka.ms/vs/16/release/vs_community.exe
 start /w vs_community.exe --passive --wait --norestart --nocache ^

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -22,7 +22,9 @@ Windows has the following additional platform specific dependencies:
 
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
-The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.
+0. Install required dependencies:
+ 
+The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
 ~~~ cmd
 winget install Git.Git
@@ -34,9 +36,11 @@ start /w vs_community.exe --passive --wait --norestart --nocache ^
   --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
   --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 del /q vs_community.exe
-
-winget install Swift.Toolchain
 ~~~
+
+1. Download the [latest package release](/download).
+
+2. Run the package installer, which will install a Swift toolchain into `%SystemDrive%\Library\Developer\Toolchains`.
 
 #### Traditional Installation
 

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -23,33 +23,33 @@ Windows has the following additional platform specific dependencies:
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
 0. Install required dependencies:
- 
-The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-~~~ cmd
-winget install Git.Git
-winget install Python.Python.3 --version 3.7.8150.0
+   The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-start /w vs_community.exe --passive --wait --norestart --nocache ^
-  --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
-  --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
-  --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-del /q vs_community.exe
-~~~
+   ~~~ cmd
+   winget install Git.Git
+   winget install Python.Python.3 --version 3.7.8150.0
+
+   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
+   start /w vs_community.exe --passive --wait --norestart --nocache ^
+     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
+     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
+     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   del /q vs_community.exe
+   ~~~
 
 0. Install Swift:
 
-Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
+   Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
 
-* Using the official installer:
-  1. Download the [latest package release](/download).
-  1. Run the package installer.
+   * Using the official installer:
+     1. Download the [latest package release](/download).
+     1. Run the package installer.
 
-* Using the Windows Package Manager:
-  ~~~ cmd
-  winget install Swift.Toolchain
-  ~~~
+   * Using the Windows Package Manager:
+     ~~~ cmd
+     winget install Swift.Toolchain
+     ~~~
 
 A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -71,7 +71,9 @@ In order to develop applications, particularly with the Swift Package Manager, y
 
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
-The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.
+0. Install required dependencies:
+ 
+The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
 ~~~ cmd
 winget install Git.Git
@@ -83,9 +85,11 @@ start /w vs_community.exe --passive --wait --norestart --nocache ^
   --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
   --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 del /q vs_community.exe
-
-winget install Swift.Toolchain
 ~~~
+
+1. Download the [latest package release](/download).
+
+2. Run the package installer, which will install a Swift toolchain into `%SystemDrive%\Library\Developer\Toolchains`.
 
 ##### Traditional Installation
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -109,7 +109,7 @@ The following additional Visual Studio components are **recommended**:
 | Git for Windows | Microsoft.VisualStudio.Component.Git |
 | Python 3 64-bit (3.7.8) | Component.CPython.x64 |
 
-The following additional Visual Studio components are **suggested**:
+The following additional Visual Studio components are **suggested** for Swift 5.3:
 
 | Component | Visual Studio ID |
 |-----------|------------------|

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -87,9 +87,20 @@ start /w vs_community.exe --passive --wait --norestart --nocache ^
 del /q vs_community.exe
 ~~~
 
-1. Download the [latest package release](/download).
+0. Install Swift:
 
-2. Run the package installer, which will install a Swift toolchain into `%SystemDrive%\Library\Developer\Toolchains`.
+Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
+
+* Using the official installer:
+  1. Download the [latest package release](/download).
+  1. Run the package installer.
+
+* Using the Windows Package Manager:
+  ~~~ cmd
+  winget install Swift.Toolchain
+  ~~~
+
+A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.
 
 ##### Traditional Installation
 
@@ -113,7 +124,7 @@ The following additional Visual Studio components are **recommended**:
 | Git for Windows | Microsoft.VisualStudio.Component.Git |
 | Python 3 64-bit (3.7.8) | Component.CPython.x64 |
 
-The following additional Visual Studio components are **suggested** for Swift 5.3:
+The following additional Visual Studio component is **suggested**:
 
 | Component | Visual Studio ID |
 |-----------|------------------|

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -75,7 +75,7 @@ The platform dependencies cannot be installed through the Windows Package Manage
 
 ~~~ cmd
 winget install Git.Git
-winget install Python.Python.3 --version 3.7.8
+winget install Python.Python.3 --version 3.7.8150.0
 
 curl -sOL https://aka.ms/vs/16/release/vs_community.exe
 start /w vs_community.exe --passive --wait --norestart --nocache ^

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -72,33 +72,33 @@ In order to develop applications, particularly with the Swift Package Manager, y
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
 0. Install required dependencies:
- 
-The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-~~~ cmd
-winget install Git.Git
-winget install Python.Python.3 --version 3.7.8150.0
+   The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-start /w vs_community.exe --passive --wait --norestart --nocache ^
-  --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
-  --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
-  --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
-del /q vs_community.exe
-~~~
+   ~~~ cmd
+   winget install Git.Git
+   winget install Python.Python.3 --version 3.7.8150.0
+
+   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
+   start /w vs_community.exe --passive --wait --norestart --nocache ^
+     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
+     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
+     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   del /q vs_community.exe
+   ~~~
 
 0. Install Swift:
 
-Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
+   Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
 
-* Using the official installer:
-  1. Download the [latest package release](/download).
-  1. Run the package installer.
+   * Using the official installer:
+     1. Download the [latest package release](/download).
+     1. Run the package installer.
 
-* Using the Windows Package Manager:
-  ~~~ cmd
-  winget install Swift.Toolchain
-  ~~~
+   * Using the Windows Package Manager:
+     ~~~ cmd
+     winget install Swift.Toolchain
+     ~~~
 
 A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.
 

--- a/getting-started/_repl.md
+++ b/getting-started/_repl.md
@@ -125,9 +125,9 @@ $R0: Int32 = 4
 
 ### On Windows
 
-The REPL depends on Python bindings.  You must ensure that Python is available
-in the path.  The following command adds Python to the PATH so that it can be
-used:
+The REPL depends on Python bindings.  You must ensure that Python 3.7 is available
+in the path.  The following command adds Python 3.7 from Visual Studio to `%PATH%`
+so that it can be used:
 
 ~~~ cmd
 path %ProgramFiles(x86)%\Microsoft Visual Studio\Shared\Python37_64;%PATH%

--- a/getting-started/_repl.md
+++ b/getting-started/_repl.md
@@ -138,6 +138,6 @@ extra parameters must be passed to the REPL.  This allows you to use multiple
 different SDKs with the same toolchain.
 
 ~~~ cmd
-set SWIFTFLAGS=-sdk %SDKROOT% -I %SDKROOT%/usr/lib/swift -L SDKROOT%/usr/lib/swift/windows
+set SWIFTFLAGS=-sdk %SDKROOT% -I %SDKROOT%/usr/lib/swift -L %SDKROOT%/usr/lib/swift/windows
 swift repl -target x86_64-unknown-windows-msvc %SWIFTFLAGS%
 ~~~


### PR DESCRIPTION
Fix some broken or outdated Windows-related documentation.

### Motivation:

* Swift on Windows currently explicitly depends on Python 3.7. Reflect
this in our guide.
* Python version 3.7.8 doesn't exist in Windows Package Manager
repository. Point to 3.7.8150.0.
* Windows Package Manager can only install Swift 5.5.3 by the time, which
is obviously outdated.  Recommend Swift.org installers for now.

### Modifications:

* Fix Python dependency on Windows to 3.7
* Fix obvious typo in `getting-started/_repl.md`
* Fix incorrect `winget` package version
* Add Swift.org installer guide


### Result:

More precise guideline for installing and using Swift on Windows.
