### PR TITLE
Typo fix: Dealer -> dealer

### DIFF
--- a/package-manager/_basic-usage.md
+++ b/package-manager/_basic-usage.md
@@ -18,7 +18,7 @@ the following example consists of four interdependent packages:
 > ~~~ shell
 > $ git clone https://github.com/apple/example-package-dealer.git
 > $ cd example-package-dealer
-> $ swift run Dealer
+> $ swift run dealer <count>
 > ~~~
 
 ### Creating a Library Package


### PR DESCRIPTION
Fixed typo and added expected argument to instructions command.

### Motivation:
In the referred to dealer project, the name of the executable is "dealer", not "Dealer". Thus typing "swift run Dealer" into the terminal results in an error, which might confuse people.
Also, it would be helpful to include the expected "\<count\>" argument in the instructions (as typing "swift run dealer" alone still results in an error due to the count argument being expected).

### Modifications:

### Result:

Before screenshot: 
![image](https://user-images.githubusercontent.com/85707581/161898259-864cca8c-cab4-45bc-aba1-025d71c09a51.png)

After screenshot: 
![image](https://user-images.githubusercontent.com/85707581/161898200-136d3f85-d177-4c90-9b86-c60b193a2dd2.png)

