### PR TITLE
Add missing Standard Library Preview package

### DIFF
--- a/_data/preview_packages.yml
+++ b/_data/preview_packages.yml
@@ -4,3 +4,9 @@
     Operations on noncontiguous subranges of collections, 
     such as <code>subranges(where:)</code> and <code>moveSubranges(_:to:)</code>, 
     as well as the supporting <code>RangeSet</code> type.
+
+- repo: https://github.com/apple/swift-se0288-is-power/
+  name: SE0288_IsPower
+  description: >-
+    Extends <code>BinaryInteger</code> with an <code>isPower(of:)</code> method 
+    that returns whether an integer is a power of another.

--- a/standard-library/_preview-package.md
+++ b/standard-library/_preview-package.md
@@ -6,7 +6,7 @@ library APIs that can be implemented as a standalone library are accepted
 through the Swift Evolution process, they are published as individual
 packages and included in the preview package, which acts as an umbrella
 library. The preview package currently includes the following individual
-package:
+packages:
 
 [preview-package]: https://github.com/apple/swift-standard-library-preview/
 


### PR DESCRIPTION
Add missing Standard Library Preview package to the list of current packages.

### Motivation:

I noticed that the package list at https://www.swift.org/standard-library/#standard-library-preview-package did not include all packages from [apple/swift-standard-library-preview](https://github.com/apple/swift-standard-library-preview/).

### Modifications:

- Added the missing package
- Updated copy

### Result:

An up-to-date list of current Standard Library Preview packages.