### PR TITLE
contributing: Minor amendments and additions to bug reporting guidelines

### DIFF
--- a/contributing/_reporting-bugs.md
+++ b/contributing/_reporting-bugs.md
@@ -8,23 +8,23 @@ or if the bug is associated with an Apple NDA,
 please file a report to Apple's [bug reporter][apple-bugtracker] instead.
 </div>
 
-When filing a new Swift bug, please include the following:
+When opening an issue, please include the following:
 
 - **A concise description of the problem.**
   If the issue is a crash, include a stack trace. Otherwise, describe the behavior you were expecting to see, along with the behavior you actually observed.
 
 - **A reproducible test case.**
-  If the test case is small (for example, less than 20 lines of code) paste it directly into the issue's description field. Otherwise, upload it as an attachment to the Jira issue.
+  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible—a smaller test case is easier to reason about and more appealing to сontributors.
 
 - **A description of the environment that reproduces the problem.**
-  Include the Swift build number, as well as information about your target OS and platform.
+  Include information about the Swift compiler's version, the deployment target (if explicitly set) and your platform.
 
-Because Swift is under very active development, we receive a lot of bug reports. Before filing a new issue, take a moment to browse our [existing issues](https://github.com/apple/swift/issues) to make sure you're not filing a duplicate.
+Because Swift is under very active development, we receive a lot of bug reports. Before opening a new issue, take a moment to browse our [existing issues](https://github.com/apple/swift/issues) to reduce the chance of reporting a duplicate.
 
 <div class="warning" markdown="1">
-Before filing an issue requesting a new language feature, see [Participating in the Swift Evolution Process](#participating-in-the-swift-evolution-process).
+Before opening an issue requesting a new language feature, see [Participating in the Swift Evolution Process](#participating-in-the-swift-evolution-process).
 </div>
 
-[bugtracker]:  http://github.com/apple/swift/issues
+[bugtracker]: http://github.com/apple/swift/issues
 [apple-bugtracker]: https://bugreport.apple.com
 [evolution-repo]: https://github.com/apple/swift-evolution "Link to the Swift evolution repository on GitHub"

--- a/contributing/_reporting-bugs.md
+++ b/contributing/_reporting-bugs.md
@@ -14,7 +14,7 @@ When opening an issue, please include the following:
   If the issue is a crash, include a stack trace. Otherwise, describe the behavior you were expecting to see, along with the behavior you actually observed.
 
 - **A reproducible test case.**
-  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible—a smaller test case is easier to reason about and more appealing to сontributors.
+  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible — a smaller test case is easier to reason about and more appealing to сontributors.
 
 - **A description of the environment that reproduces the problem.**
   Include information about the Swift compiler's version, the deployment target (if explicitly set) and your platform.

--- a/contributing/_reporting-bugs.md
+++ b/contributing/_reporting-bugs.md
@@ -14,7 +14,7 @@ When opening an issue, please include the following:
   If the issue is a crash, include a stack trace. Otherwise, describe the behavior you were expecting to see, along with the behavior you actually observed.
 
 - **A reproducible test case.**
-  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible — a smaller test case is easier to reason about and more appealing to сontributors.
+  Double-check that your test case reproduces the issue. A relatively small sample (roughly within 50 lines of code) is best pasted directly into the description; a larger one may be uploaded as an attachment. Consider reducing the sample to the smallest amount of code possible—a smaller test case is easier to reason about and more appealing to сontributors.
 
 - **A description of the environment that reproduces the problem.**
   Include information about the Swift compiler's version, the deployment target (if explicitly set) and your platform.


### PR DESCRIPTION
#### Modifications:

* Remove a mention of Jira.
* Urge reporters to pay extra attention to whether their test case reproduces the issue. We’d rather spend time fixing issues than completing test cases to reveal them.
* Bump the estimate of a small test case from "less than 20" to "within 50" lines of code. 50 lines is *fine* for an inline sample—stack traces are often commensurate, yet we tend to prefer them inline.
* Encourage reporters to reduce their test cases. Reduced examples are far easier to debug and more future-proof.
* Use "open" instead of "file" in relation to a GitHub issue.
* Prefer "version information" over the somewhat cryptic "Swift build number".
* Prefer the more familiar "deployment target" over "target OS" as per Xcode’s nomenclature.
