### PR TITLE
Fix link texts in Compiler Architecture page

### DIFF
--- a/swift-compiler/_compiler-architecture.md
+++ b/swift-compiler/_compiler-architecture.md
@@ -47,7 +47,7 @@ high-level description of the major components of the Swift compiler:
     uninitialized variables). The end result of these transformations
     is "canonical" SIL.
 
-* **SIL Optimizations**: The SIL optimizations (implemented in
+* **SIL optimizations**: The SIL optimizations (implemented in
     [lib/SILOptimizer/Analysis](https://github.com/apple/swift/tree/main/lib/SILOptimizer/Analysis),
     [lib/SILOptimizer/ARC](https://github.com/apple/swift/tree/main/lib/SILOptimizer/ARC),
     [lib/SILOptimizer/LoopTransforms](https://github.com/apple/swift/tree/main/lib/SILOptimizer/LoopTransforms), and
@@ -56,7 +56,7 @@ high-level description of the major components of the Swift compiler:
     program, including (for example) Automatic Reference Counting
     optimizations, devirtualization, and generic specialization.
 
-* **LLVM IR Generation**: IR generation (implemented in
+* **LLVM IR generation**: IR generation (implemented in
     [lib/IRGen](https://github.com/apple/swift/tree/main/lib/IRGen))
     lowers SIL to [LLVM IR](http://llvm.org/docs/LangRef.html), at
     which point [LLVM](http://llvm.org) can continue to optimize it

--- a/swift-compiler/_compiler-architecture.md
+++ b/swift-compiler/_compiler-architecture.md
@@ -48,9 +48,10 @@ high-level description of the major components of the Swift compiler:
     is "canonical" SIL.
 
 * **SIL Optimizations**: The SIL optimizations (implemented in
-    [lib/Analysis](https://github.com/apple/swift/tree/main/lib/SILOptimizer/Analysis), [lib/ARC](https://github.com/apple/swift/tree/main/lib/SILOptimizer/ARC), [lib/LoopTransforms](https://github.com/apple/swift/tree/main/lib/SILOptimizer/LoopTransforms),
-    and
-    [lib/Transforms](https://github.com/apple/swift/tree/main/lib/SILOptimizer/Transforms))
+    [lib/SILOptimizer/Analysis](https://github.com/apple/swift/tree/main/lib/SILOptimizer/Analysis),
+    [lib/SILOptimizer/ARC](https://github.com/apple/swift/tree/main/lib/SILOptimizer/ARC),
+    [lib/SILOptimizer/LoopTransforms](https://github.com/apple/swift/tree/main/lib/SILOptimizer/LoopTransforms), and
+    [lib/SILOptimizer/Transforms](https://github.com/apple/swift/tree/main/lib/SILOptimizer/Transforms))
     perform additional high-level, Swift-specific optimizations to the
     program, including (for example) Automatic Reference Counting
     optimizations, devirtualization, and generic specialization.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Hello 👋🏻, while reading the [Compiler Architecture page](https://www.swift.org/swift-compiler/#compiler-architecture) I noticed the link texts in the SIL optimizations paragraph did not reflect the actual directory name for the corresponding implementations.

### Modifications:

* Fix link texts in SIL optimizations paragraph to reflect the actual implementation directory names.
* Changed the casing of the compiler component names in the last two paragraphs to use sentence case, as in the paragraphs  above them—for consistency sake. 


### Result:

Screenshot of content after changes:

<img width="669" alt="screenshot of the compiler architecture page after changes" src="https://user-images.githubusercontent.com/40843954/189960377-be9a2964-9093-4a9e-bda4-7b04fcd4163e.png">

