### PR TITLE
[SE Dashboard] Update the search-bar height style

### DIFF
--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -5,7 +5,7 @@
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: space-between;
-        height: 3.5rem;
+        min-height: 3.5rem;
     }
 
     #search-filter {


### PR DESCRIPTION
Follow-up to apple/swift-org-website#198.

### Motivation:

The search-bar was recently changed to use a fixed height, which is a rendering issue when the filter-options are expanded.

### Modifications:

Use `min-height` instead of `height`.

### Result:

* Before (with `height`):
  <img width="760" alt="Before" src="https://user-images.githubusercontent.com/889638/213009742-5aabf123-e3e2-4cc8-a7d1-b455011e5459.png">

* After (with `min-height`):
  <img width="760" alt="After" src="https://user-images.githubusercontent.com/889638/213009805-2434b396-f4c8-4707-9937-3851b2971d3b.png">