### PR TITLE
Prepare GSoC23 projects page

### DIFF
--- a/gsoc2023/index.md
+++ b/gsoc2023/index.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Project Ideas for GSoC 2023
+---
+
+This page contains a non-exhaustive list of potential project ideas that we are keen to develop during [GSoC 2023](https://summerofcode.withgoogle.com/). If you would like to apply as a GSoC student, please follow these steps to get started:
+
+1. Read through this page and the Google Summer of Code guides,
+2. Identify, or come up with your own project ideas you find interesting.
+2. Check out the [Development forum](https://forums.swift.org/c/development) to connect with potential mentors.
+- Feel free to mention the project mentors on the forums, when starting a thread about your interest in participating in a specific project they are offering to mentor.
+
+When posting on the forums about GSoC this year, please use the [`gsoc-2022` tag](https://forums.swift.org/tag/gsoc-2023), so it is easy to identify.
+
+## Tips for contacting mentors
+
+The Swift forums are powered by discourse, a discussion forums platform which also has a number of spam avoidance mechanisms built-in. If this is your first time joining the forums, you _may_ not be able to send mentors a direct-message, as this requires a minimum amount of prior participation before the "send private message" feature is automatically enabled.
+
+If you would like to reach out to a mentor privately, rather than making a public forums post, and the forums are not allowing you to send private messages (yet), please reach out to Konrad Malawski at `ktoso AT apple.com` directly via email with the `[gsoc2022]` tag in the email subject and describe the project you would like to work on – and we'll route you to the appropriate mentor.
+
+## Potential Projects
+
+Coming soon...


### PR DESCRIPTION
Preparing for GSoC 2023 🎉 

The page is empty for now. We'll announce projects and how to add ideas very soon.

We should merge this even while empty, so we can use the link during the GSoC application.