### PR TITLE
Add staging header across the website

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="utf-8" />
   <title>{{ site.title }} - {{ page.title | escape }}</title>
+  {% if jekyll.environment == 'stage' %}
+  <meta name="robots" content="noindex" />
+  {% endif %}
   <meta name="author" content="Apple Inc." />
   <meta name="viewport" content="width=device-width initial-scale=1" />
   <link rel="license" href="/LICENSE.txt" />
@@ -57,6 +60,13 @@
 </head>
 
 <body>
+{% if jekyll.environment == 'stage' %}
+<p class="stage">
+  ⚠️ STAGING WEBSITE ⚠️<br>
+    Visit <a href="https://www.swift.org">swift.org</a> for production website.
+  </a>
+</p>
+{% endif %}
 <script src="/assets/javascripts/color-scheme-toggle.js"></script>
 {% include navigation.html %}
 {{content}}

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -969,3 +969,12 @@ article {
 .visuallyhidden {
   @include visuallyhidden();
 }
+
+.stage {
+    background-color: #fffbcc;
+    color: #808080;
+    font-size: 16px;
+    line-height: 20px;
+    padding: 10px 10px;
+    text-align: center;
+}


### PR DESCRIPTION
Staging header will only display if `JEKYLL_ENV=stage` set. 

**For example:** 
```
JEKYLL_ENV=stage LC_ALL=en_us.UTF-8 bundle exec jekyll serve
```
**Screenshot:**
<img width="1136" alt="Screenshot 2022-09-20 at 12 00 05 PM" src="https://user-images.githubusercontent.com/2727770/191342817-25126fdb-9818-4112-ad36-0f3c36a67547.png">

