### PR TITLE
Add Swift 5.9 language version to Swift Evolution page

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -34,6 +34,7 @@ var languageVersions = [
   '5.6',
   '5.7',
   '5.8',
+  '5.9',
   'Next'
 ]
 


### PR DESCRIPTION
Now that some evolution proposals are listed as implemented in Swift 5.9 add languageVersion to enable filter button for 5.9.

This adds a new 5.9 entry to the languageVersion array in the Swift evolution page JavaScript.