### PR TITLE
add cli and library getting started guides

### DIFF
--- a/_includes/getting-started/_installing.md
+++ b/_includes/getting-started/_installing.md
@@ -1,6 +1,8 @@
 ## Installing Swift
 
-If you don't have Swift installed, [install it first](/install). To test that you have Swift installed, run `swift --version` in the terminal.
+If you don't have Swift installed, [install it first](/install).
+
+To test that you have Swift installed, run `swift --version` in the terminal.
 
 ### Swift Package Manager
 

--- a/getting-started/_use-cases.html
+++ b/getting-started/_use-cases.html
@@ -3,32 +3,42 @@
 Below are some examples of the many use cases of Swift.
 
 <ul class="use-case-list">
+
+  <li class="use-case">
+    <h3>Build a Command-line Tool</h3>
+    <p class="description">
+      Build a command-line tool using Swift.
+    </p>
+
+    <a href="/getting-started/cli-tool" class="cta-secondary">Start tutorial</a>
+  </li>
+
+  <li class="use-case">
+    <h3>Build a Command-line Tool</h3>
+    <p class="description">
+      Build a library using Swift.
+    </p>
+
+    <a href="/getting-started/library" class="cta-secondary">Start tutorial</a>
+  </li>
+
   <li class="use-case">
     <h3>Build a Web Server (Vapor)</h3>
     <p class="description">
       Use the open-source Vapor framework to build a web API entirely with Swift.
       Requires macOS or Linux.
     </p>
-    
+
     <a href="/getting-started/vapor-web-server" class="cta-secondary">Start tutorial</a>
   </li>
-  
-  <li class="use-case">
-    <h3>Build a Command-line Tool</h3>
-    <p class="description">
-      Build a command-line tool using Swift and SwiftPM.
-    </p>
 
-    <a href="/getting-started/cli-tool" class="cta-secondary">Start tutorial</a>
-  </li>
-  
   <li class="use-case">
     <h3>Build an app for Apple platforms</h3>
     <p class="description">
       Use Swift and SwiftUI to build an app that works on iOS and macOS.
       Requires macOS 12 and Xcode 14.
     </p>
-    
+
     <a href="/" class="cta-secondary">Start tutorial</a>
   </li>
 </ul>

--- a/getting-started/_use-cases.html
+++ b/getting-started/_use-cases.html
@@ -7,25 +7,25 @@ Below are some examples of the many use cases of Swift.
   <li class="use-case">
     <h3>Command-line Tool</h3>
     <p class="description">
-      Build a command-line tool using Swift.
+      Build a command-line tool using SwiftPM.
     </p>
 
-    <a href="/getting-started/cli-tool" class="cta-secondary">Start tutorial</a>
+    <a href="/getting-started/cli-swiftpm" class="cta-secondary">Start tutorial</a>
   </li>
 
   <li class="use-case">
     <h3>Library</h3>
     <p class="description">
-      Build a library using Swift.
+      Build a library using SwiftPM.
     </p>
 
-    <a href="/getting-started/library" class="cta-secondary">Start tutorial</a>
+    <a href="/getting-started/library-swiftpm" class="cta-secondary">Start tutorial</a>
   </li>
 
   <li class="use-case">
     <h3>Web Server with Vapor</h3>
     <p class="description">
-      Use the open-source Vapor framework to build a web API entirely with Swift.
+      Use the open-source Vapor framework to build a web service using SwiftPM.
       Requires macOS or Linux.
     </p>
 

--- a/getting-started/_use-cases.html
+++ b/getting-started/_use-cases.html
@@ -5,7 +5,7 @@ Below are some examples of the many use cases of Swift.
 <ul class="use-case-list">
 
   <li class="use-case">
-    <h3>Build a Command-line Tool</h3>
+    <h3>Command-line Tool</h3>
     <p class="description">
       Build a command-line tool using Swift.
     </p>
@@ -14,7 +14,7 @@ Below are some examples of the many use cases of Swift.
   </li>
 
   <li class="use-case">
-    <h3>Build a Command-line Tool</h3>
+    <h3>Library</h3>
     <p class="description">
       Build a library using Swift.
     </p>
@@ -23,7 +23,7 @@ Below are some examples of the many use cases of Swift.
   </li>
 
   <li class="use-case">
-    <h3>Build a Web Server (Vapor)</h3>
+    <h3>Web Server with Vapor</h3>
     <p class="description">
       Use the open-source Vapor framework to build a web API entirely with Swift.
       Requires macOS or Linux.
