### PR TITLE
Fix typo: "such" -> "such as"

### DIFF
--- a/documentation/api-design-guidelines/index.md
+++ b/documentation/api-design-guidelines/index.md
@@ -309,7 +309,7 @@ is printed.
   {{expand}}
   {{detail}}
   Especially when a parameter type is `NSObject`, `Any`, `AnyObject`,
-  or a fundamental type such `Int` or `String`, type information and
+  or a fundamental type such as `Int` or `String`, type information and
   context at the point of use may not fully convey intent. In this
   example, the declaration may be clear, but the use site is vague.
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Please see the original PR: https://github.com/apple/swift-internals/pull/30 . Fix a typo in the Swift API Guidelines. This is a doc only change.
