### PR TITLE
Updated CVE website URL because it moved

### DIFF
--- a/support/security.md
+++ b/support/security.md
@@ -9,7 +9,7 @@ For the protection of our community, Swift.org doesn't disclose, discuss, or con
 
 Recent security updates are listed in the [Security Updates](#security-updates) section below.
 
-Swift.org security documents reference vulnerabilities by [CVE-ID](https://cve.mitre.org/about/) when possible.
+Swift.org security documents reference vulnerabilities by [CVE-ID](https://www.cve.org/About/Overview) when possible.
 
 ### Reporting a security or privacy vulnerability
 


### PR DESCRIPTION
The cve.mitre.org website has moved over to cve.org

### Motivation:
I was browsing the security section, and I clicked on the link to the cve.mitre.org site.  From there, I had to click a second time to get the actual content I was looking for.  The motivation behind this PR is to prevent anyone else from having to click twice :-) 

### Modifications:

Updated the CVE-ID link on the support/security to point to the new, preferred URL by the CVE team. 

### Result:

Anyone clicking that link will get directed to the URL that contains the appropriate content
