### PR TITLE
Update ePub link

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -26,7 +26,7 @@ offering a guided tour, a comprehensive guide, and a formal reference of the lan
 </div>
 
 <div class="links links-download" markdown="1">
-[Download The Swift Programming Language in ePub format](https://docs.swift.org/swift-book/TheSwiftProgrammingLanguageSwift.epub)
+[Download The Swift Programming Language in ePub format](https://docs.swift.org/swift-book/TheSwiftProgrammingLanguage.epub)
 </div>
 
 #### Translations

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -26,7 +26,7 @@ offering a guided tour, a comprehensive guide, and a formal reference of the lan
 </div>
 
 <div class="links links-download" markdown="1">
-[Download The Swift Programming Language in ePub format](https://docs.swift.org/swift-book/TheSwiftProgrammingLanguageSwift57.epub)
+[Download The Swift Programming Language in ePub format](https://docs.swift.org/swift-book/TheSwiftProgrammingLanguageSwift.epub)
 </div>
 
 #### Translations


### PR DESCRIPTION
The URL for "The Swift Programming Language" no longer includes the version number in its filename — we need to update the link here to match.