### PR TITLE
Add Scoop installation methods for Windows

### DIFF
--- a/download/_windows.md
+++ b/download/_windows.md
@@ -22,11 +22,21 @@ Windows has the following additional platform specific dependencies:
 
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
+#### Install using Scoop
+
+~~~ pwsh
+# Optional: Needed to run a remote script the first time
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+# Command for installing scoop
+Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
+~~~
+
 0. Install required dependencies:
 
    The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-   ~~~ cmd
+   #### With Winget (Windows Package Manager):
+   ~~~ pwsh
    winget install Git.Git
    winget install Python.Python.3 --version 3.10.2150.0
 
@@ -38,7 +48,21 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    del /q vs_community.exe
    ~~~
 
-   Start up a new Command Prompt and install the Python library six.
+   #### With Scoop:
+   ~~~ pwsh
+   # Scoop already comes pre-installed with Git, so no need to re-install it.
+   scoop bucket add versions
+   scoop install python310
+
+   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
+   start /w vs_community.exe --passive --wait --norestart --nocache ^
+     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
+     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
+     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   del /q vs_community.exe
+   ~~~
+
+   Start up a new Command Prompt/Powershell Prompt and install the Python library six.
 
    ~~~ cmd
    pip install six
@@ -46,7 +70,7 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
 
 0. Install Swift:
 
-   Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
+   Swift can be installed through the official installer directly, using the Windows Package Manager, or using Scoop as well. Notice that Windows Package Manager release may be behind the official release, Scoop won't have this issue.
 
    * Using the official installer:
      1. Download the [latest package release](/download).
@@ -55,6 +79,10 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    * Using the Windows Package Manager:
      ~~~ cmd
      winget install Swift.Toolchain
+     ~~~
+   * Using Scoop:
+     ~~~ cmd
+     scoop install swift
      ~~~
 
 A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -129,7 +129,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
      ~~~ cmd
      winget install Swift.Toolchain
      ~~~
-   * Using the Windows Package Manager:
+   * Using Scoop:
      ~~~ cmd
      scoop install swift
      ~~~

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -82,7 +82,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
 
 0. Install required dependencies:
 
-   The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
+   The platform dependencies cannot be installed through the currently supported package managers as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
    #### With Winget (Windows Package Manager):
    ~~~ pwsh

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -71,11 +71,21 @@ In order to develop applications, particularly with the Swift Package Manager, y
 
 The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
+#### Install using Scoop
+
+~~~ pwsh
+# Optional: Needed to run a remote script the first time
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+# Command for installing scoop
+Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
+~~~
+
 0. Install required dependencies:
 
    The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
-   ~~~ cmd
+   #### With Winget (Windows Package Manager):
+   ~~~ pwsh
    winget install Git.Git
    winget install Python.Python.3 --version 3.10.2150.0
 
@@ -87,23 +97,41 @@ The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager
    del /q vs_community.exe
    ~~~
 
-   Start up a new Command Prompt and install the Python library six.
+   #### With Scoop:
+   ~~~ pwsh
+   # Scoop already comes pre-installed with Git, so no need to re-install it.
+   scoop bucket add versions
+   scoop install python310
+
+   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
+   start /w vs_community.exe --passive --wait --norestart --nocache ^
+     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
+     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
+     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   del /q vs_community.exe
+   ~~~
+
+   Start up a new Command Prompt/Powershell Prompt and install the Python library six.
 
    ~~~ cmd
    pip install six
    ~~~
 
-0. Install Swift:
+1. Install Swift:
 
    Swift can be installed through the official installer directly, or using the Windows Package Manager as well.  Notice that Windows Package Manager release may be behind the official release.
 
    * Using the official installer:
      1. Download the [latest package release](/download).
-     1. Run the package installer.
+     2. Run the package installer.
 
    * Using the Windows Package Manager:
      ~~~ cmd
      winget install Swift.Toolchain
+     ~~~
+   * Using the Windows Package Manager:
+     ~~~ cmd
+     scoop install swift
      ~~~
 
 A Swift toolchain will be installed at `%SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain`.  A compatible Swift SDK will be installed at `%SystemDrive%\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk`.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->
I wanted to add scoop installation methods for swift, since I am the one who added it to [scoop](https://scoop.sh/).

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->
I added scoop installation methods to these files, **getting-started/_installing.md** and the **download/_windows.md**

### Result:

<!-- _[After your change, what will change.]_ -->
**getting-started/_installing.md** and **download/_windows.md** will now have sections that detail how to install the dependencies and the Swift programming language using scoop.