### PR TITLE
_includes/linux: list dependencies for Ubuntu 22.04

### DIFF
--- a/_includes/linux/table.html
+++ b/_includes/linux/table.html
@@ -4,6 +4,7 @@
       <th>Ubuntu 16.04</th>
       <th>Ubuntu 18.04</th>
       <th>Ubuntu 20.04</th>
+      <th>Ubuntu 22.04</th>
       <th>CentOS 7</th>
       <th>CentOS 8</th>
       <th>Amazon Linux 2</th>
@@ -14,6 +15,7 @@
       <td style="padding: 0; vertical-align: top">{% include linux/ubuntu1604.md %}</td>
       <td style="padding: 0; vertical-align: top">{% include linux/ubuntu1804.html %}</td>
       <td style="padding: 0; vertical-align: top">{% include linux/ubuntu2004.html %}</td>
+      <td style="padding: 0; vertical-align: top">{% include linux/ubuntu2204.html %}</td>
       <td style="padding: 0; vertical-align: top">{% include linux/centos7.html %}</td>
       <td style="padding: 0; vertical-align: top">{% include linux/centos8.html %}</td>
       <td style="padding: 0; vertical-align: top">{% include linux/amazonlinux2.html %}</td>

--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -1,0 +1,19 @@
+{% highlight bash %}
+$ apt-get install \
+          binutils \
+          git \
+          gnupg2 \
+          libc6-dev \
+          libcurl4-openssl-dev \
+          libedit2 \
+          libgcc-9-dev \
+          libpython3.8 \
+          libsqlite3-0 \
+          libstdc++-9-dev \
+          libxml2-dev \
+          libz3-dev \
+          pkg-config \
+          tzdata \
+          unzip \
+          zlib1g-dev
+{% endhighlight %}


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

[Getting Started page](https://www.swift.org/getting-started/) does not list dependencies for Ubuntu 22.04, even though this version is supported.

### Modifications:

Added a list of packages, as listed [in the corresponding `Dockerfile`](https://github.com/apple/swift-docker/blob/main/5.7/ubuntu/22.04/Dockerfile).

### Result:

Now it should be easier for users of Ubuntu 22.04 to install Swift.
