### PR TITLE
Fix project heading levels in GSoC 23 page

### DIFF
--- a/gsoc2023/index.md
+++ b/gsoc2023/index.md
@@ -76,7 +76,7 @@ Design and implementation of new C++ standard library overlay functionality that
 
 ### Swift Package Manager
 
-### Scripting in Swift
+#### Scripting in Swift
 
 **Project size**: Medium
 
@@ -123,7 +123,7 @@ SwiftPM currently supports a handful of hardcoded templates that can act as a st
 
 ### Swift on Server
 
-### Memcached Client
+#### Memcached Client
 
 **Project size**: Medium
 


### PR DESCRIPTION
Fix project heading levels.

### Motivation:

Heading levels in a couple of projects were `h3` instead of `h4`.

### Modifications:

Use `h4` for "Scripting in Swift" and "Memcached Client".