### PR TITLE
[SE-0285] Add `#fileID` to API Design Guidelines

### DIFF
--- a/documentation/api-design-guidelines/index.md
+++ b/documentation/api-design-guidelines/index.md
@@ -808,6 +808,12 @@ func move(from **start**: Point, to **end**: Point)
   pattern of use where methods are invoked.
   {:#parameter-with-defaults-towards-the-end}
 
+* **If your API will run in production, prefer `#fileID`** over alternatives.
+  `#fileID` saves space and protects developers’ privacy. Use `#filePath` in
+  APIs that are never run by end users (such as test helpers and scripts) if
+  the full path will simplify development workflows or be used for file I/O.
+  Use `#file` to preserve source compatibility with Swift 5.2 or earlier.
+
 ### Argument Labels
 
 ~~~swift


### PR DESCRIPTION
Add `#fileID` advice to the documentation.

### Motivation:

SE-0285 was [accepted][] (2 years ago).

[accepted]: <https://forums.swift.org/t/accepted-se-0285-ease-the-transition-to-concise-magic-file-strings/38516>

### Modifications:

Add the [amendment][] (authored by @beccadax).

[amendment]: <https://github.com/apple/swift-evolution/blob/main/proposals/0285-ease-pound-file-transition.md#swift-api-design-guidelines-amendment>

### Result:

The [parameters][] section will have a new bullet point.

[parameters]: <https://www.swift.org/documentation/api-design-guidelines/#parameter-names>