### PR TITLE
Fix broken link to Swift-DocC Plugin docs in Swift 5.6 announcement post

### DIFF
--- a/_posts/2022-03-14-swift-5.6-released.md
+++ b/_posts/2022-03-14-swift-5.6-released.md
@@ -128,7 +128,7 @@ Other updates include:
 
 ### Swift-DocC Updates
 
-Swift-DocC is now available [as a SwiftPM plugin](https://github.com/apple/swift-docc-plugin) using the new plugin command support. See the documentation to [learn how to get started](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/getting-started-with-the-swift-docc-plugin).
+Swift-DocC is now available [as a SwiftPM plugin](https://github.com/apple/swift-docc-plugin) using the new plugin command support. See the documentation to [learn how to get started](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/).
 
 In addition, you can now use Swift-DocC to [publish static content to GitHub Pages](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages).
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Since we merged the Swift-DocC Plugin's getting started guide into the documentation landing page with https://github.com/apple/swift-docc-plugin/pull/9, the link in the Swift 5.6 announcement blog post has been broken.

### Modifications:

Fixed the broken link to point to the new page where the plugin's getting started information is located.

### Result:

The Swift-DocC Plugin documentation link in the Swift 5.6 announcement blog post will work.
