### PR TITLE
fix missing ::marker of <summary> for Chrome

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -540,6 +540,7 @@ article {
         cursor: pointer;
 
         summary {
+            display: list-item;
             padding-bottom: 0.5em;
             outline: none;
             margin-top: 0;
@@ -570,7 +571,6 @@ article {
         }
 
         summary {
-            display: list-item;
             padding-bottom: 0.5em;
             outline: none;
             margin-top: 0;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -570,6 +570,7 @@ article {
         }
 
         summary {
+            display: list-item;
             padding-bottom: 0.5em;
             outline: none;
             margin-top: 0;


### PR DESCRIPTION
Explicitly add `display: list-item` attribute to `<summary>` to fix missing `::marker` on Chrome, Firefox and etc.

### Motivation:

Displaying `<summary>` as block leads to missing `::marker` icon in Chrome (Safari is fine) https://github.com/apple/swift-org-website/issues/54, which makes it difficult for users to distinguish what contents can be expanded.

Some pages has the issue:

1. [https://www.swift.org/mentorship/](https://www.swift.org/mentorship/), at "Frequently Asked Questions" part
2. [https://www.swift.org/download/](https://www.swift.org/download/)

### Modifications:

Considering this might a bug of Chrome ([ref](https://css-tricks.com/careful-when-changing-the-display-of-summary/)), I would like explicitly add `display: list-item` attribute to `<summary>` in `_screen.scss`, which overrides `display: block` in 
https://github.com/apple/swift-org-website/blob/85ee6a8a7562880b7bc9919a49583ae6f9ea0144/assets/stylesheets/core/_reset.scss#L40-L43 

### Result:

Tested on Chrome Version 101.0.4951.6, macOS Safari Version 15.5 (17613.2.7.1.8) and Android Firefox 100.3.0 (no screenshots), right side is fixed.

- Chrome
![Screen Shot 2022-05-25 at 17 41 36](https://user-images.githubusercontent.com/15633984/170233504-12cd42f2-b619-475b-afa3-48a28120de9b.png)
![Screen Shot 2022-05-25 at 17 44 46](https://user-images.githubusercontent.com/15633984/170233573-7df312b9-cb21-4be3-ba60-f15633072f45.png)

- Safari (no visual changes)
![Screen Shot 2022-05-25 at 17 47 01](https://user-images.githubusercontent.com/15633984/170234031-aa87f728-b11a-4e57-bfb0-94fe7c8a6c96.png)
