### PR TITLE
[GSoC23] Add project idea for Swift-DocC localization support

### DIFF
--- a/gsoc2023/index.md
+++ b/gsoc2023/index.md
@@ -143,3 +143,31 @@ The goal is to support the fundamental commands and expose as an asynchronous-fi
 **Potential mentors**
 
 - [Franz Bunsh](https://github.com/FranzBusch)
+
+
+### Swift-DocC 
+
+#### Swift-DocC Authoring Localization Support
+
+**Project Size**: Medium 
+
+**Recommended skills**
+
+- Basic proficiency with Swift
+
+**Expected difficulty**: Medium
+
+**Description**
+
+Swift-DocC-Render recently added support for rendering localized documentation. However, Swift-DocC currently only supports authoring documentation in a single language.
+
+The goal of this project is to design and implement support for writing localized documentation by enhancing the Swift-DocC compiler to support localized DocC catalog inputs and produce an output that's compatible with Swift-DocC-Render's existing localization support. The participant will take part in collaborative technical design and Swift-DocC development.
+
+**Expected outcomes/benefits/deliverables**
+
+Technical design and implementation for authoring localized documentation.
+
+**Potential mentors**
+
+- [Bina Maniar](https://github.com/binamaniar)
+- [Marina Aísa](https://github.com/marinaaisa) 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

-->
This adds a GSoC 2023 project idea for Swift-DocC localization support

### Motivation:

The Swift-DocC team would like to propose a project idea for GSoC 2023 

### Modifications:

Updates the GSoC 2023 "Potential Projects" list to include a Swift-DocC project idea.

### Result:

The Swift-DocC localization support project idea will be listed among the GSoC 2023 "Potential Projects".
