### PR TITLE
Add link to CI docs in swift repo

### DIFF
--- a/continuous-integration/index.md
+++ b/continuous-integration/index.md
@@ -25,6 +25,8 @@ There are several ways in which you can interact with the swift.org CI system:
 * Integration job status - you can view the build and test status of all integration jobs at  [https://ci.swift.org](https://ci.swift.org).
 * Tests on pull requests - when making a change via pull request, your changes will be tested before being integrated, and results will be posted back inline to the pull request.
 
+More usage documentation can be found [here](https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md).
+
 ### Pull Request Testing
 
 When a change is reviewed on a pull request, a member of the Swift team will trigger testing by the CI system.  Tests can be triggered to run on macOS, Linux, or both platforms.


### PR DESCRIPTION
These docs provide more detailed info about how to interact with CI.

<img width="795" alt="image" src="https://user-images.githubusercontent.com/283886/168692375-c494ce82-d1ea-4070-b89f-8a7e87d6deb6.png">