@@ -33,7 +33,7 @@ Below are some examples of the many use cases of Swift.
   </li>
 
   <li class="use-case">
-    <h3>Build an app for Apple platforms</h3>
+    <h3>App for Apple platforms</h3>
     <p class="description">
       Use Swift and SwiftUI to build an app that works on iOS and macOS.
       Requires macOS 12 and Xcode 14.

--- a/getting-started/cli-swiftpm/index.md
+++ b/getting-started/cli-swiftpm/index.md
@@ -11,37 +11,58 @@ Let’s write a small application with our new Swift development environment.
 To start, we’ll use SwiftPM to make a new project for us. In your terminal of choice run:
 
 ~~~bash
-❯ mkdir hello-swift
-❯ cd hello-swift
-❯ swift package init --name hello-swift --type executable
+❯ mkdir MyCLI
+❯ cd MyCLI
+❯ swift package init --name MyCLI --type executable
 ~~~
 
-This will generate a new directory called hello-swift with the following files:
+This will generate a new directory called MyCLI with the following files:
 
 ~~~no-highlight
 .
 ├── Package.swift
 ├── README.md
 ├── Sources
-│   └── hello-swift
-│       └── hello_swift.swift
+│   └── MyCLI
+│       └── MyCLI.swift
 └── Tests
-    └── hello-swiftTests
-        └── hello_swiftTests.swift
+    └── MyCLITests
+        └── MyCLITests.swift
 ~~~
 
 `Package.swift` is the manifest file for Swift. It’s where you keep metadata for your project, as well as dependencies.
 
-`Sources/hello-swift/main.swift` is the application entry point and where we’ll write our application code.
-`Test/hello-swiftTests/hello_swiftTests.swift` is where we can write tests for our application.
+`Sources/MyCLI/MyCLI.swift` is the application entry point and where we’ll write our application code.
+`Test/MyCLITests/MyCLITests.swift` is where we can write tests for our application.
 
-In fact, SwiftPM generated a "Hello, world!" project for us!
-We can run this program by running  `swift run`  in our terminal.
+In fact, SwiftPM generated a "Hello, world!" project for us, including some unit tests!
+
+We can run the tests by running  `swift test`  in our terminal.
 
 ~~~bash
-❯ swift run
-[3/3] Linking hello-swift
-Hello, world!
+❯ swift test
+Building for debugging...
+[6/6] Linking MyCLIPackageTests
+Build complete! (16.53s)
+Test Suite 'All tests' started at 2023-01-12 13:38:22.393
+Test Suite 'MyCLIPackageTests.xctest' started at 2023-01-12 13:38:22.394
+Test Suite 'MyCLITests' started at 2023-01-12 13:38:22.394
+Test Case '-[MyCLITests.MyCLITests testExample]' started.
+Test Case '-[MyCLITests.MyCLITests testExample]' passed (0.003 seconds).
+Test Suite 'MyCLITests' passed at 2023-01-12 13:38:22.397.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
+Test Suite 'MyCLIPackageTests.xctest' passed at 2023-01-12 13:38:22.398.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
+Test Suite 'All tests' passed at 2023-01-12 13:38:22.398.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.005) seconds
+~~~
+
+We can also run the program by running  `swift run`  in our terminal.
+
+~~~bash
+❯ swift run MyCLI
+[3/3] Linking MyCLI
+Hello, World!
 ~~~
 
 ## Adding dependencies
@@ -60,20 +81,23 @@ To do so, we extend our `Package.swift` file with the following information:
 import PackageDescription
 
 let package = Package(
-name: "hello-swift",
+name: "MyCLI",
+  products: [
+    .executable(name: "MyCLI", targets: ["MyCLI"])
+  ],
   dependencies: [
     .package(url: "https://github.com/tomerd/swift-figlet", branch: "main"),
   ],
   targets: [
     .executableTarget(
-      name: "hello-swift",
+      name: "MyCLI",
       dependencies: [
         .product(name: "Figlet", package: "swift-figlet"),
       ]
     ),
     .testTarget(
-      name: "hello-swiftTests",
-      dependencies: ["hello-swift"]
+      name: "MyCLITests",
+      dependencies: ["MyCLI"]
     ),
   ]
 )
