### PR TITLE
Fixed typographical error on /gsoc/2023.md

### DIFF
--- a/gsoc2023/index.md
+++ b/gsoc2023/index.md
@@ -10,13 +10,13 @@ This page contains a non-exhaustive list of potential project ideas that we are 
 2. Check out the [Development forum](https://forums.swift.org/c/development) to connect with potential mentors.
 - Feel free to mention the project mentors on the forums, when starting a thread about your interest in participating in a specific project they are offering to mentor.
 
-When posting on the forums about GSoC this year, please use the [`gsoc-2022` tag](https://forums.swift.org/tag/gsoc-2023), so it is easy to identify.
+When posting on the forums about GSoC this year, please use the [`gsoc-2023` tag](https://forums.swift.org/tag/gsoc-2023), so it is easy to identify.
 
 ## Tips for contacting mentors
 
 The Swift forums are powered by discourse, a discussion forums platform which also has a number of spam avoidance mechanisms built-in. If this is your first time joining the forums, you _may_ not be able to send mentors a direct-message, as this requires a minimum amount of prior participation before the "send private message" feature is automatically enabled.
 
-If you would like to reach out to a mentor privately, rather than making a public forums post, and the forums are not allowing you to send private messages (yet), please reach out to Konrad Malawski at `ktoso AT apple.com` directly via email with the `[gsoc2022]` tag in the email subject and describe the project you would like to work on – and we'll route you to the appropriate mentor.
+If you would like to reach out to a mentor privately, rather than making a public forums post, and the forums are not allowing you to send private messages (yet), please reach out to Konrad Malawski at `ktoso AT apple.com` directly via email with the `[gsoc2023]` tag in the email subject and describe the project you would like to work on – and we'll route you to the appropriate mentor.
 
 ## Potential Projects
 


### PR DESCRIPTION
Fixed a small typo in the index.md file where the year 2022 was mistakenly written instead of 2023 while mentioning the tag for the gsoc program. The corrected year has been updated in the file.


### Motivation:

This change will ensure that the index.md file accurately reflects the correct date, improving the overall accuracy and readability for the potential contributors on the site.

### Modifications:

Changed two occurrences of `gsoc2022` tag with `gsoc2023` tag in the [gsoc/index.md](https://github.com/apple/swift-org-website/blob/main/gsoc2023/index.md) file

### Result:

Correct information about the program will be displayed.