### PR TITLE
Fix typo: 'ash' -> 'as'

### DIFF
--- a/website-governance/index.md
+++ b/website-governance/index.md
@@ -12,7 +12,7 @@ The Swift.org website source code consists of several distinct parts:
 
 1. General content: Markdown, HTML, data files, images and other content.
 2. Blog posts: Source files for blog posts, mostly in markdown form.
-3. Technical infrastructure: Code and scripts for generating the website’s final static content (HTML mostly) from other forms of textual content such ash Markdown and HTML files.
+3. Technical infrastructure: Code and scripts for generating the website’s final static content (HTML mostly) from other forms of textual content such as Markdown and HTML files.
 4. Information design, user experience and user interface design: The layout and navigation of the website, including CSS and images used to define the user experience and user interface.
 
 Each one of these areas is governed by a slightly different contribution process that matches their nature.


### PR DESCRIPTION
Fix a small typo on the [Swift.org website governance](https://www.swift.org/website-governance/) page.

### Motivation:

There is a typo in the text. A similar typo was already fixed in #3, but the same paragraph also existed in another place and was not fixed.

### Modifications:

Corrected typo.

### Result:

No more typos (hopefully)! 🙂 I searched the project and could not find any more typos of this kind at least.