### PR TITLE
Add SE-0363 to the Swift 5.7 evolution appendix.

### DIFF
--- a/_posts/2022-09-12-swift-5.7-released.md
+++ b/_posts/2022-09-12-swift-5.7-released.md
@@ -153,6 +153,7 @@ The following language, standard library, and Swift Package Manager proposals we
 * SE-0354: [Regex Literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md)
 * SE-0355: [Regex Syntax and Run-time Construction](https://github.com/apple/swift-evolution/blob/main/proposals/0355-regex-syntax-run-time-construction.md)
 * SE-0357: [Regex-powered string processing algorithms](https://github.com/apple/swift-evolution/blob/main/proposals/0357-regex-string-processing-algorithms.md)
+* SE-0363: [Unicode for String Processing](https://github.com/apple/swift-evolution/blob/main/proposals/0363-unicode-for-string-processing.md)
 
 **Pointer Usability**
 


### PR DESCRIPTION
This proposal is implemented in Swift 5.7 and I missed it in the Swift Evolution Appendix in the release blog post.