### PR TITLE
Fix navigation link in `navigation.yml`

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -99,10 +99,10 @@
           name: reporting-bugs
         - title: Triaging Bugs
           name: triaging-bugs
+        - title: Blog Post Contributions
+          name: website-and-blog-post-contributions
         - title: Swift Evolution
           name: evolution-process
-        - title: Blog Post Contributions
-          name: blog-post-contributions
         - title: Contributing Code
           name: contributing-code
         - title: Adding External Library Dependencies


### PR DESCRIPTION
The order of links https://www.swift.org/contributing page is currently wrong, as "Website and Blog Post Contributions" section on the page comes before "Swift Evolution". The link itself to `#blog-post-contributions` is not working, since the actual anchor id is `website-and-blog-post-contributions`.