### PR TITLE
Community blog post submission process changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,7 @@ Swift.org contributions must adhere to the website's [governance process](https:
 
 ## Blog Posts
 
-Blog posts are covered by a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) which has a more extensive review process. You should [reach out to the SWWG](https://forums.swift.org/new-message?groupname=swift-website-workgroup) if you would like to contribute a post. This can encompass sharing language changes, libraries and tools and highlighting work done by the community.
-
-Please note that pull requests for blog posts that have not been discussed with the SWWG will be rejected, with the exception of minor updates to existing posts like typos.
+Blog posts are covered by a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance). Community-contributed blog posts are welcome through the [community blog post submission process](http://swift.org/blog-post-contributions/).
 
 ## Community Participation
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -101,6 +101,8 @@
           name: triaging-bugs
         - title: Swift Evolution
           name: evolution-process
+        - title: Blog Post Contributions
+          name: blog-post-contributions
         - title: Contributing Code
           name: contributing-code
         - title: Adding External Library Dependencies

--- a/blog-post-contributions/index.md
+++ b/blog-post-contributions/index.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Blog Post Contributions
+---
+
+The [Swift.org blog](https://www.swift.org/blog/) helps to keep the Swift community informed of recent developments in the language, the release roadmap, interesting new features, libraries, tools, and announcing project & community initiatives. It is central to Diversity in Swift’s mission to recognize and highlight work across the community. We welcome blog post contributions from everyone, regardless of background or experience.
+
+Are you doing interesting things using Swift? The community would love to hear how you’ve been using the language. See the process below for details on how to submit a blog post.
+
+## Community Contributed Content
+
+Blog posts don’t necessarily need to be technical, and your writing can appeal to anyone from beginners to language experts. Did you have an unusual journey towards Swift? Share that story. Did you use Swift code to interact with some hardware or in another context that people might not expect? That sounds great. Is there a previously covered topic you’d like to take further? Adding your experience and perspective is valuable.
+
+Readers have different backgrounds and experiences, but you can assume a basic knowledge of the Swift language.
+
+Is there anything to avoid in a Swift.org blog post? There’s a short list:
+
+* Directly commercial content promoting a product, service, or event.
+* Launch announcements for apps or libraries. While a blog post could talk about a new Swift language library or package, it should not be the post’s focus. The [Community Showcase](https://forums.swift.org/c/community-showcase/66) section of the Swift forums is ideal for community announcements.
+
+All Swift.org blog posts are published under a Creative Commons Attribution 4.0 International license. You may re-publish your work on your own website under this license with appropriate attribution.
+
+## Writing Guidelines
+
+Blog posts on Swift.org don’t need to be written in a particular style, but there are some guidelines below that will help make a great post:
+
+* Write inclusively and respectfully according to the Swift.org Code of Conduct.
+* There’s no set length for a blog post, but between 500 and 1,000 words is typical.
+* Screenshots, illustrations, code snippets, and links to documentation or other websites can be worth a thousand words.
+* You can write alone or in a small group. It’s up to you.
+
+## Submission Process
+
+Submit ideas or drafts of blog posts by [sending a message to the @swift-website-workgroup](https://forums.swift.org/new-message?groupname=swift-website-workgroup&title=Blog%20post%20proposal). Be sure to include some details about what you’d like to contribute in your post:
+
+* Either a first draft or a few paragraphs that summarise your post idea.
+* Whether your post or the topic it covers is time-sensitive and any information on why.
+* Your name and Swift forum username. If you are writing as a group, include everyone.
+
+The [Swift Website Workgroup]({% link website-workgroup/index.md %}) discusses blog post pitches bi-weekly and will reply to all submissions.
+
+Like all contributions to this website, the [Swift.org website governance]({% link website-governance/index.md %}) process covers all blog post submissions.

--- a/contributing/_website-and-blog-post-contributions.md
+++ b/contributing/_website-and-blog-post-contributions.md
@@ -1,0 +1,5 @@
+## Website and Blog Post Contributions
+
+The Swift project welcomes suggestions and enhancements to this website and community blog post contributions showcasing initiatives and stories across the community. The [Swift Website Workgroup]({% link website-workgroup/index.md %}) oversees all website and blog post contributions.
+
+Learn more about contributing to this website in the [Swift.org website governance]({% link website-governance/index.md %}) process and about how to [submit blog post contributions]({% link blog-post-contributions/index.md %}).

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -20,6 +20,7 @@ as described in [Source Code](/source-code).
 {% include_relative _answering-questions.md %}
 {% include_relative _reporting-bugs.md %}
 {% include_relative _triaging-bugs.md %}
+{% include_relative _website-and-blog-post-contributions.md %}
 {% include_relative _swift-evolution-process.md %}
 {% include_relative _contributing-code.md %}
 {% comment %}{% include_relative _contributing-documentation.md %}{% endcomment %}
@@ -28,4 +29,3 @@ as described in [Source Code](/source-code).
 * * *
 
 {% include_relative _llvm.md %}
-

--- a/website-governance/index.md
+++ b/website-governance/index.md
@@ -26,7 +26,7 @@ Larger changes to content, such as introducing broad new topics, require consult
 
 ### Blog posts governance
 
-The Swift.org blog is designed to keep the Swift community informed of recent development in the language, its ecosystem, and news about the community. It is a platform for sharing the language roadmap and release schedule, interesting new features, libraries, and tools, and announcing project & community initiatives.
+The Swift.org blog is designed to keep the Swift community informed of recent development in the language, its ecosystem, and news about the community. It is a platform for sharing the language roadmap, interesting new features, libraries, and tools, and announcing project & community initiatives.
 
 The blog is also an opportunity to recognize and highlight the work being done by members of our community, and we welcome post contributions through the [blog post contribution process]({% link blog-post-contributions/index.md %}).
 

--- a/website-governance/index.md
+++ b/website-governance/index.md
@@ -26,14 +26,9 @@ Larger changes to content, such as introducing broad new topics, require consult
 
 ### Blog posts governance
 
-The Swift.org blog is designed to keep the Swift community informed of recent development in the language, its ecosystem, and news about the community itself.
+The Swift.org blog is designed to keep the Swift community informed of recent development in the language, its ecosystem, and news about the community. It is a platform for sharing the language roadmap and release schedule, interesting new features, libraries, and tools, and announcing project & community initiatives.
 
-The blog is a platform for sharing the language roadmap and release schedule, interesting new features, libraries, and tools, and announcing project & community initiatives.
-
-The blog is also an opportunity to recognize and highlight the work being done by developers across our community.
-However, contributions to the Swift.org blog have a more extensive review process, and will not be accepted by direct pull request, with the exception of minor changes like typo fixes.
-
-Community-focused content on the blog is facilitated by the [website workgroup](/website-workgroup); reach out to [@swift-website-workgroup](https://forums.swift.org/new-message?groupname=swift-website-workgroup) if you’re interested in contributing to the Swift.org blog.
+The blog is also an opportunity to recognize and highlight the work being done by members of our community, and we welcome post contributions through the [blog post contribution process]({% link blog-post-contributions/index.md %}).
 
 ### Swift libraries documentation and "The Swift Programming Language"
 


### PR DESCRIPTION
### Motivation:

This change supports the [Swift Website Workgroup](https://www.swift.org/website-workgroup/)'s goal of encouraging more community contribution to the Swift.org website and blog.

### Modifications:

Here is a first draft of the potential changes to the community blog post contribution process.

All suggestions are welcome on anything in this PR. I’d also welcome an official eye on whether any of my changes to the governance process are suitable. I did consider adding the submission process directly in to the governance page, but it’s already quite long.

I think I managed to catch everywhere that the site talks about blog post contributions and redirect them into the new process, but please let me know if I missed any.

Thanks also to @alexandersandberg for his help with creating this process.
