### PR TITLE
Docker images now available on hub.docker.com/_/swift for Swift 5.6.2

### DIFF
--- a/_data/builds/swift-5_6_2-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_6_2-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.6.2-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-amazonlinux2
+  docker: 5.6.2-amazonlinux2

--- a/_data/builds/swift-5_6_2-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_6_2-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.6.2-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-amazonlinux2
+  docker: 5.6.2-amazonlinux2

--- a/_data/builds/swift-5_6_2-release/centos7.yml
+++ b/_data/builds/swift-5_6_2-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-centos7.tar.gz
   download_signature: swift-5.6.2-RELEASE-centos7.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-centos7
+  docker: 5.6.2-centos7

--- a/_data/builds/swift-5_6_2-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_6_2-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.6.2-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-bionic
+  docker: 5.6.2-bionic

--- a/_data/builds/swift-5_6_2-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_6_2-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.6.2-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-focal
+  docker: 5.6.2-focal

--- a/_data/builds/swift-5_6_2-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_6_2-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.6.2-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.6.2-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.6.2-RELEASE
-  docker: Coming Soon #5.6.2-focal
+  docker: 5.6.2-focal


### PR DESCRIPTION
Add links for Swift 5.6.2 Docker images.