@@ -84,7 +108,7 @@ Running `swift build` will instruct SwiftPM to install the new dependencies and 
 Running this command also created a new file for us, `Package.resolved`.
 This file is a snapshot of the exact versions of the dependencies we are using locally.
 
-To use this dependency, we can open `hello_swift.swift`, remove everything that’s in there (it’s just an example), and add this line to it:
+To use this dependency, we can open `MyCLI.swift`, remove everything that’s in there (it’s just an example), and add this line to it:
 
 ~~~swift
 import Figlet
@@ -94,7 +118,7 @@ This line means that we can now use the `Figlet` module that the `swift-figlet` 
 
 ## A small application
 
-Now let’s write a small application with our new dependency. In our `hello_swift.swift`, add the following code:
+Now let’s write a small application with our new dependency. In our `MyCLI.swift`, add the following code:
 
 ~~~swift
 import Figlet // from the previous step
@@ -102,10 +126,19 @@ import Figlet // from the previous step
 @main
 struct FigletTool {
   static func main() {
-    let figlet = Figlet()
-    figlet.say("Hello, Swift!")
+    Figlet.say("Hello, Swift!")
   }
 }
+~~~
+
+Now lets remove the default unit test since we changes the tools' code.
+Replace the example content of `MyCLITests.swift` with the following code:
+
+~~~swift
+@testable import MyCLI
+import XCTest
+
+final class MyCLITests: XCTestCase {}
 ~~~
 
 Once we save that, we can run our application with `swift run`
