### PR TITLE
Remove "(Unassigned, N/A)" from SE Dashboard

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -404,17 +404,10 @@ function renderReviewManager(reviewManager) {
   ])
 }
 
-/** Tracking bugs linked in a proposal are updated via bugs.swift.org. */
+/** Tracking bugs linked in a proposal are updated via GitHub Issues. */
 function renderTrackingBugs(bugs) {
   var bugNodes = bugs.map(function (bug) {
-    return html('a', { href: bug.link, target: '_blank' }, [
-      bug.id,
-      ' (',
-      bug.assignee || 'Unassigned',
-      ', ',
-      bug.status || 'N/A',
-      ')'
-    ])
+    return html('a', { href: bug.link, target: '_blank' }, bug.id)
   })
 
   bugNodes = _joinNodes(bugNodes, ', ')


### PR DESCRIPTION
Update the [SE Dashboard](https://www.swift.org/swift-evolution/) bug fields.

### Motivation:

The `assignee` and `status` properties are always empty
(after migrating from JIRA to GitHub Issues).

### Modifications:

Update the script to not render "(Unassigned, N/A)".

### Result:

The fields will only include JIRA or rdar IDs.