### PR TITLE
swift-evolution: update search text input

### DIFF
--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -5,6 +5,16 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: space-between;
+        height: 3.5rem;
+    }
+
+    #search-filter {
+        font-size: .8rem;
+        padding: .2rem .5rem;
+        -webkit-appearance: textfield;
+        appearance: textfield;
+        border: .1rem solid var(--color-dropdown-border);
+        border-radius: .5rem;
     }
 
     @supports ((position: sticky) or (position: -webkit-sticky)) {


### PR DESCRIPTION
### Motivation:

Search field on the Swift Evolution page has default user agent style applied, which makes it too small and close to unreadable on Safari. In other browsers the field does not fit with the website style, as it has no border radius and also has inconsistent position.

### Modifications:

#### Safari:

*Before:*

<img width="243" alt="safari_before" src="https://user-images.githubusercontent.com/112310/211336993-153a358f-a9eb-4092-a8b4-d9b68eb113a6.png">

*After:*

<img width="241" alt="safari_after" src="https://user-images.githubusercontent.com/112310/211337158-1392cc2b-f79b-474d-b2e8-43c159a265d2.png">

#### Firefox

*Before:*

<img width="278" alt="firefox_before" src="https://user-images.githubusercontent.com/112310/211337284-46341f07-5b0a-47fb-bee0-03b058772c4d.png">

*After:*

<img width="288" alt="firefox_after" src="https://user-images.githubusercontent.com/112310/211337332-415497b4-ab6d-4056-8048-ae23da7aa68f.png">

#### Edge

*Before:*

<img width="283" alt="edge_before" src="https://user-images.githubusercontent.com/112310/211337382-5e811346-6053-4a1e-93f1-1dd8706ba90b.png">

*After:*

<img width="283" alt="edge_after" src="https://user-images.githubusercontent.com/112310/211337424-c05de600-0cc6-4ae8-bd71-4178fc0cf646.png">

### Result:

Search field on the Swift Evolution page is readable and fits the overall website design in all browsers.