@@ -134,22 +167,25 @@ To do so, we extend our `Package.swift` file with the following information:
 import PackageDescription
 
 let package = Package(
-  name: "hello-swift",
+  name: "swift-swift",
   dependencies: [
     .package(url: "https://github.com/tomerd/swift-figlet", branch: "main"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
   ],
+  products: [
+    .executable(name: "MyCLI", targets: ["MyCLI"])
+  ],  
   targets: [
     .executableTarget(
-      name: "hello-swift",
+      name: "MyCLI",
       dependencies: [
         .product(name: "Figlet", package: "swift-figlet"),
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
     .testTarget(
-      name: "hello-swiftTests",
-      dependencies: ["hello-swift"]
+      name: "MyCLITests",
+      dependencies: ["MyCLI"]
     ),
   ]
 )
@@ -167,15 +203,14 @@ struct FigletTool: ParsableCommand {
   public var input: String
 
   public func run() throws {
-    let figlet = Figlet()
-    figlet.say(self.input)
+    Figlet.say(self.input)
   }
 }
 ~~~
 
 For more information about how [swift-argument-parser](https://github.com/apple/swift-argument-parser) parses command line options, see [swift-argument-parser documentation](https://github.com/apple/swift-argument-parser) documentation.
 
-Once we save that, we can run our application with `swift run hello-swift --input 'Hello, world!'`
+Once we save that, we can run our application with `swift run MyCLI --input 'Hello, world!'`
 
 Note we need to specify the executable in this case, so we can pass the `input` argument to it.
 

--- a/getting-started/cli-swiftpm/index.md
+++ b/getting-started/cli-swiftpm/index.md
@@ -224,3 +224,7 @@ _   _          _   _                                           _       _   _
 |_| |_|  \___| |_| |_|  \___/  ( )     \_/\_/    \___/  |_|    |_|  \__,_| (_)
                               |/
 ~~~
+
+---
+
+Find the source code for this guide at [https://github.com/apple/swift-getting-started-cli](https://github.com/apple/swift-getting-started-cli)

--- a/getting-started/cli-tool/index.md
+++ b/getting-started/cli-tool/index.md
@@ -155,7 +155,7 @@ let package = Package(
 )
 ~~~
 
-We can now import the argument parsing module provided by `swift-argument-parser` and use it in our application
+We can now import the argument parsing module provided by `swift-argument-parser` and use it in our application:
 
 ~~~swift
 import ArgumentParser

--- a/getting-started/cli-tool/index.md
+++ b/getting-started/cli-tool/index.md
@@ -3,4 +3,109 @@ layout: page
 title: Build a Command-line Tool
 ---
 
-TODO
+{% include getting-started/_installing.md %}
+
+## Bootstrapping
+
+Let’s write a small application with our new Swift development environment.
+To start, we’ll use SwiftPM to make a new project for us. In your terminal of choice run:
+
+~~~bash
+❯ mkdir hello-swift
+❯ cd hello-swift
+❯ swift package init --name hello-swift --type executable
+~~~
+
+This will generate a new directory called hello-swift with the following files:
+
+~~~no-highlight
+.
+├── Package.swift
+├── README.md
+├── Sources
+│   └── hello-swift
+│       └── main.swift
+└── Tests
+    └── hello-swiftTests
+        └── hello_swiftTests.swift  
+~~~
+
+`Package.swift` is the manifest file for Swift. It’s where you keep metadata for your project, as well as dependencies.
+
+`Sources/hello-swift/main.swift` is the application entry point and where we’ll write our application code.
+`Test/hello-swiftTests/hello_swiftTests.swift` is where we can write tests for our application.
+
+In fact, SwiftPM generated a "Hello, world!" project for us!
+We can run this program by running  `swift run`  in our terminal.
+
+~~~bash
+❯ swift run
+[3/3] Linking hello-swift
+Hello, world!
+~~~
+
+## Adding dependencies
+
+Let’s add a dependency to our application.
+You can find interesting libraries on [Swift Package Index](https://swiftpackageindex.com), the unofficial package index for Swift.
+
+[TODO: actually make this library available publicly]
+
+In this project, we’ll use a package called [swift-figlet](https://github.com/tomerd/swift-figlet).
+To do so, we add the following information to our `Package.swift` file:
+
+~~~swift
+import PackageDescription
+
+let package = Package(
+    name: "hello-swift",
+    dependencies: [
+       .package(name: "figlet", url: "https://github.com/tomerd/swift-figlet.git", .branch("master")),
+    ],
+    targets: [
+        .target(
+            name: "hello-swift",
+            dependencies: ["figlet"]),
+        .testTarget(
+            name: "hello-swiftTests",
+            dependencies: ["hello-swift"]),
+    ]
+)
+~~~
+
+Running `swift build`  will instruct SwimPM to install the new dependency and then proceed to build the code.
+
+Running this command also created a new file for us, `Package.resolved`.
+This file is a snapshot of the exact versions of the dependencies we are using locally.
+
+To use this dependency, we can open `main.swift`, remove everything that’s in there (it’s just an example), and add this line to it:
+
+~~~swift
+import Figlet
+~~~
+
+This line means that we can now use the `Figlet` module that the `swift-figlet` package exports for us.
+
+
+## A small application
+
+Now let’s write a small application with our new dependency. In our  `main.swift`, add the following code:
+
+```swift
+import Figlet // from the previous step
+
+let figlet = Figlet()
+figlet.say("Hello, Swift!")
+```
+
+Once we save that, we can run our application with `swift run`
+Assuming everything went well, you should see your application print this to the screen:
+
+~~~no-highlight
+ _   _      _ _          ____          _  __ _   _
+| | | | ___| | | ___    / ___|_      _(_)/ _| |_| |
+| |_| |/ _ \ | |/ _ \   \___ \ \ /\ / / | |_| __| |
+|  _  |  __/ | | (_) |   ___) \ V  V /| |  _| |_|_|
+|_| |_|\___|_|_|\___( ) |____/ \_/\_/ |_|_|  \__(_)
+                   |/
+~~~

--- a/getting-started/cli-tool/index.md
+++ b/getting-started/cli-tool/index.md
@@ -122,7 +122,7 @@ _   _          _   _                                  _    __   _     _
 
 ## Argument parsing
 
-Most command line tools need to be able and parse command line arguments.
+Most command line tools need to be able to parse command line arguments.
 
 To add this capability to our application, we add a dependency on [swift-argument-parser](https://github.com/apple/swift-argument-parser).
 

--- a/getting-started/cli-tool/index.md
+++ b/getting-started/cli-tool/index.md
@@ -94,9 +94,9 @@ This line means that we can now use the `Figlet` module that the `swift-figlet` 
 
 ## A small application
 
-Now let’s write a small application with our new dependency. In our  `main.swift`, add the following code:
+Now let’s write a small application with our new dependency. In our `hello_swift.swift`, add the following code:
 
-```swift
+~~~swift
 import Figlet // from the previous step
 
 @main
@@ -106,7 +106,7 @@ struct FigletTool {
     figlet.say("Hello, Swift!")
   }
 }
-```
+~~~
 
 Once we save that, we can run our application with `swift run`
 Assuming everything went well, you should see your application print this to the screen:
@@ -157,7 +157,7 @@ let package = Package(
 
 We can now import the argument parsing module provided by `swift-argument-parser` and use it in our application
 
-```swift
+~~~swift
 import ArgumentParser
 import Figlet
 
@@ -171,7 +171,7 @@ struct FigletTool: ParsableCommand {
     figlet.say(self.input)
   }
 }
-```
+~~~
 
 For more information about how [swift-argument-parser](https://github.com/apple/swift-argument-parser) parses command line options, see [swift-argument-parser documentation](https://github.com/apple/swift-argument-parser) documentation.
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -3,6 +3,6 @@ layout: page
 title: Getting Started
 ---
 
-{% include_relative _installing.md %}
+{% include getting-started/_installing.md %}
 {% include_relative _use-cases.html %}
 {% include_relative _go-further.html %}

--- a/getting-started/library-swiftpm/index.md
+++ b/getting-started/library-swiftpm/index.md
@@ -11,9 +11,9 @@ Let’s write a small application with our new Swift development environment.
 To start, we’ll use SwiftPM to make a new project for us. In your terminal of choice run:
 
 ~~~bash
-❯ mkdir swift-library
-❯ cd swift-library
-❯ swift package init --name swift-library --type library
+❯ mkdir MyLibrary
+❯ cd MyLibrary
+❯ swift package init --name MyLibrary --type library
 ~~~
 
 This will generate a new directory called hello-swift with the following files:
@@ -23,17 +23,17 @@ This will generate a new directory called hello-swift with the following files:
 ├── Package.swift
 ├── README.md
 ├── Sources
-│   └── swift-library
-│       └── swift_library.swift
+│   └── MyLibrary
+│       └── MyLibrary.swift
 └── Tests
-    └── swift-libraryTests
-        └── swift_libraryTests.swift
+    └── MyLibraryTests
+        └── MyLibraryTests.swift
 ~~~
 
 `Package.swift` is the manifest file for Swift. It’s where you keep metadata for your project, as well as dependencies.
 
-`Sources/swift-library/swift-library.swift` is the library initial source file and where we’ll write our library code.
-`Test/swift-libraryTests/swift-libraryTests.swift` is where we can write tests for our library.
+`Sources/MyLibrary/MyLibrary.swift` is the library initial source file and where we’ll write our library code.
+`Test/MyLibraryTests/MyLibraryTests.swift` is where we can write tests for our library.
 
 In fact, SwiftPM generated a "Hello, world!" project for us, including some unit tests!
 We can run the tests by running  `swift test`  in our terminal.
@@ -41,24 +41,25 @@ We can run the tests by running  `swift test`  in our terminal.
 ~~~bash
 ❯ swift test
 Building for debugging...
-[3/3] Linking swift-libraryPackageTests
-Test Suite 'All tests' started at 2023-01-03 10:57:52.659
-Test Suite 'swift-libraryPackageTests.xctest' started at 2023-01-03 10:57:52.660
-Test Suite 'swift_libraryTests' started at 2023-01-03 10:57:52.660
-Test Case '-[swift_libraryTests.swift_libraryTests testExample]' started.
-Test Case '-[swift_libraryTests.swift_libraryTests testExample]' passed (0.003 seconds).
-Test Suite 'swift_libraryTests' passed at 2023-01-03 10:57:52.664.
-	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
-Test Suite 'swift-libraryPackageTests.xctest' passed at 2023-01-03 10:57:52.664.
-	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
-Test Suite 'All tests' passed at 2023-01-03 10:57:52.664.
-	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.005) seconds
+[4/4] Compiling MyLibraryTests MyLibraryTests.swift
+Build complete! (1.30s)
+Test Suite 'All tests' started at 2023-01-12 12:05:56.127
+Test Suite 'MyLibraryPackageTests.xctest' started at 2023-01-12 12:05:56.128
+Test Suite 'MyLibraryTests' started at 2023-01-12 12:05:56.128
+Test Case '-[MyLibraryTests.MyLibraryTests testExample]' started.
+Test Case '-[MyLibraryTests.MyLibraryTests testExample]' passed (0.005 seconds).
+Test Suite 'MyLibraryTests' passed at 2023-01-12 12:05:56.133.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
+Test Suite 'MyLibraryPackageTests.xctest' passed at 2023-01-12 12:05:56.133.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
+Test Suite 'All tests' passed at 2023-01-12 12:05:56.133.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.007) seconds
 ~~~
 
 ## A small library
 
 Now let’s write a small library.
-Replace the example content of `swift-library.swift` with the following code:
+Replace the example content of `MyLibrary.swift` with the following code:
 
 ~~~swift
 import Foundation
@@ -80,14 +81,14 @@ private struct InvalidEmailError: Error {
 }
 ~~~
 
-Now lets add a unit test for this strongly typed Email API.  
-Replace the example content of `swift_libraryTests.swift` with the following code:
+Now lets add a unit test for this strongly typed Email API.
+Replace the example content of `MyLibraryTests.swift` with the following code:
 
 ~~~swift
-@testable import swift_library
+@testable import MyLibrary
 import XCTest
 
-final class swift_libraryTests: XCTestCase {
+final class MyLibraryTests: XCTestCase {
   func testEmail() throws {
     let email = try Email("john.appleseed@apple.com")
     XCTAssertEqual(email.description, "john.appleseed@apple.com")

--- a/getting-started/library-swiftpm/index.md
+++ b/getting-started/library-swiftpm/index.md
@@ -118,3 +118,7 @@ Test Suite 'swift-libraryPackageTests.xctest' passed at 2023-01-03 16:22:45.076.
 Test Suite 'All tests' passed at 2023-01-03 16:22:45.076.
 	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.007) seconds
 ~~~
+
+---
+
+Find the source code for this guide at [https://github.com/apple/swift-getting-started-package-library](https://github.com/apple/swift-getting-started-package-library)

--- a/getting-started/library/index.md
+++ b/getting-started/library/index.md
@@ -80,7 +80,7 @@ private struct InvalidEmailError: Error {
 }
 ~~~
 
-Now lets add a unit test for this strongly types Email API.  
+Now lets add a unit test for this strongly typed Email API.  
 Replace the example content of `swift_libraryTests.swift` with the following code:
 
 ~~~swift

--- a/getting-started/library/index.md
+++ b/getting-started/library/index.md
@@ -40,6 +40,7 @@ We can run the tests by running  `swift test`  in our terminal.
 
 ~~~bash
 ❯ swift test
+Building for debugging...
 [3/3] Linking swift-libraryPackageTests
 Test Suite 'All tests' started at 2023-01-03 10:57:52.659
 Test Suite 'swift-libraryPackageTests.xctest' started at 2023-01-03 10:57:52.660
@@ -56,4 +57,62 @@ Test Suite 'All tests' passed at 2023-01-03 10:57:52.664.
 
 ## A small library
 
-Now let’s write a small library
+Now let’s write a small library.
+Replace the example content of `swift-library.swift` with the following code:
+
+~~~swift
+import Foundation
+
+struct Email {
+    public init(_ emailString: String) throws {
+        let regex = #"^\S+@\S+\.\S+$"#
+
+        guard let _ = emailString.range(of: regex, options: .regularExpression) else {
+            throw InvalidEmailError(email: emailString)
+        }
+    }
+}
+
+private struct InvalidEmailError: Error {
+    let email: String
+}
+
+~~~
+
+Now lets add a unit test for this strongly types Email API.  
+Replace the example content of `swift_libraryTests.swift` with the following code:
+
+~~~swift
+@testable import swift_library
+import XCTest
+
+final class swift_libraryTests: XCTestCase {
+    func testEmail() throws {
+        let email = try Email("john.appleseed@apple.com")
+        XCTAssertEqual(email.description, "john.appleseed@apple.com")
+
+        XCTAssertThrowsError(try Email("invalid"))
+    }
+}
+~~~
+
+Once we save that, we can run our application with `swift run`
+Assuming everything went well, we can run the tests successfully again:
+
+~~~no-highlight
+❯ swift test
+Building for debugging...
+[3/3] Linking swift-libraryPackageTests
+Build complete! (0.84s)
+Test Suite 'All tests' started at 2023-01-03 16:22:45.070
+Test Suite 'swift-libraryPackageTests.xctest' started at 2023-01-03 16:22:45.071
+Test Suite 'swift_libraryTests' started at 2023-01-03 16:22:45.071
+Test Case '-[swift_libraryTests.swift_libraryTests testEmail]' started.
+Test Case '-[swift_libraryTests.swift_libraryTests testEmail]' passed (0.005 seconds).
+Test Suite 'swift_libraryTests' passed at 2023-01-03 16:22:45.076.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
+Test Suite 'swift-libraryPackageTests.xctest' passed at 2023-01-03 16:22:45.076.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.005) seconds
+Test Suite 'All tests' passed at 2023-01-03 16:22:45.076.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.005 (0.007) seconds
+~~~

--- a/getting-started/library/index.md
+++ b/getting-started/library/index.md
@@ -53,3 +53,7 @@ Test Suite 'swift-libraryPackageTests.xctest' passed at 2023-01-03 10:57:52.664.
 Test Suite 'All tests' passed at 2023-01-03 10:57:52.664.
 	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.005) seconds
 ~~~
+
+## A small library
+
+Now let’s write a small library

--- a/getting-started/library/index.md
+++ b/getting-started/library/index.md
@@ -63,20 +63,21 @@ Replace the example content of `swift-library.swift` with the following code:
 ~~~swift
 import Foundation
 
-struct Email {
-    public init(_ emailString: String) throws {
-        let regex = #"^\S+@\S+\.\S+$"#
+struct Email: CustomStringConvertible {
+  var description: String
 
-        guard let _ = emailString.range(of: regex, options: .regularExpression) else {
-            throw InvalidEmailError(email: emailString)
-        }
+  public init(_ emailString: String) throws {
+    let regex = #"[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}"#
+    guard let _ = emailString.range(of: regex, options: .regularExpression) else {
+      throw InvalidEmailError(email: emailString)
     }
+    self.description = emailString
+  }
 }
 
 private struct InvalidEmailError: Error {
-    let email: String
+  let email: String
 }
-
 ~~~
 
 Now lets add a unit test for this strongly types Email API.  
@@ -87,12 +88,12 @@ Replace the example content of `swift_libraryTests.swift` with the following cod
 import XCTest
 
 final class swift_libraryTests: XCTestCase {
-    func testEmail() throws {
-        let email = try Email("john.appleseed@apple.com")
-        XCTAssertEqual(email.description, "john.appleseed@apple.com")
+  func testEmail() throws {
+    let email = try Email("john.appleseed@apple.com")
+    XCTAssertEqual(email.description, "john.appleseed@apple.com")
 
-        XCTAssertThrowsError(try Email("invalid"))
-    }
+    XCTAssertThrowsError(try Email("invalid"))
+  }
 }
 ~~~
 

--- a/getting-started/library/index.md
+++ b/getting-started/library/index.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: Build a library
+---
+
+{% include getting-started/_installing.md %}
+
+## Bootstrapping
+
+Let’s write a small application with our new Swift development environment.
+To start, we’ll use SwiftPM to make a new project for us. In your terminal of choice run:
+
+~~~bash
+❯ mkdir swift-library
+❯ cd swift-library
+❯ swift package init --name swift-library --type library
+~~~
+
+This will generate a new directory called hello-swift with the following files:
+
+~~~no-highlight
+.
+├── Package.swift
+├── README.md
+├── Sources
+│   └── swift-library
+│       └── swift_library.swift
+└── Tests
+    └── swift-libraryTests
+        └── swift_libraryTests.swift
+~~~
+
+`Package.swift` is the manifest file for Swift. It’s where you keep metadata for your project, as well as dependencies.
+
+`Sources/swift-library/swift-library.swift` is the library initial source file and where we’ll write our library code.
+`Test/swift-libraryTests/swift-libraryTests.swift` is where we can write tests for our library.
+
+In fact, SwiftPM generated a "Hello, world!" project for us, including some unit tests!
+We can run the tests by running  `swift test`  in our terminal.
+
+~~~bash
+❯ swift test
+[3/3] Linking swift-libraryPackageTests
+Test Suite 'All tests' started at 2023-01-03 10:57:52.659
+Test Suite 'swift-libraryPackageTests.xctest' started at 2023-01-03 10:57:52.660
+Test Suite 'swift_libraryTests' started at 2023-01-03 10:57:52.660
+Test Case '-[swift_libraryTests.swift_libraryTests testExample]' started.
+Test Case '-[swift_libraryTests.swift_libraryTests testExample]' passed (0.003 seconds).
+Test Suite 'swift_libraryTests' passed at 2023-01-03 10:57:52.664.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
+Test Suite 'swift-libraryPackageTests.xctest' passed at 2023-01-03 10:57:52.664.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
+Test Suite 'All tests' passed at 2023-01-03 10:57:52.664.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.005) seconds
+~~~


### PR DESCRIPTION
motivation: getting started guides

changes:
* add a cli guide
* add a library guide + link from index page
* share install instructions across pages
