### PR TITLE
Update the Docker image links for Swift 5.7.3

### DIFF
--- a/_data/builds/swift-5_7_3-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_7_3-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.7.3-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-amazonlinux2
+  docker: 5.7.3-amazonlinux2

--- a/_data/builds/swift-5_7_3-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_7_3-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.7.3-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-amazonlinux2
+  docker: 5.7.3-amazonlinux2

--- a/_data/builds/swift-5_7_3-release/centos7.yml
+++ b/_data/builds/swift-5_7_3-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-centos7.tar.gz
   download_signature: swift-5.7.3-RELEASE-centos7.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-centos7
+  docker: 5.7.3-centos7

--- a/_data/builds/swift-5_7_3-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_7_3-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.7.3-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-bionic
+  docker: 5.7.3-bionic

--- a/_data/builds/swift-5_7_3-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_7_3-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.7.3-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-focal
+  docker: 5.7.3-focal

--- a/_data/builds/swift-5_7_3-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_7_3-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.7.3-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-focal
+  docker: 5.7.3-focal

--- a/_data/builds/swift-5_7_3-release/ubuntu2204-aarch64.yml
+++ b/_data/builds/swift-5_7_3-release/ubuntu2204-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-ubuntu22.04-aarch64.tar.gz
   download_signature: swift-5.7.3-RELEASE-ubuntu22.04-aarch64.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-jammy
+  docker: 5.7.3-jammy

--- a/_data/builds/swift-5_7_3-release/ubuntu2204.yml
+++ b/_data/builds/swift-5_7_3-release/ubuntu2204.yml
@@ -4,4 +4,4 @@
   download: swift-5.7.3-RELEASE-ubuntu22.04.tar.gz
   download_signature: swift-5.7.3-RELEASE-ubuntu22.04.tar.gz.sig
   dir: swift-5.7.3-RELEASE
-  docker: Coming Soon #5.7.3-jammy
+  docker: 5.7.3-jammy


### PR DESCRIPTION
Docker images are now available on hub.docker.com/_/swift