### PR TITLE
Fixed an old mailing list link

### DIFF
--- a/contributing/_answering-questions.md
+++ b/contributing/_answering-questions.md
@@ -2,9 +2,8 @@
 
 One of the most important and immediate ways you can support the community
 is to answer questions on the
-[forums](/community/#mailing-lists).
+[forums](/community/#forums).
 Whether you're helping a newcomer understand a language feature
 or troubleshooting an edge case with a seasoned developer,
 your knowledge and experience of Swift
 can go a long way to help others.
-


### PR DESCRIPTION
It looks like this link was missed during the switch from mailing lists to forums. The page still exists, but the anchor has gone so the visitor was left at the top of the community page.
