### PR TITLE
Update links to TSPL, to avoid multiple redirects

### DIFF
--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -9,7 +9,7 @@ If you're new to Swift, check out [A Swift Tour][TSPL] in
 _The Swift Programming Language_, for a quick introduction to the
 most important concepts and features of the language.
 
-[TSPL]: https://developer.apple.com/library/prerelease/content/documentation/Swift/Conceptual/Swift_Programming_Language/GuidedTour.html#//apple_ref/doc/uid/TP40014097-CH2-ID1
+[TSPL]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/
 
 {% include_relative _installing.md %}
 {% include_relative _repl.md %}

--- a/package-manager/index.md
+++ b/package-manager/index.md
@@ -28,4 +28,4 @@ You can find instructions for how to install Swift in
 
 {% include_relative _basic-usage.md %}
 
-[TSPL]: https://developer.apple.com/library/prerelease/content/documentation/Swift/Conceptual/Swift_Programming_Language/GuidedTour.html#//apple_ref/doc/uid/TP40014097-CH2-ID1
+[TSPL]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/


### PR DESCRIPTION
### Motivation:

Before this change, the link went through multiple redirects:

* https://developer.apple.com/library/prerelease/content/documentation/Swift/Conceptual/Swift_Programming_Language/GuidedTour.html#//apple_ref/doc/uid/TP40014097-CH2-ID1
* https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/GuidedTour.html
* https://docs.swift.org/swift-book/GuidedTour/GuidedTour.html
* https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/

### Modifications:

The redirects are themselves undesirable, and some users are getting 404 errors from the last redirect getting confused.  (I'll look into that issue next, separately.)

Note that the link from the SwiftPM page goes to the top level, because the prose around it is referring to the book in general, and not to the tour chapter.

### Result:

Links go directly to the current location of their destinations.