### PR TITLE
[FIX] Display the Swift Logo on small-width Devices

### DIFF
--- a/assets/stylesheets/_mobile.scss
+++ b/assets/stylesheets/_mobile.scss
@@ -36,7 +36,6 @@
       padding: 0;
 
       a {
-        width: auto;
         margin: 0 auto;
       }
     }


### PR DESCRIPTION
The Swift Logo is not visible on mobile devices

### Motivation:

### Modifications:


### Result:

Swift logo is also shown on mobile devices


Before
![BE3EDD55-2C1B-4EDC-BD5B-9807F923B8CC](https://user-images.githubusercontent.com/25514/161828629-42f44b88-bdac-44a7-9646-1e333682fbf8.png)


After
![430CD91E-94C0-4729-AFDD-592BB2ED6EDE](https://user-images.githubusercontent.com/25514/161828675-6bce605b-6196-4d28-a723-d7595965f44d.png)
