### PR TITLE
Add Windows to older Swift 5.7 nightly snapshot list and update the …

### DIFF
--- a/download/_older-5_7-snapshots.md
+++ b/download/_older-5_7-snapshots.md
@@ -112,7 +112,7 @@ Amazon Linux 2
 {% endif %}
 
 
-<!-- {% if windows10_5_7_builds.size > 1 %}
+{% if windows10_5_7_builds.size > 1 %}
 
 Windows 10
 
@@ -129,4 +129,4 @@ Windows 10
     </tbody>
 </table>
 
-{% endif %} -->
+{% endif %}

--- a/download/index.md
+++ b/download/index.md
@@ -467,7 +467,7 @@ but they have not gone through the full testing that is performed for official r
     </tbody>
 </table>
 
-<!-- <sup>1</sup> Swift Windows 10 toolchain is provided by [Saleem Abdulrasool](https://github.com/compnerd). Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br> -->
+<sup>1</sup> Swift Windows 10 toolchain is provided by [Saleem Abdulrasool](https://github.com/compnerd). Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br>
 
 <details class="download">
   <summary>Older Snapshots</summary>


### PR DESCRIPTION
…Windows toolchain provider

Older Windows Swift 5.7 nightly snapshot were missing on the download page.


<img width="553" alt="Screen Shot 2022-06-13 at 1 25 47 AM" src="https://user-images.githubusercontent.com/2727770/173311962-c732cb21-50bd-41de-8ff5-724599397ddf.png">

<img width="526" alt="Screen Shot 2022-06-13 at 1 26 02 AM" src="https://user-images.githubusercontent.com/2727770/173311980-a62b9a96-2d3b-4af3-9e2f-633446568690.png">


