### PR TITLE
[SR-7507] Update the code templates

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -90,11 +90,11 @@ All source files hosted on Swift.org must contain a comment block at the top of 
 ~~~~
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
+// Copyright (c) {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 ~~~~
 
 

--- a/contributing/_contributing-code.md
+++ b/contributing/_contributing-code.md
@@ -74,22 +74,17 @@ As mentioned in the [Community Overview][community], the license and copyright p
 For Swift source files the code header should look this:
 
 ~~~~swift
-// subfolder/Filename.swift - Very brief description
+//===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
+// Copyright (c) {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-// -----------------------------------------------------------------------------
-///
-/// This file contains stuff that I am describing here in the header and will
-/// be sure to keep up to date.
-///
-// -----------------------------------------------------------------------------
+//===----------------------------------------------------------------------===//
 ~~~~
 
 For C or C++ source or header files, the code header should look this:
@@ -99,7 +94,7 @@ For C or C++ source or header files, the code header should look this:
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
+// Copyright (c) {{site.time | date: "%Y"}} Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
* <https://bugs.swift.org/browse/SR-7507>
* <rdar://problem/39869728>

### Motivation:

https://github.com/apple/swift/pull/14576#issuecomment-366762016

> Technically speaking, the year or years listed are meant to correspond to the year(s) of first publication of the copyrighted work. So if the file was not published in 2014 and didn’t even exist then, we should definitely not be putting that year on the copyright line.

### Modifications:

* Remove the `2014 -` from all code templates.
* Update the Swift template to match the standard library.

### Result:

Apple's lawyers will rejoice.
