### PR TITLE
Fix typo: announcments

### DIFF
--- a/community/_forums.md
+++ b/community/_forums.md
@@ -38,7 +38,7 @@ A core principle for the Swift project is that the community is an open and incl
 
 **[LLBuild](http://forums.swift.org/c/development/llbuild)** - For developers to discuss the implementation of the low level build system (llbuild). This category will accept email sent to: swift+llbuild@forums.swift.org
 
-**[Announcements](http://forums.swift.org/c/development/dev-announce)** - For announcements relevant to developers such as release announcments, branching, and infrastructure updates. 
+**[Announcements](http://forums.swift.org/c/development/dev-announce)** - For announcements relevant to developers such as release announcements, branching, and infrastructure updates. 
 
 **[CI Notifications](http://forums.swift.org/c/development/ci-notifications)** - Automated notifications from ci.swift.org for build and test failures. 
 


### PR DESCRIPTION
This PR fixes a typo at [/community](https://www.swift.org/community/).

### Modifications:

"announcments" -> "announcements"
