### PR TITLE
Fix visibility of detail controls in Firefox.

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -867,6 +867,7 @@ article {
      font-family: inherit;
      position: relative;
      top: -.85rem;
+     -moz-appearance: none;
   }
 
   p + input.detail[type=checkbox] {


### PR DESCRIPTION
Resolves #178

Fixes the visibility of "More Detail" and "Less Detail" controls in Firefox. ([forums post](https://forums.swift.org/t/can-t-expand-html-sections-in-api-design-guidelines/))

### Motivation:

"More Detail" and "Less Detail" controls were missing from Firefox. They were visible in Safari and Chrome.

### Modifications:

Adds `-moz-appearance: none;` to `article input.detail[type=checkbox]`. 

### Result:

"More Detail" and "Less Detail" controls are now visible in Firefox.

**Before:** 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/44757473/207408955-8fa9b6f7-e439-44a6-bc90-0bf1417fec17.png">

**After:**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/44757473/207409107-64f02e48-9eda-442b-9cfc-4ce7148e7888.png">

