### PR TITLE
Fix Jekyll warning in the “The Future of Foundation” blog post

### DIFF
--- a/_posts/2022-12-09-future-of-foundation.md
+++ b/_posts/2022-12-09-future-of-foundation.md
@@ -11,7 +11,7 @@ The Foundation framework is used in nearly all Swift projects. It provides both 
 Today, we have some exciting announcements for the future of Foundation.
 
 ## Going Open
-When Swift [began life as an open source project]({% post_url /blog/2015-12-03-welcome %}), we wanted to open not just the language itself, but the ecosystem around it. Foundation has been instrumental in the success of decades of software and has been an integral part of the Swift developer experience from the beginning, and we knew it had to be included in the open source offering.
+When Swift [began life as an open source project]({% post_url 2015-12-03-welcome %}), we wanted to open not just the language itself, but the ecosystem around it. Foundation has been instrumental in the success of decades of software and has been an integral part of the Swift developer experience from the beginning, and we knew it had to be included in the open source offering.
 
 The [swift-corelibs-foundation](https://github.com/apple/swift-corelibs-foundation) project helped launch the open source Swift version of Foundation in 2016, wrapping a Swift layer around the preexisting, open source C implementation of Foundation.
 


### PR DESCRIPTION
The use of `post_url` in the “The Future of Foundation” blog post was causing a Jekyll warning:

```
Generating... 
Deprecation: A call to '{% post_url /blog/2015-12-03-welcome %}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly.
```

This PR fixes the warning.