### PR TITLE
Fix broken anchor link

### DIFF
--- a/package-manager/_basic-usage.md
+++ b/package-manager/_basic-usage.md
@@ -1,6 +1,6 @@
 ## Example Usage
 
-In [Getting Started](/getting-started#package-manager),
+In [Getting Started](/getting-started#using-the-package-manager),
 a simple "Hello, world!" program is built with the Swift Package Manager.
 
 To provide a more complete look at what the Swift Package Manager can do,


### PR DESCRIPTION
Fix broken anchor link at https://www.swift.org/package-manager/ linking to the **Using the Package Manager** section in https://www.swift.org/getting-started/.

### Motivation:

The Package Manager section title in https://www.swift.org/getting-started/ has been changed from "Package Manager" to "Using the Package Manager". Since the title anchors are generated based on the titles, links with anchors to this section also have to be updated.

This PR fixes an outdated anchor link.

### Modifications:

- Updated anchor link: `/getting-started#package-manager` -> `/getting-started#using-the-package-manager`

### Result:

No longer landing at top of the Getting Started page when using this anchor link! :)