### PR TITLE
Remove extra "something" from server deployment page.

### DIFF
--- a/server/guides/deployment.md
+++ b/server/guides/deployment.md
@@ -20,6 +20,6 @@ If you are deploying to you own servers (e.g. bare metal, VMs or Docker) there a
 
         lldb --batch -o "break set -n main --auto-continue 1 -C \"process handle SIGPIPE -s 0\"" -o run -k "image list" -k "register read" -k "bt all" -k "exit 134" ./my-program
 
-    instead of `./my-program` to get something something akin to a 'crash report' on crash.
+    instead of `./my-program` to get something akin to a 'crash report' on crash.
 
 - If you don't have `--privileged` (or `--security-opt seccomp=unconfined`) containers (meaning you won't be able to use `lldb`) or you don't want to use lldb, consider using a library like [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) to get stack traces on crash.


### PR DESCRIPTION
Fixed small typo on server deployment page.

### Motivation:

Hi, noticed a small typo when reading the server deployment page. I'm new to making pull request so hopefully i'm doing this right.

### Modifications:

Removed extra "something" from /server/guides/deployment.md

### Result:

Removed extra "something".
