### PR TITLE
Improve references on /website and /website-governance

### DIFF
--- a/website-governance/index.md
+++ b/website-governance/index.md
@@ -6,7 +6,7 @@ title: Swift.org website governance
 See [website overview](/website) for more information about the Swift.org website goals and contribution guidelines.
 
 The website has a small list of *maintainers* which have *write* access and are in charge of reviewing and merging pull requests from *contributors*.
-The *maintainers* group consists of a small subset of the Swift core team and the [Swift website workgroup members](/website-workgroup). (see `CODEOWNERS`).
+The *maintainers* group consists of a small subset of the Swift core team and the [Swift website workgroup members](/website-workgroup).
 
 The Swift.org website source code consists of several distinct parts:
 

--- a/website/index.md
+++ b/website/index.md
@@ -27,7 +27,7 @@ Everyone is welcome to contribute to the Swift.org website in the following ways
 * Asking or answering questions on the forums
 * Reporting or triaging bugs
 
-See `CONTRIBUTING.md` for additional information about the website's contribution guidelines.
+See [`CONTRIBUTING.md`](https://github.com/apple/swift-org-website/blob/main/CONTRIBUTING.md) for additional information about the website's contribution guidelines.
 
 
 ## Governance

--- a/website/index.md
+++ b/website/index.md
@@ -33,7 +33,7 @@ See [`CONTRIBUTING.md`](https://github.com/apple/swift-org-website/blob/main/CON
 ## Governance
 
 The website has a small list of *maintainers* which have *write* access and are in charge of reviewing and merging pull requests from *contributors*.
-The *maintainers* group consists of a small subset of the Swift core team and the [Swift website workgroup members](/website-workgroup). (see `CODEOWNERS`).
+The *maintainers* group consists of a small subset of the Swift core team and the [Swift website workgroup members](/website-workgroup).
 
 The Swift.org website source code consists of several distinct parts:
 


### PR DESCRIPTION
Some smaller changes to https://www.swift.org/website/ and https://www.swift.org/website-governance/.

### Motivation:

I added a link to the `CONTRIBUTING.md` reference that takes you to the file on GitHub. This makes it easier to find and read the guidelines.

I removed two references to the `CODEOWNERS` file, as I thought they were unnecessary. There is already enough information to find out who the maintainers are.

**Note:** We could also link to https://github.com/apple/swift-org-website/blob/main/CODEOWNERS, but I'm not sure if this provides much value (the file is a bit confusing atm as it contains two different lists—maybe we should fix that in a separate PR).

### Modifications:

- Added a link to the `CONTRIBUTING.md` reference on /website
- Removed references to the `CODEOWNERS` file

### Result:

Improved references on https://www.swift.org/website/ and https://www.swift.org/website-governance/.