### PR TITLE
Generate Projects list on Swift on Server page with data file

### DIFF
--- a/_data/sswg/projects.yml
+++ b/_data/sswg/projects.yml
@@ -1,77 +1,160 @@
 - name: SwiftNIO
+  description: Event-driven network application framework.
   maturity: Graduated
-  pitched: 2018-09-07
+  pitched: N/A
   accepted: 2018-09-07
   url: http://github.com/apple/swift-nio/
 
-- name: Logging API
+- name: SwiftLog
+  description: Logging API
   maturity: Graduated
   pitched: 2018-09-10
   accepted: 2019-02-07
   url: http://github.com/apple/swift-log/
 
-- name: Metrics API
-  maturity: Sandbox
+- name: SwiftMetrics
+  description: Metrics API
+  maturity: Graduated
   pitched: 2019-01-08
   accepted: 2019-04-04
   url: http://github.com/apple/swift-metrics/
     
-- name: Postgres Client
-  maturity: Sandbox
+- name: PostgresNIO
+  description: PostgreSQL driver
+  maturity: Incubating
   pitched: 2018-11-18
   accepted: 2019-05-16
   url: https://github.com/vapor/nio-postgres
 
-- name: Redis Client
+- name: RediStack
+  description: Redis driver
   maturity: Sandbox
   pitched: 2019-01-07
   accepted: 2019-06-27
   url: https://github.com/mordil/swift-redis-nio-client
     
-- name: HTTP Client
-  maturity: Sandbox
+- name: AsyncHTTPClient
+  description: HTTP Client
+  maturity: Graduated
   pitched: 2019-04-18
   accepted: 2019-06-27
   url: https://github.com/swift-server/async-http-client
 
-- name: APNS Client
-  maturity: Sandbox
+- name: APNSwift
+  description: APNS Client
+  maturity: Incubating
   pitched: 2019-02-05
   accepted: 2019-06-27
-  url: https://github.com/kylebrowning/swift-nio-apns
+  url: https://github.com/swift-server-community/APNSwift
 
-- name: Statsd Client
-  maturity: Sandbox
+- name: SwiftStatsdClient
+  description: StatsD driver for the metrics API
+  maturity: Incubating
   pitched: 2019-06-02
   accepted: 2019-08-11
   url: https://github.com/apple/swift-statsd-client
 
-- name: Prometheus Client
+- name: SwiftPrometheus
+  description: Prometheus driver for the metrics API
   maturity: Sandbox
   pitched: 2018-11-18
   accepted: 2019-08-11
   url: https://github.com/MrLotU/SwiftPrometheus
     
-- name: gRPC
-  maturity: Sandbox
+- name: gRPC Swift
+  description: gRPC client & server framework
+  maturity: Graduated
   pitched: 2019-09-30
   accepted: 2020-02-19
   url: https://github.com/grpc/grpc-swift
 
-- name: Crypto
-  maturity: Sandbox
+- name: Swift Crypto
+  description: Open-source implementation of a substantial portion of the API of Apple CryptoKit
+  maturity: Incubating
   pitched: 2020-02-20
   accepted: 2020-03-04
   url: https://github.com/apple/swift-crypto
   
+- name: OpenAPIKit
+  description: OpenAPI client
+  maturity: Sandbox
+  pitched: 2020-01-14
+  accepted: 2020-04-29
+  url: https://github.com/mattpolzin/OpenAPIKit
+  
+- name: MongoSwift
+  description: MongoDB driver
+  maturity: Incubating
+  pitched: 2019-10-30
+  accepted: 2020-05-13
+  url: https://github.com/mongodb/mongo-swift-driver
+  
+- name: Swift AWS Lambda Runtime
+  description: Runtime library for AWS Lambda functions in Swift
+  maturity: Sandbox
+  pitched: N/A
+  accepted: 2020-06-24
+  url: https://github.com/swift-server/swift-aws-lambda-runtime
+  
+- name: Backtrace
+  description: Nice backtraces in production
+  maturity: Incubating
+  pitched: 2019-05-30
+  accepted: 2020-07-29
+  url: https://github.com/swift-server/swift-backtrace
+  
+- name: Service Lifecycle
+  description: Lifecycle management
+  maturity: Incubating
+  pitched: N/A
+  accepted: 2020-09-02
+  url: https://github.com/swift-server/swift-service-lifecycle
+  
+- name: Soto for AWS
+  description: Third-party SDK for AWS
+  maturity: Incubating
+  pitched: 2020-10-01
+  accepted: 2020-11-12
+  url: https://github.com/soto-project/soto
+  
+- name: MultipartKit
+  description: Multipart parser and serializer with Codable support for Multipart Form Data
+  maturity: Incubating
+  pitched: 2021-03-03
+  accepted: 2021-11-11
+  url: https://github.com/vapor/multipart-kit
+  
+- name: MQTT NIO
+  description: A Swift NIO MQTT v3.1.1 and v5.0 Client
+  maturity: Sandbox
+  pitched: 2021-11-02
+  accepted: 2022-01-19
+  url: https://github.com/swift-server-community/mqtt-nio
+  
 - name: GraphQL
