### PR TITLE
Windows: update SourceKit-LSP status

### DIFF
--- a/platform-support/_platform-support.md
+++ b/platform-support/_platform-support.md
@@ -46,7 +46,7 @@ The Swift compiler and debugger run on platforms supporting development.  Suppor
 | **Ubuntu**         | ✓                      | ✓              |
 | **CentOS**         | ✓                      | ✓              |
 | **Amazon Linux**   | ✓                      | ✓              |
-| **Windows**        | ✓                      | In development |
+| **Windows**        | ✓                      | ✓              |
 
 ### Deployment-only
 


### PR DESCRIPTION
Update the status of SourceKit-LSP on Windows.  It has been available for some time now and works with SPM as on other platforms.