### PR TITLE
Add reference to plugin getting started guide

### DIFF
--- a/getting-started/_build-system.md
+++ b/getting-started/_build-system.md
@@ -164,3 +164,5 @@ $ swift run Hello `whoami`
 > To learn about the Swift Package Manager,
 > including how to build modules, import dependencies, and map system libraries,
 > see the [Swift Package Manager](/package-manager) section of the website.
+
+> To learn more about Package Plugins, see [Getting Started with Plugins](https://github.com/apple/swift-package-manager/blob/main/Documentation/Plugins.md#getting-started-with-plugins).


### PR DESCRIPTION
We have a getting started guide for using package plugins on the SwiftPM repo and it would be good to link it from swift.org
