### PR TITLE
Verify Jekyll config in CI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,10 @@ services:
 
    build:
       <<: *common
-      command: /bin/bash -cl "bundle check && bundle exec jekyll build --source /srv/jekyll --destination /output"
+      command: /bin/bash -cl "
+        bundle check
+        && bundle exec jekyll doctor --source /srv/jekyll --destination /output
+        && bundle exec jekyll build --source /srv/jekyll --destination /output"
 
    website:
      <<: *common


### PR DESCRIPTION
To avoid broken configs in the future, adding `Jekyll doctor` command. 

https://github.com/apple/swift-org-website/issues/44