### PR TITLE
Fix StartBug link in Mentorship Page

### DIFF
--- a/mentorship/index.md
+++ b/mentorship/index.md
@@ -83,7 +83,7 @@ Most communication is expected to happen asynchronously on the Swift Forums. The
 <details class="download">
   <summary>How are open source tasks for mentees identified?</summary>
 
-If the mentee does not have any ideas in mind, project maintainers and mentors may identify starter tasks that are suitable for newcomers to the project. For example, the Swift compiler project has issues labeled [StarterBug](https://github.com/apple/swift/issues?q=is%3Aopen+is%3Aissue+label%3AStarterBug). Beyond the initial contribution, mentors or mentees may suggest small “projects” that are implementable given the expected time commitment. Otherwise, every open source project has an endless supply of issues to be fixed! Participants may rely on the issue tracking system for the open source project to identify these tasks.
+If the mentee does not have any ideas in mind, project maintainers and mentors may identify starter tasks that are suitable for newcomers to the project. For example, the Swift compiler project has issues labeled <a href="https://github.com/apple/swift/issues?q=is%3Aopen+is%3Aissue+label%3AStarterBug">StarterBug</a>. Beyond the initial contribution, mentors or mentees may suggest small “projects” that are implementable given the expected time commitment. Otherwise, every open source project has an endless supply of issues to be fixed! Participants may rely on the issue tracking system for the open source project to identify these tasks.
 </details>
 
 <details class="download">


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

The StartBug link is broken

### Modifications:

Change link style from Markdown style to HTML

### Result:

- Before: https://www.swift.org/mentorship/#frequently-asked-questions
![SCR-20220929-ouq](https://user-images.githubusercontent.com/43724855/193001745-b33a8de7-a49a-4e54-8ad2-c75efeaa7eac.png)

- After: http://127.0.0.1:4000/mentorship/#frequently-asked-questions
![SCR-20220929-oui](https://user-images.githubusercontent.com/43724855/193001758-34eb7951-cfd0-4ed9-92b6-fd0cbe5a8c0b.png)
