### PR TITLE
Update sidebar page sections

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -85,6 +85,11 @@
           name: community-participation
     - title: Mentorship
       url: /mentorship/
+      sections:
+        - title: Current Program
+          name: current-program
+        - title: Frequently Asked Questions
+          name: frequently-asked-questions
     - title: Contributing
       url: /contributing/
       sections:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,6 +2,8 @@
     - title: About Swift
       url: /about/
       sections:
+        - title: Features
+          name: features
         - title: Swift.org and Open Source
           name: swiftorg-and-open-source
         - title: Platform Support

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -200,5 +200,12 @@
           name: xcode-playground-support
     - title: Swift on Server
       url: /server/
+      sections:
+        - title: Why Swift on Server?
+          name: why-swift-on-server
+        - title: Swift Server Workgroup
+          name: swift-server-workgroup
+        - title: Development guides
+          name: development-guides
     - title: Swift.org website
       url: /website/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -70,6 +70,19 @@
           name: forums
     - title: Diversity
       url: /diversity/
+      sections:
+        - title: Mission
+          name: mission
+        - title: Work Group
+          name: work-group
+        - title: Community Groups
+          name: community-groups
+        - title: Events
+          name: events
+        - title: Community-focused blog on Swift.org
+          name: community-focused-blog-on-swiftorg
+        - title: Community Participation
+          name: community-participation
     - title: Mentorship
       url: /mentorship/
     - title: Contributing

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -155,6 +155,11 @@
           name: building-projects
     - title: Security
       url: /support/security.html
+      sections:
+        - title: Security Process
+          name: security-process
+        - title: Security Updates
+          name: security-updates
 
 - header: Open Source Efforts
   pages:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -34,6 +34,13 @@
           name: docker
     - title: Platform Support
       url: /platform-support/
+      sections:
+        - title: Deployment and Development
+          name: deployment-and-development
+        - title: Deployment-only
+          name: deployment-only
+        - title: Platform Owners
+          name: platform-owners
     - title: Documentation
       url: /documentation/
       sections:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -151,6 +151,8 @@
           name: maintaining-projects
         - title: Pull Request Testing
           name: pull-request-testing
+        - title: Building Projects
+          name: building-projects
     - title: Security
       url: /support/security.html
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -209,3 +209,10 @@
           name: development-guides
     - title: Swift.org website
       url: /website/
+      sections:
+        - title: Community Participation
+          name: community-participation
+        - title: Governance
+          name: governance
+        - title: Website workgroup
+          name: website-workgroup

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -138,6 +138,8 @@
           name: configuration
         - title: Usage
           name: usage
+        - title: Community Involvement
+          name: community-involvement
     - title: Source Compatibility
       url: /source-compatibility/
       sections:


### PR DESCRIPTION
Update sidebar page sections.

### Motivation:

I noticed that quite a few pages were missing sections in the sidebar. I added the missing ones.

### Modifications:

- updated **About Swift** sections
- updated **Platform Support** sections
- updated **Diversity** sections
- updated **Mentorship** sections
- updated **Continuous Integration** sections
- updated **Source Compatibility** sections
- updated **Security** sections
- updated **Swift on Server** sections
- updated **Swift.org website** sections

(if you want to see which sections were added, the commits below are pretty self-explanatory)

### Result:

Up-to-date sidebar navigation—makes it easier to get an overview of page contents and to navigate between page sections.