### PR TITLE
Updated URLs to be Markdown links.

### DIFF
--- a/_posts/2022-05-19-mentorship-2022.md
+++ b/_posts/2022-05-19-mentorship-2022.md
@@ -16,7 +16,7 @@ Anh started her journey by studying well-documented open source Swift projects, 
 
 One important strategy that Anh learned from Erica is the “No Delete” rule, where you do not use the “delete” key as you brainstorm ideas. This strategy encourages you to record your thought process, and allows you to thoroughly flesh out an idea. By preventing an idea from being cut off and instead expanding upon that idea, Anh felt a heightened flow of creativity.
 
-You can read Anh’s full reflection on her mentorship journey here: https://medium.com/@thuanhsone99/swift-mentorship-program-a-reflection-47921be0e538
+[You can read Anh’s full reflection on her mentorship journey here](https://medium.com/@thuanhsone99/swift-mentorship-program-a-reflection-47921be0e538).
 
 
 ## Swift on Server
@@ -38,11 +38,11 @@ Though Amritpan formed an effective strategy for breaking down Swift evolution p
 
 > While there is plenty that I still do not fully grasp, I have no doubt that more of it will fall into place as I continue to walk about the code with future contributions.
 
-You can read Amritpan’s full reflection on her mentorship journey here: https://forums.swift.org/t/swift-mentorship-compiler-language-design/52522
+[You can read Amritpan’s full reflection on her mentorship journey here](https://forums.swift.org/t/swift-mentorship-compiler-language-design/52522).
 
 
 ## Changes to the mentorship program
 
 The Diversity in Swift work group is excited to continue offering the Swift Mentorship Program to welcome and support more programmers in the Swift community. After the 12-week cohort over the summer, we’ll continue to offer mentorship on a rolling bases for starter bug contributions, so new mentors and new mentees can submit applications to join throughout the year.
 
-You can find out more about the Swift mentorship program, and instructions for how to apply at [Swift.org/mentorship](/mentorship/).
+You can find out more about the Swift mentorship program, and instructions for how to apply at [swift.org/mentorship](/mentorship/).

--- a/_posts/2022-05-19-mentorship-2022.md
+++ b/_posts/2022-05-19-mentorship-2022.md
@@ -45,4 +45,4 @@ Though Amritpan formed an effective strategy for breaking down Swift evolution p
 
 The Diversity in Swift work group is excited to continue offering the Swift Mentorship Program to welcome and support more programmers in the Swift community. After the 12-week cohort over the summer, we’ll continue to offer mentorship on a rolling bases for starter bug contributions, so new mentors and new mentees can submit applications to join throughout the year.
 
-You can find out more about the Swift mentorship program, and instructions for how to apply at [swift.org/mentorship](/mentorship/).
+You can find out more about the Swift mentorship program, and instructions for how to apply at [Swift.org/mentorship](/mentorship/).


### PR DESCRIPTION
This changes the links to be clickable.

### Motivation:

It reads better, is easier to use, and is less annoying for VoiceOver to read.

### Modifications:

I made the URLs into Markdown links.

### Result:

The URLs are now clickable.
