### PR TITLE
Add Docker link to Swift 5.7 nightly snapshots

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -459,10 +459,10 @@ but they have not gone through the full testing that is performed for official r
     </thead>
     <tbody>
         {% include_relative _build-arch.html platform="Apple Platforms" build=xcode_5_7_builds.first name="Xcode" platform_dir="xcode" branch_dir="swift-5.7-branch" arch="Universal" %}
-        {% include_relative _build-arch.html platform="Linux" build=ubuntu1804_5_7_builds.first name="Ubuntu 18.04" docker_tag="Coming Soon" platform_dir="ubuntu1804" branch_dir="swift-5.7-branch" arch="x86_64" %}
-        {% include_relative _build-arch.html platform="Linux" build=ubuntu2004_5_7_builds.first build_2=ubuntu2004_aarch64_5_7_builds.first name="Ubuntu 20.04" docker_tag="Coming Soon" platform_dir="ubuntu2004" platform_dir_2="ubuntu2004-aarch64" branch_dir="swift-5.7-branch" arch="x86_64" arch_2="aarch64" %}
-        {% include_relative _build-arch.html platform="Linux" build=centos7_5_7_builds.first name="CentOS 7" docker_tag="Coming Soon" platform_dir="centos7" branch_dir="swift-5.7-branch" arch="x86_64" %}
-        {% include_relative _build-arch.html platform="Linux" build=amazonlinux2_5_7_builds.first build_2=amazonlinux2_aarch64_5_7_builds.first name="Amazon Linux 2" docker_tag="Coming Soon" platform_dir="amazonlinux2" platform_dir_2="amazonlinux2-aarch64" branch_dir="swift-5.7-branch" arch="x86_64" arch_2="aarch64" %}
+        {% include_relative _build-arch.html platform="Linux" build=ubuntu1804_5_7_builds.first name="Ubuntu 18.04" docker_tag="nightly-5.7-bionic" platform_dir="ubuntu1804" branch_dir="swift-5.7-branch" arch="x86_64" %}
+        {% include_relative _build-arch.html platform="Linux" build=ubuntu2004_5_7_builds.first build_2=ubuntu2004_aarch64_5_7_builds.first name="Ubuntu 20.04" docker_tag="nightly-5.7-focal" platform_dir="ubuntu2004" platform_dir_2="ubuntu2004-aarch64" branch_dir="swift-5.7-branch" arch="x86_64" arch_2="aarch64" %}
+        {% include_relative _build-arch.html platform="Linux" build=centos7_5_7_builds.first name="CentOS 7" docker_tag="nightly-5.7-centos7" platform_dir="centos7" branch_dir="swift-5.7-branch" arch="x86_64" %}
+        {% include_relative _build-arch.html platform="Linux" build=amazonlinux2_5_7_builds.first build_2=amazonlinux2_aarch64_5_7_builds.first name="Amazon Linux 2" docker_tag="nightly-5.7-amazonlinux2" platform_dir="amazonlinux2" platform_dir_2="amazonlinux2-aarch64" branch_dir="swift-5.7-branch" arch="x86_64" arch_2="aarch64" %}
         {% include_relative _build-arch.html platform="windows" build=windows10_5_7_builds.first name="Windows 10" platform_dir="windows10" branch_dir="swift-5.7-branch" arch="x86_64" %}
     </tbody>
 </table>


### PR DESCRIPTION
Nightly Docker images for Swift 5.7 now available on https://hub.docker.com/r/swiftlang/swift/tags?page=1&name=5.7
<img width="896" alt="Screen Shot 2022-06-13 at 1 09 28 AM" src="https://user-images.githubusercontent.com/2727770/173309209-6d706dff-06b6-4b6a-bee3-eec0fd7bdbdb.png">

