### PR TITLE
fix missing overflow style for blockquote

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -442,6 +442,7 @@ article {
         margin: 0.5em 0 23px 1em;
         padding: 4px 0 2px 10px;
         color: var(--color-aside-note);
+        overflow-x: auto;
 
         p:last-child {
             margin-bottom: 0;


### PR DESCRIPTION
Fix missing overflow style for `blockquote` elements.

### Motivation:

The missing overflow style for `blockquote` elements makes some pages layout weird, especially on mobile browsers (or desktop browser with small viewport width).

eg: [https://www.swift.org/blog/package-collections](https://www.swift.org/blog/package-collections/)

### Modifications:

Add `overflow-x: auto` to `blockquote` attributes.

### Result:

Tested on Safari and the pages with `blockquote` elements looks no longer weird.

![Untitled](https://user-images.githubusercontent.com/15633984/159625486-8a591a60-c6a3-4733-947a-73ef60d47551.png)
