### PR TITLE
Cleanup blog author layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,9 @@ layout: base
     {% if author.name %}
       <div class="byline">
         {% if author.gravatar %}
-          <img src="https://s.gravatar.com/avatar/{{ author.gravatar }}?s=64" alt="{{ author.name }}"/>
+          <img src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=64&d=mp" alt="{{ author.name }}"/>
+        {% else %}
+          <img src="https://www.gravatar.com/avatar/dummy?s=64&d=mp&f=y" alt="{{ author.name }}"/>
         {% endif %}
 
         <span class="author">

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -383,7 +383,6 @@ article {
         }
 
         .byline {
-            float: left;
             font-size: 14px;
             margin-bottom: 1em;
 

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -376,7 +376,7 @@ article {
     header {
         width: 100%;
         display: inline-block;
-        padding-bottom: 2.5em;
+        padding-bottom: 1.5em;
 
         h1 {
             padding-bottom: 0.125em;
@@ -414,13 +414,13 @@ article {
         }
 
         time {
-            float: left;
+            display: block;
             text-transform: uppercase;
             font-size: 14px;
             font-weight: 400;
             color: var(--color-figure-gray-tertiary);
             margin-right: 3em;
-            margin-bottom: 1em;
+            margin-bottom: 2em;
         }
 
         .tags {


### PR DESCRIPTION
This PR contains three small commits that address a few issues in how authors are presented in blog posts. Each change has been tested in a desktop browser and a mobile-sized browser.

## 1. Layout first author below date
Currently the first author's name is listed next to the date of the blog post. This looks very awkward and unaligned when there are multiple authors:

_Example 1:_
<img width="790" alt="Screenshot 2023-03-25 at 8 11 35 AM" src="https://user-images.githubusercontent.com/470139/227728389-d701524d-a2f0-412d-8f53-b19544151701.png" style="border: 1px solid gray;">

---

_Example 2:_
<img width="835" alt="Screenshot 2023-03-25 at 8 13 00 AM" src="https://user-images.githubusercontent.com/470139/227728418-afe1f0cb-3ac1-4289-8441-07178d9fad0d.png">

---

### Proposed fix
This change puts the first author below the date in all cases, which is consistent between all blog posts and makes multi-author posts look much better:

_Updated Example 1:_
<img width="819" alt="Screenshot 2023-03-25 at 8 11 44 AM" src="https://user-images.githubusercontent.com/470139/227728523-d6b66f19-5ba8-4c66-a037-3bf0fb9f7a1b.png">

---

_Updated Example 2:_
<img width="816" alt="Screenshot 2023-03-25 at 8 13 06 AM" src="https://user-images.githubusercontent.com/470139/227728535-cb8297a9-e107-45cd-959c-06165e4b9842.png">

---

### Updated margin and padding to maintain spacing
Note that in the commit, bottom padding and margin values were adjusted to maintain spacing between the heading and the body of the post. These CSS values also affect the main blog listing. In both cases, the spacing between the heading and the post/summary body are reduced by a few pixels.

_Main Blog Listing Current:_
<img width="948" alt="Screenshot 2023-03-25 at 9 09 27 AM" src="https://user-images.githubusercontent.com/470139/227728871-bf90f949-fa4f-40cd-90e6-0016b439f55a.png">

---

_Main Blog Listing With Change:_
<img width="895" alt="Screenshot 2023-03-25 at 9 09 37 AM" src="https://user-images.githubusercontent.com/470139/227728882-b70e597e-7839-4f18-b504-f649b20e33be.png">

---

## 2. Fix possible author name overlap

In a post with multiple authors, if the first author doesn't have any 'about' info, the second author's name is presented next to the first author. This removes a left float so the second author's name appears below.

_Before:_
<img width="785" alt="Screenshot 2023-03-25 at 8 04 50 AM" src="https://user-images.githubusercontent.com/470139/227729036-4d4fa19e-8c0f-4836-9689-39f53eef945d.png">

---

_After:_
<img width="740" alt="Screenshot 2023-03-25 at 8 13 58 AM" src="https://user-images.githubusercontent.com/470139/227729056-b7a3e321-5725-4ab2-b979-d9f3d4fea509.png">

---

## 3. Use default Gravatar image when needed
If an author does not have a Gravatar use the default shilouette image. This provides consistent layout with multiple authors and removes awkward layout spacing for authors without a Gravatar.

Note these examples already incorporate the fixes listed above.

### Multiple Authors
_Before:_
<img width="909" alt="Screenshot 2023-03-25 at 9 40 04 AM" src="https://user-images.githubusercontent.com/470139/227730309-a84ec5a9-94ac-4416-bead-a84adf06727b.png">

---

_After:_
<img width="799" alt="Screenshot 2023-03-25 at 8 14 53 AM" src="https://user-images.githubusercontent.com/470139/227729410-e783d98c-91eb-4aa0-9ede-2153fc7d0077.png">

---

### Single Author
_Before:_
<img width="927" alt="Screenshot 2023-03-25 at 9 42 38 AM" src="https://user-images.githubusercontent.com/470139/227730458-f3b7ca0c-0e47-4b60-9b74-a540f58be8bd.png">

---

_After:_
<img width="820" alt="Screenshot 2023-03-25 at 8 14 32 AM" src="https://user-images.githubusercontent.com/470139/227729427-22caa2cc-e119-4048-9285-2e107975332c.png">

---

The commit adds an 'if else' between two different img elements rather than try to conditionally construct the Gravitar URL. That seemed like the approach which would be easier to read and understand.


