### PR TITLE
Fix links in Swift Server guides

### DIFF
--- a/server/guides/allocations.md
+++ b/server/guides/allocations.md
@@ -20,7 +20,7 @@ To not waste your time, be sure to do any profiling in _release mode_. Swift's o
     
 #### Install `perf`
 
-Follow the [installation instructions]({{site.url}}/server/guides/linux-perf) in the Linux `perf` utility guide.
+Follow the [installation instructions]({{site.url}}/server/guides/linux-perf.html) in the Linux `perf` utility guide.
 
 #### Clone the `FlameGraph` project
 
@@ -45,7 +45,7 @@ or similar.
 
 ## Tools
 
-In this guide, we will be using the [Linux `perf`](https://perf.wiki.kernel.org/index.php/Main_Page) tool. If you're struggling to get `perf` to work, have a look at our [information regarding `perf`]({{site.url}}/server/guides/linux-perf). If you're running in a Docker container, don't forget that you'll need a privileged container. And generally, you will need `root` access, so you may need to prefix the commands with `sudo`.
+In this guide, we will be using the [Linux `perf`](https://perf.wiki.kernel.org/index.php/Main_Page) tool. If you're struggling to get `perf` to work, have a look at our [information regarding `perf`]({{site.url}}/server/guides/linux-perf.html). If you're running in a Docker container, don't forget that you'll need a privileged container. And generally, you will need `root` access, so you may need to prefix the commands with `sudo`.
 
 ## Getting a `perf` user probe
 

--- a/server/guides/deploying/digital-ocean.md
+++ b/server/guides/deploying/digital-ocean.md
@@ -64,4 +64,4 @@ Copy the root user's authorized SSH keys to the newly created user. This will al
 rsync --archive --chown=swift:swift ~/.ssh /home/swift
 ```
 
-Your DigitalOcean virtual machine is now ready. Continue using the [Ubuntu]({{site.url}}/server/guides/deploying/ubuntu) guide. 
+Your DigitalOcean virtual machine is now ready. Continue using the [Ubuntu]({{site.url}}/server/guides/deploying/ubuntu.html) guide.

--- a/server/guides/deploying/gcp.md
+++ b/server/guides/deploying/gcp.md
@@ -46,7 +46,7 @@ project root:
 You should test your Dockerfile with `docker build . -t test` and
 `docker run -p 8080:8080 test` and make sure it builds and runs locally.
 
-The _Dockerfile_ is the same as in the [packaging guide]({{site.url}}/server/guides/packaging/#docker).
+The _Dockerfile_ is the same as in the [packaging guide]({{site.url}}/server/guides/packaging.html#docker).
 Replace `<executable-name>` with your `executableTarget` (ie. "Server"):
 
 ```Dockerfile

--- a/server/guides/deploying/ubuntu.md
+++ b/server/guides/deploying/ubuntu.md
@@ -5,9 +5,9 @@ title: Deploying on Ubuntu
 
 Once you have your Ubuntu virtual machine ready, you can deploy your Swift app. This guide assumes you have a fresh install with a non-root user named `swift`. It also assumes both `root` and `swift` are accessible via SSH. For information on setting this up, check out the platform guides:
 
-- [DigitalOcean]({{site.url}}/server/guides/deploying/digital-ocean)
+- [DigitalOcean]({{site.url}}/server/guides/deploying/digital-ocean.html)
 
-The [packaging]({{site.url}}/server/guides/packaging) guide provides an overview of available deployment options. This guide takes you through each deployment option step-by-step for Ubuntu specifically. These examples will deploy SwiftNIO's [example HTTP server](https://github.com/apple/swift-nio/tree/master/Sources/NIOHTTP1Server), but you can test with your own project.
+The [packaging]({{site.url}}/server/guides/packaging.html) guide provides an overview of available deployment options. This guide takes you through each deployment option step-by-step for Ubuntu specifically. These examples will deploy SwiftNIO's [example HTTP server](https://github.com/apple/swift-nio/tree/master/Sources/NIOHTTP1Server), but you can test with your own project.
 
 - [Binary Deployment](#binary-deployment)
 - [Source Deployment](#source-deployment)
@@ -39,7 +39,7 @@ docker run --rm \
      cp -P /usr/lib/swift/linux/lib*so* .build/install/'
 ```
 
-> Tip: If you are building this project for production, use `swift build -c release`, see [building for production]({{site.url}}/server/guides/building/#building-for-production) for more information.
+> Tip: If you are building this project for production, use `swift build -c release`, see [building for production]({{site.url}}/server/guides/building.html#building-for-production) for more information.
 
 Notice that Swift's shared libraries are being included. This is important since Swift is not ABI stable on Linux. This means Swift programs must run against the shared libraries they were compiled with. 
 
@@ -173,7 +173,7 @@ cd swift-nio
 swift build
 ```
 
-> Tip: If you are building this project for production, use `swift build -c release`, see [building for production]({{site.url}}/server/guides/building/#building-for-production) for more information.
+> Tip: If you are building this project for production, use `swift build -c release`, see [building for production]({{site.url}}/server/guides/building.html#building-for-production) for more information.
 
 ### Run
 

--- a/server/guides/deployment.md
+++ b/server/guides/deployment.md
@@ -4,14 +4,14 @@ title: Deploying to Servers or Public Cloud
 ---
 
 The following guides can help with the deployment to public cloud providers:
-* [AWS]({{site.url}}/server/guides/deploying/aws)
-* [DigitalOcean]({{site.url}}/server/guides/deploying/digital-ocean)
-* [Heroku]({{site.url}}/server/guides/deploying/heroku)
-* [Kubernetes & Docker]({{site.url}}/server/guides/packaging/#docker)
-* [GCP]({{site.url}}/server/guides/deploying/gcp)
+* [AWS]({{site.url}}/server/guides/deploying/aws.html)
+* [DigitalOcean]({{site.url}}/server/guides/deploying/digital-ocean.html)
+* [Heroku]({{site.url}}/server/guides/deploying/heroku.html)
+* [Kubernetes & Docker]({{site.url}}/server/guides/packaging.html#docker)
+* [GCP]({{site.url}}/server/guides/deploying/gcp.html)
 * _Have a guides for other popular public clouds like Azure? Add it here!_
 
-If you are deploying to you own servers (e.g. bare metal, VMs or Docker) there are several strategies for packaging Swift applications for deployment, see the [Packaging Guide]({{site.url}}/server/guides/packaging) for more information.
+If you are deploying to you own servers (e.g. bare metal, VMs or Docker) there are several strategies for packaging Swift applications for deployment, see the [Packaging Guide]({{site.url}}/server/guides/packaging.html) for more information.
 
 ## Deploying a Debuggable Configuration (Production on Linux)
 

--- a/server/guides/index.md
+++ b/server/guides/index.md
@@ -7,19 +7,19 @@ The Swift Server Workgroup and Swift on Server community have developed a number
 
 They focus on how to compile, test, deploy and debug such application and provides tips in those areas.
 
-- [Setup and code editing]({{site.url}}/server/guides/setup-and-ide-alternatives/)
-- [Building]({{site.url}}/server/guides/building/)
-- [Testing]({{site.url}}/server/guides/testing/)
-- [Debugging Memory leaks]({{site.url}}/server/guides/memory-leaks-and-usage)
-- [Performance troubleshooting and analysis]({{site.url}}/server/guides/performance)
-- [Optimizing allocations]({{site.url}}/server/guides/allocations)
-- [Debugging multithreading issues and memory checks]({{site.url}}/server/guides/llvm-sanitizers/)
-- [Deployment]({{site.url}}/server/guides/deployment)
-- [Packaging]({{site.url}}/server/guides/packaging)
+- [Setup and code editing](/server/guides/setup-and-ide-alternatives.html)
+- [Building]({{site.url}}/server/guides/building.html)
+- [Testing]({{site.url}}/server/guides/testing.html)
+- [Debugging Memory leaks]({{site.url}}/server/guides/memory-leaks-and-usage.html)
+- [Performance troubleshooting and analysis]({{site.url}}/server/guides/performance.html)
+- [Optimizing allocations]({{site.url}}/server/guides/allocations.html)
+- [Debugging multithreading issues and memory checks]({{site.url}}/server/guides/llvm-sanitizers.html)
+- [Deployment]({{site.url}}/server/guides/deployment.html)
+- [Packaging]({{site.url}}/server/guides/packaging.html)
 
 Additionally, there are specific guides for library developers:
 
-* [Log Levels]({{site.url}}/server/guides/libraries/log-levels)
-* [Adopting Swift Concurrency]({{site.url}}/server/guides/libraries/concurrency-adoption-guidelines)
+* [Log Levels]({{site.url}}/server/guides/libraries/log-levels.html)
+* [Adopting Swift Concurrency]({{site.url}}/server/guides/libraries/concurrency-adoption-guidelines.html)
 
 _These guides are community effort, and all are invited to share their tips and know-how by submitting pull requests to the [Swift.org site](https://github.com/apple/swift-org-website)_.

--- a/server/guides/linux-perf.md
+++ b/server/guides/linux-perf.md
@@ -13,7 +13,7 @@ The Linux [`perf` tool](https://perf.wiki.kernel.org/index.php/Main_Page) is an 
 
 In general, `perf` can count and/or record the call stacks of your threads when a certain event occurs. These events can be triggered by:
 
-- Time (e.g. 1000 times per second), useful for time profiling. For an example use, see the [CPU performance debugging guide]({{site.url}}/server/guides/performance).
+- Time (e.g. 1000 times per second), useful for time profiling. For an example use, see the [CPU performance debugging guide]({{site.url}}/server/guides/performance.html).
 - System calls, useful to see where your system calls are happening.
 - Various system events, for example if you'd like to know when context switches occur.
 - CPU performance counters, useful if your performance issues can be traced down to micro-architectural details of your CPU (such as branch mispredictions). For an example, see [SwiftNIO's Advanced Performance Analysis guide](https://github.com/apple/swift-nio/blob/main/docs/advanced-performance-analysis.md).

--- a/server/guides/performance.md
+++ b/server/guides/performance.md
@@ -106,7 +106,7 @@ for f in 0..<2_000 {
 
 The above program contains the `TerribleArray` data structure which has _O(n)_ appends and not the amortised _O(1)_ that users are used to from `Array`.
 
-We will assume, that you have Linux's `perf` installed and configured, documentation on how to install `perf` can be found in [this guide]({{site.url}}/server/guides/linux-perf).
+We will assume, that you have Linux's `perf` installed and configured, documentation on how to install `perf` can be found in [this guide]({{site.url}}/server/guides/linux-perf.html).
 
 Let's assume we have compiled the above code using `swift build -c release` into a binary called `./slow`. We also assume that the `https://github.com/brendangregg/FlameGraph` repository is cloned in `~/FlameGraph`:
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Fixes #111.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

As these server guide files are not `index.html` files inside a named folder, we have to link to them by appending `.html`.

This is one of probably several ways to fix this, but I think this is good enough for now.

cc: @0xTim 