### PR TITLE
Fix typo in Community Overview

### DIFF
--- a/community/_forums.md
+++ b/community/_forums.md
@@ -40,7 +40,7 @@ A core principle for the Swift project is that the community is an open and incl
 
 **[Announcements](http://forums.swift.org/c/development/dev-announce)** - For announcements relevant to developers such as release announcments, branching, and infrastructure updates. 
 
-**[CI Notifications](http://forums.swift.org/c/development/ci-notifications)** -Automated notifications from ci.swift.org for build and test failures. 
+**[CI Notifications](http://forums.swift.org/c/development/ci-notifications)** - Automated notifications from ci.swift.org for build and test failures. 
 
 ### Swift Evolution
 [Evolution]: #evolution


### PR DESCRIPTION
### Motivation

There is a lack of a space between a dash and the next word, "Automated", in [Community Overview](https://www.swift.org/community).

### Modifications

Minor fix for the typo.

### Screenshot

<img width="616" alt="Screen Shot 2022-05-06 at 9 20 14 AM" src="https://user-images.githubusercontent.com/71743241/167144298-417179a9-1c5c-4f95-b2d3-759994e8a752.png">


