### PR TITLE
Add Github link for Documentation Workgroup member

### DIFF
--- a/documentation-workgroup/index.md
+++ b/documentation-workgroup/index.md
@@ -17,18 +17,18 @@ The Documentation Workgroup will:
 
 The current Documentation Workgroup consists of the following people:
 
-* Daniel Grumberg
-* Dave Verwer
-* David Rönnqvist
-* Ethan Kusters
-* Franklin Schrans (chair)
-* Joe Heck
-* Kelvin Ma
-* Kyle Murray
-* Kyle Ye
-* Max Obermeier
-* Sven Schmidt
-* Victoria Mitchell
+* [Daniel Grumberg](https://github.com/daniel-grumberg)
+* [Dave Verwer](https://github.com/daveverwer)
+* [David Rönnqvist](https://github.com/d-ronnqvist)
+* [Ethan Kusters](https://github.com/ethan-kusters)
+* [Franklin Schrans](https://github.com/franklinsch) (chair)
+* [Joe Heck](https://github.com/heckj)
+* [Kelvin Ma](https://github.com/kelvin13)
+* [Kyle Murray](https://github.com/krilnon)
+* [Kyle Ye](https://github.com/Kyle-Ye)
+* [Max Obermeier](https://github.com/theMomax)
+* [Sven Schmidt](https://github.com/finestructure)
+* [Victoria Mitchell](https://github.com/QuietMisdreavus)
 
 ## Charter
 


### PR DESCRIPTION
### Motivation:

[language-workgroup](https://www.swift.org/language-workgroup/) lists their members with link support so that others could easily reach out to them. 

<img width="478" alt="image" src="https://user-images.githubusercontent.com/43724855/194717622-e8f21724-df03-451f-b1b2-5f71fb5e5f7f.png">

IMO, add such links in Documentation Workgroup would be great.

Forum discussion link https://forums.swift.org/t/website-add-member-links-for-documentation-workgroup-page/60732 (Private for Documentation Workgroup member)

### Modifications:

The PR adds Github link for each of the Documentation Workgroup member.

If the link is wrong, feel free to reach to me or comment on the PR.

### Result:

Before

<img width="602" alt="image" src="https://user-images.githubusercontent.com/43724855/194717630-8f2b1498-399a-45ff-af35-c6fd2727caab.png">

After

<img width="609" alt="image" src="https://user-images.githubusercontent.com/43724855/194717650-f272b7e0-1915-4633-8761-56ec8c29eb5b.png">

