### PR TITLE
fix missing overflow for table contents (#8)

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -497,6 +497,8 @@ article {
     }
 
     table {
+        display: block;
+        overflow-x: auto;
         width: auto;
         min-width: 68%;
         margin: 2em auto 3em auto;


### PR DESCRIPTION
Fix issue "missing overflow style for table contents" (https://github.com/apple/swift-org-website/issues/8).

### Motivation:

The missing overflow style for table contents makes some pages layout broken, especially on mobile browsers (or desktop with small window width).

### Modifications:

Add attributes `display: block` and `overflow-x: auto` for table content. 

### Result:

Tested on Safari and the table contents would no longer break pages layout.
![Untitled](https://user-images.githubusercontent.com/15633984/158636488-43a47f1d-2642-423a-87d0-d831dbdd3c50.png)
