### PR TITLE
fix table width issue

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -565,6 +565,10 @@ article {
         margin-top: 0;
         cursor: pointer;
 
+        table {
+            display: inline-table;
+        }
+
         summary {
             padding-bottom: 0.5em;
             outline: none;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -508,8 +508,9 @@ article {
     table {
         display: block;
         overflow-x: auto;
-        width: auto;
+        width: max-content;
         min-width: 68%;
+        max-width: 100%;
         margin: 2em auto 3em auto;
         border-collapse: separate;
         border: 1px var(--color-dropdown-border) solid;


### PR DESCRIPTION
Fix a table width issue caused by PR https://github.com/apple/swift-org-website/pull/11.

### Motivation:

In the previous PR, `table { display: block; // ... }` brings some issues to the width of the table elements, thanks for pointed it out https://github.com/apple/swift-org-website/pull/11#discussion_r879027397, so the purpose of this PR is to fix table width issue without revert the previous PR.

Some pages which has this issue:

1. [https://www.swift.org/about/](https://www.swift.org/about/)
2. [https://www.swift.org/download/](https://www.swift.org/download/)

### Modifications:

1. For table inside `article`, add another 2 attributes: `width: max-content` and `max-width: 100%`
2. For table inside `details.download`, explicitly use `display: inline-table`

### Result:

Tested on macOS Safari Version 15.5 (17613.2.7.1.8), the right side is fixed:

![Screen Shot 2022-05-25 at 13 16 43](https://user-images.githubusercontent.com/15633984/170189867-7d149db4-d938-45d9-a2e7-57607b67557e.png)

![Screen Shot 2022-05-25 at 13 17 36](https://user-images.githubusercontent.com/15633984/170189949-c765cd67-7ef1-4517-8a83-dc19c67b8320.png)

![Screen Shot 2022-05-25 at 13 18 31](https://user-images.githubusercontent.com/15633984/170190008-56e5af06-e228-4f5b-92dc-f06ad16eccf1.png)

![Screen Shot 2022-05-25 at 13 20 40](https://user-images.githubusercontent.com/15633984/170190027-c95c8ca4-8b96-44e9-ac6a-32c11e8bb5a4.png)
