### PR TITLE
Add Documentation Workgroup to navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -240,3 +240,14 @@
           name: membership
         - title: Communication
           name: communication
+    - title: Documentation Workgroup
+      url: /documentation-workgroup/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Communication
+          name: communication
+        - title: Community Participation
+          name: community-participation


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

All other swift workgroup's post is listed under "Open Source Efforts". Swift Documentation Workgroup should be listed here too. (Now it can only be discovered by the Announcement Post)

<img width="240" alt="image" src="https://user-images.githubusercontent.com/43724855/192201350-9549f51e-6eae-4634-bb66-1f18f79ff169.png">

https://www.swift.org/documentation-workgroup/

### Modifications:

Add "Swift Documentation Workgroup" Page to the Navigation Bar

### Result:

"Documentation Workgroup" will be added under "[C++ INTEROPERABILITY](https://www.swift.org/cxx-interop-workgroup/)"
