### PR TITLE
Fix navigation links for sections in Source Code page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -96,6 +96,12 @@
           name: package-manager
         - title: Xcode Playground Support
           name: xcode-playground-support
+        - title: Source Tooling
+          name: source-tooling
+        - title: SourceKit-LSP Service
+          name: sourcekit-lsp-service
+        - title: Swift.org Website
+          name: swiftorg-website
         - title: Cloned Repositories
           name: cloned-repositories
     - title: Continuous Integration

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -95,7 +95,7 @@
         - title: Package Manager
           name: package-manager
         - title: Xcode Playground Support
-          name: playground-support
+          name: xcode-playground-support
         - title: Cloned Repositories
           name: cloned-repositories
     - title: Continuous Integration


### PR DESCRIPTION
Fix the links in the navigation index for the sections in the Source Code page

### Motivation:

The link in the navigation index for the Xcode Playground Support section does not work as the name is not the expected one. There are also a few sections inside the Source Code page that do not have a matching link in the navigation index. These changes fix the link for the Xcode Playground Support section and add the links for the missing sections.

### Modifications:

Fix the name for the Xcode Playground Support section to match the right id, and add the sections from the Source Code page that were missing from the navigation index.

### Result:

All sections inside the Source Code page now have a matching section in the navigation index and they all link to the right section.
