### PR TITLE
fix: og:image path

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -38,7 +38,7 @@
   {% endif %}
 
   <meta property="og:site_name" content="{{ site.title }}" />
-  <meta property="og:image" content="{{ site.url }}/touch-icon-ipad-180x180.png" />
+  <meta property="og:image" content="{{ site.url }}/apple-touch-icon-180x180.png" />
   {% if page.robots %}
     <meta name="robots" content="{{page.robots}}" />
   {% endif %}


### PR DESCRIPTION
`og:image`(touch-icon-ipad-180x180.png) does not exist. This change fix it.

### Motivation:

`og:image` exist. 

### Modifications:

`https://www.swift.org/touch-icon-ipad-180x180.png` ->  `https://www.swift.org/apple-touch-icon-180x180.png`

### Result:

`og:image` exist. 
