### PR TITLE
added link to AWS Fargate with Vapor and MongoDB guide

### DIFF
--- a/server/guides/deployment.md
+++ b/server/guides/deployment.md
@@ -4,7 +4,8 @@ title: Deploying to Servers or Public Cloud
 ---
 
 The following guides can help with the deployment to public cloud providers:
-* [AWS]({{site.url}}/server/guides/deploying/aws.html)
+* [AWS on EC2]({{site.url}}/server/guides/deploying/aws.html)
+* [AWS on Fargate with Vapor and MongoDB Atlas]({{site.url}}/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html)
 * [DigitalOcean]({{site.url}}/server/guides/deploying/digital-ocean.html)
 * [Heroku]({{site.url}}/server/guides/deploying/heroku.html)
 * [Kubernetes & Docker]({{site.url}}/server/guides/packaging.html#docker)


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

Added link to new AWS Guide for Fargate, Vapor, and MongoDB Atlas
-->

### Motivation:

<!-- _[The guide existed but there was no link to get to it.]_ -->

### Modifications:

<!-- _[added a new link to the Deployments page. Renamed the existing, older AWS link to specify AWS on EC2 to differentiate it from the newer guide which is AWS with Fargate]_ -->

### Result:

<!-- _new link added to the Deployments page._ -->
