### PR TITLE
fix missing line break and refine blog header layout

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -386,7 +386,7 @@ article {
         .byline {
             float: left;
             font-size: 14px;
-            margin-left: 3em;
+            margin-bottom: 1em;
 
             img {
                 width: 32px;
@@ -420,7 +420,8 @@ article {
             font-size: 14px;
             font-weight: 400;
             color: var(--color-figure-gray-tertiary);
-
+            margin-right: 3em;
+            margin-bottom: 1em;
         }
 
         .tags {

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -497,6 +497,8 @@ article {
     }
 
     table {
+        display: block;
+        overflow-x: auto;
         width: auto;
         min-width: 68%;
         margin: 2em auto 3em auto;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -127,6 +127,7 @@ p, li, dd, blockquote, td {
 p {
     & > code {
         white-space: pre-wrap;
+        word-break: break-word;
     }
 }
 

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -22,6 +22,8 @@ body {
 }
 
 a {
+    word-break: break-word;
+
     &:link {
         color: var(--color-link);
         text-decoration: none;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -124,6 +124,12 @@ p, li, dd, blockquote, td {
     }
 }
 
+p {
+    & > code {
+        white-space: pre-wrap;
+    }
+}
+
 hr {
     border: none;
     border-top: 1px var(--color-dropdown-border) solid;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -22,8 +22,6 @@ body {
 }
 
 a {
-    word-break: break-word;
-
     &:link {
         color: var(--color-link);
         text-decoration: none;
@@ -698,6 +696,10 @@ article {
     border-style: solid;
     padding: 0.5em;
     margin: 0.5em 0 1.5em 0;
+
+    a {
+        word-break: break-word;
+    }
 
     p:first-child {
       margin-top: 0;

--- a/assets/stylesheets/core/_reset.scss
+++ b/assets/stylesheets/core/_reset.scss
@@ -24,6 +24,7 @@ pre, code, address, caption, th, figcaption {
 }
 
 fieldset, iframe, img {
+    width: 100%;
     border: none
 }
 

--- a/continuous-integration/index.md
+++ b/continuous-integration/index.md
@@ -22,7 +22,7 @@ Continuous integration jobs are organized within the [CI system](https://ci.swif
 
 There are several ways in which you can interact with the swift.org CI system:
 
-* Integration job status - you can view the build and test status of all integration jobs at  [https://ci.swift.org](https://ci.swift.org).  
+* Integration job status - you can view the build and test status of all integration jobs at  [https://ci.swift.org](https://ci.swift.org).
 * Tests on pull requests - when making a change via pull request, your changes will be tested before being integrated, and results will be posted back inline to the pull request.
 
 ### Pull Request Testing
@@ -32,12 +32,15 @@ When a change is reviewed on a pull request, a member of the Swift team will tri
 ![pull request CI trigger](../continuous-integration/images/ci_pull_command.png)
 
 Testing status is then posted inline with the pull request, showing that a test is in progress.  You can click the "details" link to go directly to the status page for the test in progress.
+
 ![CI Progress](../continuous-integration/images/ci_pending.png)
 
 When tests complete, that result is also updated in the pull request
+
 ![CI Pass](../continuous-integration/images/ci_pass.png)
 
 If there are issues found during testing, you will get a link to the details of the failure.
+
 ![CI Pass](../continuous-integration/images/ci_failure.png)
 
 It is expected that changes meet the [quality standards](../contributing/#quality) for the Swift project before they are committed to the development branch, and you are responsible for fixing problems found by your changes.  If your changes break builds or tests on the development or release branches, you will receive email notification.
@@ -51,4 +54,4 @@ The Swift project welcomes proposals from the community for adding support for o
 
 Community members can volunteer to host nodes for additional platforms on [Swift Community-Hosted Continuous Integration](https://ci-external.swift.org), and are responsible for maintaining the host system.  New nodes can be initiated by creating a pull request at: [Swift Community-Hosted CI Repository](https://github.com/apple/swift-community-hosted-continuous-integration).  Further information about the process is documented in the [README.md](https://github.com/apple/swift-community-hosted-continuous-integration/blob/main/README.md).
 
-The Swift community-hosted CI allows un-supported platforms to be moved over to a supported platform on a case by case basis. Depending on the number of nodes provided, @swift-ci pull request testing can be integrated with the community-hosted CI as well. 
+The Swift community-hosted CI allows un-supported platforms to be moved over to a supported platform on a case by case basis. Depending on the number of nodes provided, @swift-ci pull request testing can be integrated with the community-hosted CI as well.


### PR DESCRIPTION
Fix missing line break for URL and inline code blocks, fix layout for images and blog headers, which makes the website more acceptable on narrow screens.

### Motivation:

Currently I found some page of the website seems not fully compatible with narrow screens which cause weird layout issues on some sceneries (eg. viewing on a phone, iPad Spilt-View or browsers with a small window):

1. [https://www.swift.org/download](https://www.swift.org/download) long URLs and inline code blocks makes page layout broken

2. [https://www.swift.org/continuous-integration](https://www.swift.org/continuous-integration) the width of images is consist and not changing with viewport width, I also noticed some missing spacing between texts and images

3. [https://www.swift.org/blog/website-open-source](https://www.swift.org/blog/website-open-source) the `time` and `byline` layout looks weird in `header` element (all blog posts) 

### Modifications:

1. Add `word-break: break-word` for URL elements, add `white-space: pre-wrap` and `word-break: break-word` for inline code blocks (`p>code`)

2. Explicitly mark `width: 100%` for `fieldset, iframe, img` contents, add missing spacing to `continuous-integration/index.md`

3. Remove `margin-left` of `header byline`, add `margin-right` and `margin-bottom` to `header time`

### Result:

**1.** ![1](https://user-images.githubusercontent.com/15633984/158751479-fc103f4c-0dbe-4a5a-94aa-5b1517c88ccb.png)

**2.** ![2](https://user-images.githubusercontent.com/15633984/158751513-a2993349-904b-4464-a588-cc058fdd6e7f.png)

**3.** ![3](https://user-images.githubusercontent.com/15633984/158751530-f39909dc-462b-48f0-8518-987cec2b77b8.png)
