### PR TITLE
Add Ubuntu 22.04 support for development snapshots

### DIFF
--- a/download/_linux.md
+++ b/download/_linux.md
@@ -8,13 +8,13 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 #### Requirements
 
 * Ubuntu 18.04, 20.04, or 22.04
-* CentOS 7
+* CentOS 7, 8
 * Amazon Linux 2
 
 #### Supported Target Platforms
 
 * Ubuntu 18.04, 20.04, or 22.04
-* CentOS 7
+* CentOS 7, 8
 * Amazon Linux 2
 
 * * *

--- a/download/_linux.md
+++ b/download/_linux.md
@@ -7,14 +7,14 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 
 #### Requirements
 
-* Ubuntu 18.04 or 20.04 (64-bit)
-* CentOS 7, 8
+* Ubuntu 18.04, 20.04, or 22.04
+* CentOS 7
 * Amazon Linux 2
 
 #### Supported Target Platforms
 
-* Ubuntu 18.04 or 20.04 (64-bit)
-* CentOS 7, 8
+* Ubuntu 18.04, 20.04, or 22.04
+* CentOS 7
 * Amazon Linux 2
 
 * * *

--- a/download/_older-development-snapshots.md
+++ b/download/_older-development-snapshots.md
@@ -55,6 +55,25 @@ Ubuntu 20.04
 
 {% endif %}
 
+{% if ubuntu2204_development_builds.size > 1 %}
+
+Ubuntu 22.04
+
+<table id="linux-builds" class="downloads">
+    <thead>
+        <tr>
+            <th class="download">Download</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for build in ubuntu2204_development_builds | offset:1 | limit:10 %}
+            {% include_relative _old-snapshot.html build=build name="Ubuntu 22.04" platform_dir="ubuntu2204" branch_dir="development" %}
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endif %}
+
 {% if centos7_development_builds.size > 1 %}
 
 CentOS 7

--- a/download/index.md
+++ b/download/index.md
@@ -12,6 +12,8 @@ title: Download Swift
 {% assign ubuntu1804_development_builds = site.data.builds.development.ubuntu1804 | sort: 'date' | reverse %}
 {% assign ubuntu2004_development_builds = site.data.builds.development.ubuntu2004 | sort: 'date' | reverse %}
 {% assign ubuntu2004_aarch64_development_builds = site.data.builds.development.ubuntu2004-aarch64 | sort: 'date' | reverse %}
+{% assign ubuntu2204_development_builds = site.data.builds.development.ubuntu2204 | sort: 'date' | reverse %}
+{% assign ubuntu2204_aarch64_development_builds = site.data.builds.development.ubuntu2204-aarch64 | sort: 'date' | reverse %}
 {% assign centos7_development_builds = site.data.builds.development.centos7 | sort: 'date' | reverse %}
 {% assign centos8_development_builds = site.data.builds.development.centos8 | sort: 'date' | reverse %}
 {% assign centos8_aarch64_development_builds = site.data.builds.development.centos8-aarch64 | sort: 'date' | reverse %}
@@ -422,6 +424,7 @@ but they have not gone through the full testing that is performed for official r
         {% include_relative _build-arch.html platform="Apple Platforms" build=xcode_development_builds.first name="Xcode" platform_dir="xcode" branch_dir="development" arch="Universal" %}
         {% include_relative _build-arch.html platform="Linux" build=ubuntu1804_development_builds.first name="Ubuntu 18.04" docker_tag="nightly-bionic" platform_dir="ubuntu1804" branch_dir="development" arch="x86_64" %}
         {% include_relative _build-arch.html platform="Linux" build=ubuntu2004_development_builds.first build_2=ubuntu2004_aarch64_development_builds.first name="Ubuntu 20.04" docker_tag="nightly-focal" platform_dir="ubuntu2004" platform_dir_2="ubuntu2004-aarch64" branch_dir="development" arch="x86_64" arch_2="aarch64" %}
+        {% include_relative _build-arch.html platform="Linux" build=ubuntu2204_development_builds.first build_2=ubuntu2204_aarch64_development_builds.first name="Ubuntu 22.04" docker_tag="Coming Soon" platform_dir="ubuntu2204" platform_dir_2="ubuntu2204-aarch64" branch_dir="development" arch="x86_64" arch_2="aarch64" %}
         {% include_relative _build-arch.html platform="Linux" build=centos7_development_builds.first name="CentOS 7" docker_tag="nightly-centos7" platform_dir="centos7" branch_dir="development" arch="x86_64" %}
         {% include_relative _build-arch.html platform="Linux" build=centos8_development_builds.first build_2=centos8_aarch64_development_builds.first name="CentOS 8" docker_tag="nightly-centos8" platform_dir="centos8" platform_dir_2="centos8-aarch64"  branch_dir="development" arch="x86_64" arch_2="aarch64" %}
         {% include_relative _build-arch.html platform="Linux" build=amazonlinux2_development_builds.first build_2=amazonlinux2_aarch64_development_builds.first name="Amazon Linux 2" docker_tag="nightly-amazonlinux2" platform_dir="amazonlinux2" platform_dir_2="amazonlinux2-aarch64" branch_dir="development" arch="x86_64" arch_2="aarch64" %}


### PR DESCRIPTION
Support Ubuntu 22.04 
### Motivation:

Add latest Ubuntu version

### Modifications:

Add links to Ubuntu 22.04 download page.

### Result:

<img width="777" alt="Screen Shot 2022-06-03 at 12 01 51 AM" src="https://user-images.githubusercontent.com/2727770/171804697-8993193c-a87c-46dd-ad23-e3a78f50196c.png">

