### PR TITLE
Update the Swift 5.7 Docker image URLs

### DIFF
--- a/_data/builds/swift-5_7-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_7-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.7-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-amazonlinux2
+  docker: 5.7-amazonlinux2

--- a/_data/builds/swift-5_7-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_7-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.7-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-amazonlinux2
+  docker: 5.7-amazonlinux2

--- a/_data/builds/swift-5_7-release/centos7.yml
+++ b/_data/builds/swift-5_7-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-centos7.tar.gz
   download_signature: swift-5.7-RELEASE-centos7.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-centos7
+  docker: 5.7-centos7

--- a/_data/builds/swift-5_7-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_7-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.7-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-bionic
+  docker: 5.7-bionic

--- a/_data/builds/swift-5_7-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_7-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.7-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-focal
+  docker: 5.7-focal

--- a/_data/builds/swift-5_7-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_7-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.7-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-focal
+  docker: 5.7-focal

--- a/_data/builds/swift-5_7-release/ubuntu2204-aarch64.yml
+++ b/_data/builds/swift-5_7-release/ubuntu2204-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-ubuntu22.04-aarch64.tar.gz
   download_signature: swift-5.7-RELEASE-ubuntu22.04-aarch64.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-focal
+  docker: 5.7-jammy

--- a/_data/builds/swift-5_7-release/ubuntu2204.yml
+++ b/_data/builds/swift-5_7-release/ubuntu2204.yml
@@ -4,4 +4,4 @@
   download: swift-5.7-RELEASE-ubuntu22.04.tar.gz
   download_signature: swift-5.7-RELEASE-ubuntu22.04.tar.gz.sig
   dir: swift-5.7-RELEASE
-  docker: Coming Soon #5.7-focal
+  docker: 5.7-jammy


### PR DESCRIPTION
Docker images now available on hub.docker.com/_/swift