### PR TITLE
Add links to Swift 5.7.2 Docker images

### DIFF
--- a/_data/builds/swift-5_7_1-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_7_1-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.1-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.7.1-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.7.1-RELEASE
-  docker: Coming Soon #5.7.1-amazonlinux2
+  docker: 5.7.1-amazonlinux2

--- a/_data/builds/swift-5_7_1-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_7_1-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.1-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.7.1-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.7.1-RELEASE
-  docker: Coming Soon #5.7.1-amazonlinux2
+  docker: 5.7.1-amazonlinux2

--- a/_data/builds/swift-5_7_2-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_7_2-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.7.2-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-amazonlinux2
+  docker: 5.7.2-amazonlinux2

--- a/_data/builds/swift-5_7_2-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_7_2-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.7.2-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-amazonlinux2
+  docker: 5.7.2-amazonlinux2

--- a/_data/builds/swift-5_7_2-release/centos7.yml
+++ b/_data/builds/swift-5_7_2-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-centos7.tar.gz
   download_signature: swift-5.7.2-RELEASE-centos7.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-centos7
+  docker: 5.7.2-centos7

--- a/_data/builds/swift-5_7_2-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_7_2-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.7.2-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-bionic
+  docker: 5.7.2-bionic

--- a/_data/builds/swift-5_7_2-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_7_2-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.7.2-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-focal
+  docker: 5.7.2-focal

--- a/_data/builds/swift-5_7_2-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_7_2-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.7.2-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-focal
+  docker: 5.7.2-focal

--- a/_data/builds/swift-5_7_2-release/ubuntu2204-aarch64.yml
+++ b/_data/builds/swift-5_7_2-release/ubuntu2204-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-ubuntu22.04-aarch64.tar.gz
   download_signature: swift-5.7.2-RELEASE-ubuntu22.04-aarch64.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-jammy
+  docker: 5.7.2-jammy

--- a/_data/builds/swift-5_7_2-release/ubuntu2204.yml
+++ b/_data/builds/swift-5_7_2-release/ubuntu2204.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.2-RELEASE-ubuntu22.04.tar.gz
   download_signature: swift-5.7.2-RELEASE-ubuntu22.04.tar.gz.sig
   dir: swift-5.7.2-RELEASE
-  docker: Coming Soon #5.7.2-jammy
+  docker: 5.7.2-jammy


### PR DESCRIPTION
The docker images are now available on hub.docker.com, adding the links for them on download page. 