+  description: GraphQL query language implementation
   maturity: Incubating
   pitched: 2022-08-22
   accepted: 2022-09-15
   url: https://github.com/GraphQLSwift/GraphQL
 
 - name: Graphiti
+  description: Library for building GraphQL schemas
   maturity: Incubating
   pitched: 2022-08-22
   accepted: 2022-09-15
   url: https://github.com/GraphQLSwift/Graphiti
+
+- name: Swift Distributed Actors
+  description: Peer-to-peer cluster implementation for Swift Distributed Actors
+  maturity: Sandbox
+  pitched: 2022-10-27
+  accepted: 2023-01-03
+  url: https://github.com/apple/swift-distributed-actors
+
+- name: CassandraClient
+  description: Client library for the Cassandra distributed database
+  maturity: Incubating
+  pitched: 2023-01-19
+  accepted: 2023-02-02
+  url: https://github.com/apple/swift-cassandra-client

--- a/sswg/index.md
+++ b/sswg/index.md
@@ -57,26 +57,26 @@ The Swift Server Workgroup has a [process](https://github.com/swift-server/sswg/
 ## Projects
 
 <table>
-	<thead>
-		<tr>
-			<th>Project</th>
-			<th>Description</th>
-			<th>Maturity Level</th>
-			<th>Pitched</th>
-			<th>Accepted</th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for project in site.data.sswg.projects %}
-		<tr>
-			<td><a href="{{ project.url }}">{{ project.name }}</a></td>
-			<td>{{ project.description }}</td>
-			<td>{{ project.maturity }}</td>
-			<td>{{ project.pitched }}</td>
-			<td>{{ project.accepted }}</td>
-		</tr>
-		{% endfor %}
-	</tbody>
+  <thead>
+    <tr>
+      <th>Project</th>
+      <th>Description</th>
+      <th>Maturity Level</th>
+      <th>Pitched</th>
+      <th>Accepted</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for project in site.data.sswg.projects %}
+    <tr>
+      <td><a href="{{ project.url }}">{{ project.name }}</a></td>
+      <td>{{ project.description }}</td>
+      <td>{{ project.maturity }}</td>
+      <td>{{ project.pitched }}</td>
+      <td>{{ project.accepted }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
 </table>
 
 The SSWG publishes a [package collection](/blog/package-collections/) that contains the projects incubated by the workgroup. The collection is available at `https://swiftserver.group/collection/sswg.json`.

--- a/sswg/index.md
+++ b/sswg/index.md
@@ -56,31 +56,28 @@ The Swift Server Workgroup has a [process](https://github.com/swift-server/sswg/
 
 ## Projects
 
-| Project | Description | Maturity Level | Pitched | Accepted |
-|---|---|---|---|---|
-| [SwiftNIO](http://github.com/apple/swift-nio/) | Event-driven network application framework. | Graduated  | N/A  | 9/7/2018 |
-| [SwiftLog](http://github.com/apple/swift-log/) | Logging API | Graduated | 9/10/2018 | 2/7/2019 |
-| [SwiftMetrics](http://github.com/apple/swift-metrics/) | Metrics API | Graduated | 1/8/2019 | 4/4/2019 |
-| [PostgresNIO](https://github.com/vapor/nio-postgres) | PostgreSQL driver | Incubating | 11/18/2018 | 5/16/2019 |
-| [RediStack](https://github.com/mordil/swift-redis-nio-client) | Redis driver | Sandbox | 1/7/2019 | 6/27/2019 |
-| [AsyncHTTPClient](https://github.com/swift-server/async-http-client) | HTTP client | Graduated | 4/18/2019 | 6/27/2019 |
-| [APNSwift](https://github.com/swift-server-community/APNSwift) | APNS client | Incubating | 2/5/2019 | 6/27/2019 |
-| [SwiftStatsdClient](https://github.com/apple/swift-statsd-client) | StatsD driver for the metrics API | Incubating | 6/2/2019 | 8/11/2019 |
-| [SwiftPrometheus](https://github.com/MrLotU/SwiftPrometheus) | Prometheus driver for the metrics API | Sandbox | 11/18/2018 | 8/11/2019  |
-| [gRPC Swift](https://github.com/grpc/grpc-swift) | gRPC client & server framework | Graduated | 9/30/2019 | 2/19/2020 |
-| [Swift Crypto](https://github.com/apple/swift-crypto) | Open-source implementation of a substantial portion of the API of Apple CryptoKit | Incubating | 2/20/2020 | 3/4/2020 |
-| [OpenAPIKit](https://github.com/mattpolzin/OpenAPIKit) | OpenAPI client | Sandbox | 1/14/2020 | 4/29/2020 |
-| [MongoSwift](https://github.com/mongodb/mongo-swift-driver) | MongoDB driver | Incubating | 10/30/2019 | 5/13/2020 |
-| [Swift AWS Lambda Runtime](https://github.com/swift-server/swift-aws-lambda-runtime) | Runtime library for AWS Lambda functions in Swift | Sandbox | N/A | 6/24/2020 |
-| [Backtrace](https://github.com/swift-server/swift-backtrace) | Nice backtraces in production | Incubating | 5/30/19 | 7/29/2020 |
-| [Service Lifecycle](https://github.com/swift-server/swift-service-lifecycle) | Lifecycle management | Incubating | N/A | 9/2/2020 |
-| [Soto for AWS](https://github.com/soto-project/soto) | Third-party SDK for AWS | Incubating | 10/1/2020 | 11/12/2020 |
-| [MultipartKit](https://github.com/vapor/multipart-kit) | Multipart parser and serializer with Codable support for Multipart Form Data | Incubating | 3/3/2021 | 11/11/2021 |
-| [MQTT NIO](https://github.com/swift-server-community/mqtt-nio) | A Swift NIO MQTT v3.1.1 and v5.0 Client | Sandbox | 11/2/2021 | 1/19/2022 |
-| [GraphQL](https://github.com/GraphQLSwift/GraphQL) | GraphQL query language implementation | Incubating | 8/22/2022 | 9/15/2022 |
-| [Graphiti](https://github.com/GraphQLSwift/Graphiti) | Library for building GraphQL schemas | Incubating | 8/22/2022 | 9/15/2022 |
-| [Swift Distributed Actors](https://github.com/apple/swift-distributed-actors) | Peer-to-peer cluster implementation for Swift Distributed Actors | Sandbox | 10/27/2022 | 1/3/2023 |
-| [CassandraClient](https://github.com/apple/swift-cassandra-client) | Client library for the Cassandra distributed database | Incubating | 19/1/2023 | 2/2/2023 |
+<table>
+	<thead>
+		<tr>
+			<th>Project</th>
+			<th>Description</th>
+			<th>Maturity Level</th>
+			<th>Pitched</th>
+			<th>Accepted</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for project in site.data.sswg.projects %}
+		<tr>
+			<td><a href="{{ project.url }}">{{ project.name }}</a></td>
+			<td>{{ project.description }}</td>
+			<td>{{ project.maturity }}</td>
+			<td>{{ project.pitched }}</td>
+			<td>{{ project.accepted }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+</table>
 
 The SSWG publishes a [package collection](/blog/package-collections/) that contains the projects incubated by the workgroup. The collection is available at `https://swiftserver.group/collection/sswg.json`.
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

I [noticed recently](https://github.com/apple/swift-org-website/pull/231#issuecomment-1413283423) that the projects table on the Swift on Server page was using a static table instead of the existing (but outdated) projects data file.

Using a data file will make the process of maintaining this list easier.

### Modifications:

- Updated the `_data/swwg/projects.yml` file to match the static table on the Swift on Server page
- Replaced the static table with one generated from the data file

Note: The date format is now changed from MM/DD/YYYY to YYYY-MM-DD (05/16/2019 → 2019-05-16). As we've had some issues with the former before (mixing up days and months), I think this more internationally recognized date format is better.

### Result:

The same table as before but now generated from the data file. When SSWG now wants to update this list they should change the `_data/sswg/projects.yml` file instead.

As I was manually updating the data file based on the data in the static table, feel free to help me double-check that all the new data is correct. 🙂

cc: @ktoso @0xTim @tomerd 

<img width="786" alt="CleanShot 2023-02-03 at 09 47 10" src="https://user-images.githubusercontent.com/35671299/216553913-a6a56cf7-8493-49a1-9d03-04e7b5cd28b7.png">
