### PR TITLE
Add forum link to Foundation blog post

### DIFF
--- a/_posts/2022-12-09-future-of-foundation.md
+++ b/_posts/2022-12-09-future-of-foundation.md
@@ -31,4 +31,4 @@ And this also achieves an important community goal:
 * **Open contribution process.** Open source projects are at their best when the community of users can participate and become a community of developers. A new, open contribution process will be available to enable all developers to contribute new API to Foundation.
 
 ## Going Together
-We're excited to start discussing these plans with everyone on the Swift forums. The project itself will launch on GitHub in 2023.
+We're excited to start discussing these plans with everyone [on the Swift forums](https://forums.swift.org/t/what-s-next-for-foundation/61939). The project itself will launch on GitHub in 2023.


### PR DESCRIPTION
### Motivation:

Include the forum link for the Foundation conversation in the Foundation blog post.

### Modifications:

Add a single link to the recently posted Foundation blog post.

### Result:

Readers can get to the forums easily if they're interested.