### PR TITLE
[Mentorship] Updates for the 2022 Swift Mentorship Program.

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -269,3 +269,9 @@ diversity-work-group:
   twitter: 0xTim
   gravatar: c8678b78a2c1c113302ce686f13435d1
   about: "Tim Condon sits on the SSWG (Swift Server Work Group) and is part of the Vapor Core Team"
+
+devanshimodha:
+  name: Devanshi Modha
+  github: devanshimodha
+  twitter: devanshimodha
+  about: "Devanshi is an iOS engineer and a member of the Diversity in Swift work group."

--- a/_posts/2022-05-19-mentorship-2022.md
+++ b/_posts/2022-05-19-mentorship-2022.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+published: true
 date: 2022-05-19 10:00:00
 title: Celebrating learning experiences from the 2021 Swift Mentorship Program
 author: devanshimodha

--- a/_posts/2022-05-19-mentorship-2022.md
+++ b/_posts/2022-05-19-mentorship-2022.md
@@ -5,7 +5,7 @@ title: Celebrating learning experiences from the 2021 Swift Mentorship Program
 author: devanshimodha
 ---
 
-The inaugural offering of the Swift Mentorship Program has concluded, and we’re excited to share insights from a few of the mentees on their learning journey.
+As we prepare for the 2022 Swift Mentorship Program, we’re excited to share insights from a few of last year's mentees on their learning journey.
 
 ## Documentation
 

--- a/_posts/2022-05-19-mentorship-2022.md
+++ b/_posts/2022-05-19-mentorship-2022.md
@@ -1,0 +1,47 @@
+---
+layout: post
+date: 2022-05-19 10:00:00
+title: Celebrating learning experiences from the 2021 Swift Mentorship Program
+author: devanshimodha
+---
+
+The inaugural offering of the Swift Mentorship Program has concluded, and we’re excited to share insights from a few of the mentees on their learning journey.
+
+## Documentation
+
+**Anh Pham** worked with her mentor, Erica Sadun, on documentation contributions to open source Swift packages. Anh’s learning goal for the program was to practice technical writing by actively contributing documentation to open source Swift projects.
+
+Anh started her journey by studying well-documented open source Swift projects, both to learn by example, and to discover which open source projects are active and welcome contributions. During these initial weeks, Anh faced a common barrier for new contributors: self-doubt. Anh overcame this barrier by affirming her own skills, answering guiding questions from Erica, and accepting that mistakes are a necessary part of the learning process.
+
+One important strategy that Anh learned from Erica is the “No Delete” rule, where you do not use the “delete” key as you brainstorm ideas. This strategy encourages you to record your thought process, and allows you to thoroughly flesh out an idea. By preventing an idea from being cut off and instead expanding upon that idea, Anh felt a heightened flow of creativity.
+
+You can read Anh’s full reflection on her mentorship journey here: https://medium.com/@thuanhsone99/swift-mentorship-program-a-reflection-47921be0e538
+
+
+## Swift on Server
+
+**David Reyes** spent his summer working on an introduction to Vapor with his mentor, Tim Condon. David's goal was to learn the basics before jumping into the codebase. This was accomplished with the help of the Vapor book and he was successful in learning introductory Vapor. 
+
+It’s not easy to tackle such a broad topic as Vapor, but regular guidance from his mentor helped David to stay focused on the topic and allowed him to tackle the various related packages in the Vapor project. David is now looking forward to learning more in the coming days and won't stop even after the mentorship program.
+
+> I had a wonderful mentor who gave generously of his time and of his experience. He answered all my questions, and never seemed disconnected to the mentorship purpose.
+
+
+## Language design and compiler development
+
+**Amritpan Kaur** dedicated her mentorship experience to working on open source language design and compiler development. Amritpan’s primary goal was to practice turning knowledge gaps into learning opportunities, which she accomplished by delving into the Swift compiler codebase, navigating unfamiliar concepts and code.
+
+During the first few weeks of mentorship, Amritpan studied a number of Swift evolution proposals. By asking questions to clarify jargon and talking through formal computer science concepts that she felt were blocking her understanding, Amritpan was empowered to engage in discussions about the motivation for the change and the proposed semantics. Most importantly, Amritpan learned that she — an iOS engineer who writes Swift regularly — can offer valuable insight on the usability of the language in practice.
+
+Though Amritpan formed an effective strategy for breaking down Swift evolution proposals to clarify new concepts, she found the compiler codebase to be a greater challenge. Amritpan quickly realized that it isn’t possible to have a complete understanding of such a large project before making contributions, and she discovered that stepping through the code was more effective than attempting to read it. In her reflection, Amritpan notes that framing the learning process as continuous, rather than something you must do upfront, helped her overcome the uncertainty of working in a large, complex project.
+
+> While there is plenty that I still do not fully grasp, I have no doubt that more of it will fall into place as I continue to walk about the code with future contributions.
+
+You can read Amritpan’s full reflection on her mentorship journey here: https://forums.swift.org/t/swift-mentorship-compiler-language-design/52522
+
+
+## Changes to the mentorship program
+
+The Diversity in Swift work group is excited to continue offering the Swift Mentorship Program to welcome and support more programmers in the Swift community. After the 12-week cohort over the summer, we’ll continue to offer mentorship on a rolling bases for starter bug contributions, so new mentors and new mentees can submit applications to join throughout the year.
+
+You can find out more about the Swift mentorship program, and instructions for how to apply at [Swift.org/mentorship](/mentorship/).

