### PR TITLE
Add support for feature identifier field on Swift Evolution page

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -349,6 +349,7 @@ function renderProposals() {
       if (state === '.implemented') detailNodes.push(renderVersion(proposal.status.version))
       if (state === '.previewing') detailNodes.push(renderPreview())
       if (proposal.implementation) detailNodes.push(renderImplementation(proposal.implementation))
+      if (proposal.featureIdentifier) detailNodes.push(renderFeatureIdentifier(proposal.featureIdentifier))
       if (state === '.acceptedWithRevisions') detailNodes.push(renderStatus(proposal.status))
 
       if (state === '.activeReview' || state === '.scheduledForReview') {
@@ -444,6 +445,18 @@ function renderImplementation(implementations) {
     html('div', { className: 'implementation-list proposal-detail-value' },
       implNodes
     )
+  ])
+}
+
+/** For proposals that contain a Feature Identifier */
+function renderFeatureIdentifier(featureIdentifier) {
+  return html('div', { className: 'proposal-detail' }, [
+    html('div', { className: 'proposal-detail-label' }, [
+      'Feature Identifier: '
+    ]),
+    html('div', { className: 'proposal-detail-value' }, [
+      featureIdentifier
+    ])
   ])
 }
 
@@ -718,7 +731,8 @@ function _searchProposals(filterText) {
       ['trackingBugs', 'link'],
       ['trackingBugs', 'status'],
       ['trackingBugs', 'id'],
-      ['trackingBugs', 'assignee']
+      ['trackingBugs', 'assignee'],
+      ['featureIdentifier']
   ]
 
   // reflect over the proposals and find ones with matching properties

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -349,7 +349,7 @@ function renderProposals() {
       if (state === '.implemented') detailNodes.push(renderVersion(proposal.status.version))
       if (state === '.previewing') detailNodes.push(renderPreview())
       if (proposal.implementation) detailNodes.push(renderImplementation(proposal.implementation))
-      if (proposal.featureIdentifier) detailNodes.push(renderFeatureIdentifier(proposal.featureIdentifier))
+      if (proposal.upcomingFeatureFlag) detailNodes.push(renderUpcomingFeatureFlag(proposal.upcomingFeatureFlag))
       if (state === '.acceptedWithRevisions') detailNodes.push(renderStatus(proposal.status))
 
       if (state === '.activeReview' || state === '.scheduledForReview') {
@@ -448,14 +448,14 @@ function renderImplementation(implementations) {
   ])
 }
 
-/** For proposals that contain a Feature Identifier */
-function renderFeatureIdentifier(featureIdentifier) {
+/** For proposals that contain an upcoming feature flag. */
+function renderUpcomingFeatureFlag(upcomingFeatureFlag) {
   return html('div', { className: 'proposal-detail' }, [
     html('div', { className: 'proposal-detail-label' }, [
-      'Feature Identifier: '
+      'Upcoming Feature Flag: '
     ]),
     html('div', { className: 'proposal-detail-value' }, [
-      featureIdentifier
+      upcomingFeatureFlag
     ])
   ])
 }
@@ -732,7 +732,7 @@ function _searchProposals(filterText) {
       ['trackingBugs', 'status'],
       ['trackingBugs', 'id'],
       ['trackingBugs', 'assignee'],
-      ['featureIdentifier']
+      ['upcomingFeatureFlag']
   ]
 
   // reflect over the proposals and find ones with matching properties

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -38,6 +38,18 @@ var languageVersions = [
   'Next'
 ]
 
+/** 
+ * Mapping of proposal ids to upcoming feature flags. 
+ * Temporary until upcomingFeatureFlag property is returned in proposals.json. 
+ */
+const upcomingFeatureFlags = new Map([
+  ['SE-0274', 'ConciseMagicFile'],
+  ['SE-0286', 'ForwardTrailingClosures'],
+  ['SE-0335', 'ExistentialAny'],
+  ['SE-0354', 'BareSlashRegexLiterals'],
+  ['SE-0384', 'ImportObjcForwardDeclarations']
+])
+
 /** Storage for the user's current selection of filters when filtering is toggled off. */
 var filterSelection = []
 
@@ -137,6 +149,14 @@ function init() {
     proposals = proposals.filter(function (proposal) {
       return !proposal.errors
     })
+    
+    // Add upcomingFeatureFlag to proposal if present in mapping.
+    // Temporary until upcomingFeatureFlag property is returned in proposals.json. 
+    for (var proposal of proposals) {
+      if (upcomingFeatureFlags.has(proposal.id)) {
+        proposal.upcomingFeatureFlag = upcomingFeatureFlags.get(proposal.id)
+      }
+    }
 
     // descending numeric sort based the numeric nnnn in a proposal ID's SE-nnnn
     proposals.sort(function compareProposalIDs (p1, p2) {


### PR DESCRIPTION
- Read and display `upcomingFeatureFlag` field if present
- Enable search on that field
- Use a map between proposal id and upcoming feature flags temporarily until backing JSON file adds the `upcomingFeatureFlag` field.
- Part of Issue #261 

This PR adds support for an 'upcoming feature flag' field to be read, displayed, and searched on the Swift Evolution page.

Note that the `upcomingFeatureFlag` field is not present in the source `proposals.json` file at the moment. This PR uses a map from proposal id to upcoming feature flag in the JavaScript file to add the property to the appropriate proposals. This is intended to be temporary until the property is included in the JSON.

Note also that this Issue #261 also includes filtering for all proposals with an upcoming feature flag. This PR does not address that part of the issue. 