### PR TITLE
Getting started tweaks

### DIFF
--- a/_includes/getting-started/_installing.md
+++ b/_includes/getting-started/_installing.md
@@ -4,4 +4,4 @@ If you don't have Swift installed, [install it first](/install).
 
 To test that you have Swift installed, run `swift --version` from your shell or terminal app.
 
-Swift comes bundled with the Swift Package Manager (SwiftPM), which manages the distribution of your Swift code, and allows easy importing of other Swift packages into your apps.
+Swift comes bundled with the [Swift Package Manager (SwiftPM)]({% link package-manager/index.md %}), which manages the distribution of your Swift code, and allows easy importing of other Swift packages into your apps.

--- a/_includes/getting-started/_installing.md
+++ b/_includes/getting-started/_installing.md
@@ -2,13 +2,6 @@
 
 If you don't have Swift installed, [install it first](/install).
 
-To test that you have Swift installed, run `swift --version` in the terminal.
+To test that you have Swift installed, run `swift --version` from your shell or terminal app.
 
-### Swift Package Manager
-
-When you install Swift you’ll also get the latest stable version of the Swift build tool and package manager, also known as Swift Package Manager, or SwiftPM .
-
-SwiftPM does lots of things:
-- Build your project with `swift build`.
-- Test your project with `swift test`.
-- Run your project with `swift run`.
+Swift comes bundled with the Swift Package Manager (SwiftPM), which manages the distribution of your Swift code, and allows easy importing of other Swift packages into your apps.

--- a/getting-started/_use-cases.html
+++ b/getting-started/_use-cases.html
@@ -1,6 +1,6 @@
 ## Using Swift
 
-Below are some examples of the many use cases of Swift.
+If you want to get started with a lanbuage reference, [The Swift Programming Language](https://docs.swift.org/swift-book/) book is the best resource. However, if you'd prefer to get straight into writing some code, here are some examples of the many use cases of Swift.
 
 <ul class="use-case-list">
 

--- a/package-manager/index.md
+++ b/package-manager/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Package Manager
 ---
 
-The Swift Package Manager is a tool for managing the distribution of Swift code.
+The Swift Package Manager (SwiftPM) is a tool for managing the distribution of Swift code.
 It's integrated with the Swift build system
 to automate the process of downloading, compiling, and linking dependencies.
 


### PR DESCRIPTION
### Motivation:

Improving the Getting Started page from the perspective of someone completely new to Swift.

### Modifications:

* Removed the references to `swift build`, `swift test`, `swift run`. If someone had just installed Swift to the point where they can run `swift --version` as recommended on the lines above, these commands are going to fail while looking for `Package.swift`. The use case examples below introduce these commands in a more natural way.
* Tweaked how we introduce the SwiftPM abbreviation when we first introduce it (and also on the package manager page).
* Link to the package manager page when introducing SwiftPM.
* Added a link to TSPL. I know we want to get into some slightly less daunting tasks than "Read this whole book", but I feel it's important to have a link to it somewhere on this page. I tried to phrase it as optional.
