### PR TITLE
Fix Python version for Windows install

### DIFF
--- a/download/_windows.md
+++ b/download/_windows.md
@@ -8,7 +8,7 @@ Swift has the following general dependencies:
 
 - Python[^1] (used by the debugger - lldb)
 
-[^1]: The windows binaries are built against Python 3.7.8
+[^1]: The windows binaries are built against Python 3.10.2
 
 Windows has the following additional platform specific dependencies:
 
@@ -38,7 +38,7 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    del /q vs_community.exe
    ~~~
    
-1. Install Swift:
+0. Install Swift:
 
    Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
 

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -28,7 +28,7 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
 
    ~~~ cmd
    winget install Git.Git
-   winget install Python.Python.3 --version 3.7.8150.0
+   winget install Python.Python.3 --version 3.10.2150.0
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    start /w vs_community.exe --passive --wait --norestart --nocache ^
@@ -37,14 +37,14 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
      --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
-
-0. Install Swift:
+   
+1. Install Swift:
 
    Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
 
    * Using the official installer:
      1. Download the [latest package release](/download).
-     1. Run the package installer.
+     2. Run the package installer.
 
    * Using the Windows Package Manager:
      ~~~ cmd

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -38,6 +38,12 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    del /q vs_community.exe
    ~~~
    
+   Start up a new Command Prompt and install the Python library six.
+
+   ~~~ cmd
+   pip install six
+   ~~~
+   
 0. Install Swift:
 
    Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -53,7 +53,7 @@ Swift has the following general dependencies:
 
 - Python[^1] (used by the debugger - lldb)
 
-[^1]: The windows binaries are built against Python 3.7.8
+[^1]: The windows binaries are built against Python 3.10.2
 
 Windows has the following additional platform specific dependencies:
 
@@ -77,7 +77,7 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
 
    ~~~ cmd
    winget install Git.Git
-   winget install Python.Python.3 --version 3.7.8150.0
+   winget install Python.Python.3 --version 3.10.2150.0
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    start /w vs_community.exe --passive --wait --norestart --nocache ^

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -87,6 +87,12 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    del /q vs_community.exe
    ~~~
 
+   Start up a new Command Prompt and install the Python library six.
+
+   ~~~ cmd
+   pip install six
+   ~~~
+   
 0. Install Swift:
 
    Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.


### PR DESCRIPTION
Change Python Install version for Windows Install dependencies

### Motivation:

Python install version is out of date for the current version of Swift

### Discussion:

@compnerd I haven't added the change here but I was wondering should we tell the user to open a new terminal after installing the dependencies and before installing swift. I can't be sure but I think that might be required to setup the paths correctly for the swift install.
