### PR TITLE
Update Getting Started REPL instructions

### DIFF
--- a/getting-started/_repl.md
+++ b/getting-started/_repl.md
@@ -1,13 +1,14 @@
 ## Using the REPL
 
-If you run the `swift` command without any other arguments,
+If you run `swift repl` without any other arguments,
 you'll launch the REPL, an interactive shell
 that will read, evaluate, and print the results
 of any Swift code you enter.
 
 ~~~ shell
-$ swift
-Welcome to Apple Swift version 2.2. Type :help for assistance.
+$ swift repl
+Welcome to Apple Swift version 5.7 (swiftlang-5.7.0.127.4 clang-1400.0.29.50).
+Type :help for assistance.
   1>
 ~~~
 


### PR DESCRIPTION
Hi, I noticed the REPL instructions no longer work. So I've updated them. Please let me know if there's anything else I should do here.

### Motivation:

The REPL is no longer available by simply running `swift`. Now you need to run `swift repl`. Just running `swift` shows help text instead of the REPL as of Swift 5.7:

```
$ swift                                                                             

Welcome to Swift!

Subcommands:

  swift build      Build Swift packages
  swift package    Create and work on packages
  swift run        Run a program from a package
  swift test       Run package tests
  swift repl       Experiment with Swift code interactively

  Use `swift --help` for descriptions of available options and flags.

  Use `swift help <subcommand>` for more information about a subcommand.
````

### Modifications:

Update the text to reflect the fact that you have to run `swift repl`, not just `swift`. This commit also adjusts the output to reflect what Swift 5.7 (macOS/Xcode 14) outputs.

### Result:

These instructions will be more up to date.
![image](https://user-images.githubusercontent.com/1696960/189767144-726c6d7c-8694-4daf-81f5-d4cdb52d1165.png)