--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -3,16 +3,35 @@ layout: page
 title: Swift Mentorship Program
 ---
 
-The Swift Mentorship Program is designed to encourage developers to actively participate in the Swift open source community through direct mentorship with experienced developers. The program is open to everyone! The program also looks to foster mentorship relationships within Swift’s [community groups](/diversity/#community-groups), for those who are interested. Members of Women in Swift and Black in Swift are strongly encouraged to participate!
+The Swift Mentorship Program is designed to encourage developers to actively participate in the Swift open source community through direct mentorship with experienced developers. The program is open to everyone! The program also looks to foster mentorship relationships within Swift’s [community groups](/diversity/#community-groups), for those who are interested. Members of Women in Swift, Black in Swift, and Pride in Swift are strongly encouraged to participate!
 
-Each mentee will have the opportunity to connect with and learn from an experienced developer within the Swift community, with the goal of them contributing code directly to an open-source project. The mentee can contribute to any open-source project written in Swift, or even in the Swift compiler itself, depending on the mentee's learning goals. Mentors and mentees will be matched based on the learning goals of the mentee and the experience of the mentor, and mentees will work with their mentor on open source contributions for 12 weeks.
+Each mentee will have the opportunity to connect with and learn from an experienced developer within the Swift community, with the goal of them contributing code directly to an open-source project. The mentee can contribute to any open-source project written in Swift, or even in the Swift compiler itself, depending on the mentee's learning goals. Mentors and mentees will be matched based on the learning goals of the mentee and the experience of the mentor.
 
-If the mentee has not contributed to the project before, they will first work with their mentor to submit their first patch and overcome any workflow hurdles. The core of the mentorship program is making contributions that work toward the mentee’s learning goals. These contributions can range from implementing a small feature within the project, to several independent bug fixes within the same area of the project.
-At the end of the mentorship program, mentees’ contributions and learnings will be featured in a dedicated post on the Swift.org blog.
+If the mentee has not contributed to the project before, they will first work with their mentor to submit their first patch and overcome any workflow hurdles. The core of the mentorship program is making contributions that work toward the mentee’s learning goals. These contributions can range from implementing a small feature within the project, to several independent bug fixes within the same area of the project. At the end of the mentorship, mentees will have an opportunity for their contributions and learnings to be featured in a dedicated post on the Swift.org blog.
 
 ## Current Program
 
-Stay tuned to the [Announcements](https://forums.swift.org/c/general-announce/) category on the Swift Forums for the 2022 offering of the Swift Mentorship Program!
+### 2022 Timeline
+
+| Date               | Event                          |
+|:-------------------|:-------------------------------|
+| **June 1st**       |  Interest surveys open         |
+| **June 15th**      |  Interest survey deadline      |
+| **June 27th**      |  Mentorship pairings announced |
+| **July 4th**       |  12-week cohort begins         |
+| **August 8th**     |  Halfway checkpoint            |
+| **September 23rd** |  12-week cohort ends           |
+| **September 30th** |  Feedback deadline             |
+
+After the 12-week cohort ends on September 30th, the interest surveys will open back up to offer short-term mentorship for starter bug contributions.
+
+### Interest Surveys
+
+The 2022 mentee and mentor interest survey submissions will open on June 1st - check back here for the survey links on that date. In the meantime, start to think through the specific goals that you'd like to work toward through the Swift Mentorship Program.
+
+The mentee interest survey is not an application; but rather it will tell the Diversity in Swift work group about your technical interests and learning goals, which will be used to help match you with a suitable mentor. Although the survey won't be evaluated like an application, the work group may not be able to match every interested mentee if there aren't enough mentors, or if none of the mentors are equipped to help with your specific learning goals.
+
+The Swift Mentorship Program is also a leadership opportunity for veteran community members, particularly if they are already an open-source project maintainer or frequent contributor. If you’re passionate about lowering the barrier to entry for new contributors in our community, please consider getting involved as a mentor!
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Update the community for the 2022 offering of the Swift Mentorship Program with a blog post and updates to Swift.org/mentorship.