### PR TITLE
Update name of bugtracker

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -12,7 +12,7 @@ The Swift language is developed in the open, and all technical or administrative
 
 * Directory of forum categories and email instructions are in the [forum section](#forums)
 * Source code for all Swift projects can be found on GitHub at [github.com/apple][github]
-* The Swift.org bug tracking system is maintained at [github.com/apple/swift/issues][bugtracker]
+* The Swift language bug tracking system is maintained at [github.com/apple/swift/issues][bugtracker]
 
 All communication within project spaces should adhere to Swift project's [Code of Conduct](/code-of-conduct).
 


### PR DESCRIPTION
After #32 , we update the bug track link to Github Issues.

And since swift-org-website is open sourced too. Maybe "the Swift.org bug tracking system" should be redirected to this repo instead of apple/swift repo.