### PR TITLE
Fix the tag link for swift-5.5.3-RELEASE

### DIFF
--- a/download/_older-releases.md
+++ b/download/_older-releases.md
@@ -48,7 +48,7 @@ Tag: <a href="https://github.com/apple/swift/releases/tag/swift-5.6-RELEASE">swi
 <h3>Swift 5.5.3</h3>
 
 Date: February 9, 2022<br>
-Tag: <a href="https://github.com/apple/swift/releases/tag/swift-5.3-RELEASE">swift-5.3-RELEASE</a>
+Tag: <a href="https://github.com/apple/swift/releases/tag/swift-5.5.3-RELEASE">swift-5.5.3-RELEASE</a>
 
 <table id="latest-builds" class="downloads">
     <thead>


### PR DESCRIPTION
Fix the tag link for swift-5.5.3-RELEASE

### Motivation:

The link for the 5.5.3 release tag was wrong (5.3 instead of 5.5.3).

### Modifications:

Changed 5.3 to 5.5.3 in the release tag link and description.

### Result:

The tag will correctly point to 5.5.3
