### PR TITLE
Update LLVM bug tracker link in `contributing/_llvm.md`

### DIFF
--- a/contributing/_llvm.md
+++ b/contributing/_llvm.md
@@ -43,6 +43,6 @@ the LLDB coding conventions.
 
 [llvm-project]: https://github.com/apple/llvm-project
 [LLVM]: http://llvm.org
-[llvm-bugs]: https://bugs.llvm.org/ "LLVM Bug Tracker"
+[llvm-bugs]: https://github.com/llvm/llvm-project/issues "LLVM Bug Tracker"
 [Clang]: http://clang.llvm.org
 [LLDB]: http://lldb.llvm.org


### PR DESCRIPTION
LLVM Bugzilla is read-only and represents the historical archive of all LLVM issues filled before November 26, 2021. We should use a link to GitHub to point to the actual LLVM bug tracker.