### PR TITLE
Add Docker links for Swift 5.6

### DIFF
--- a/_data/builds/swift-5_6-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_6-release/amazonlinux2-aarch64.yml
@@ -3,4 +3,4 @@
   download: swift-5.6-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.6-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-amazonlinux2-aarch64
+  docker: 5.6-amazonlinux2

--- a/_data/builds/swift-5_6-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_6-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.6-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.6-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-amazonlinux2
+  docker: 5.6-amazonlinux2

--- a/_data/builds/swift-5_6-release/centos7.yml
+++ b/_data/builds/swift-5_6-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.6-RELEASE-centos7.tar.gz
   download_signature: swift-5.6-RELEASE-centos7.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-centos7
+  docker: 5.6-centos7

--- a/_data/builds/swift-5_6-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_6-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.6-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.6-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-bionic
+  docker: 5.6-bionic

--- a/_data/builds/swift-5_6-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_6-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.6-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.6-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-focal-aarch64
+  docker: 5.6-focal

--- a/_data/builds/swift-5_6-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_6-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.6-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.6-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.6-RELEASE
-  docker: Coming Soon #5.6-focal
+  docker: 5.6-focal


### PR DESCRIPTION
Update the Docker links

### Motivation:

Make it easier for community to find Docker images
