### PR TITLE
Update issue link from swift to swift-docc

### DIFF
--- a/documentation-workgroup/index.md
+++ b/documentation-workgroup/index.md
@@ -94,7 +94,7 @@ contribute, consider:
 * Discussing ideas in the Swift Forums, for example in the [Swift-DocC
   forum](https://forums.swift.org/c/development/swift-docc) for
   Swift-DocC–related ideas
-* Creating [GitHub Issues](https://github.com/apple/swift/issues) to track
-  documentation and documentation tooling enhancements and bugs
+* Opening issues to track enhancements and bugs for the projects governed by the Documentation Workgroup:
+  [Swift-DocC](https://github.com/apple/swift-docc/issues), [The Swift Programming Language book](https://github.com/apple/swift-book/issues)
 * Participating in the [Swift Mentorship
   Program](/mentorship)


### PR DESCRIPTION
### Motivation:

Issus on documentation and documentation tooling enhancements and bugs should better be reported at `apple/swift-docc` rather than `apple/swift`. cc @franklinsch 

### Modifications:

Update the Github issue link on Swift Documentation Workgroup Chapter.

### Result:

The Github issue link on Swift Documentation Workgroup Chapter will be redirected into https://github.com/apple/swift-docc/issues
