### PR TITLE
Improve page metadata for sharing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ timezone: America/Lower_Princes
 exclude: ["README.md", "config.ru", "Gemfile", "Gemfile.lock", "Procfile", "vendor"]
 safe: true
 future: true
+excerpt_separator: <!--end excerpt-->
+page_excerpts: true
 
 kramdown:
     syntax_highlighter: rouge

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,5 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+  
+{%- if page.title -%}
+  {%- capture meta_title -%}
+    {{ page.title | escape }}
+  {%- endcapture -%}
+{%- else -%}
+  {%- assign meta_title = site.title -%}
+{%- endif -%}
+
+{%- if page.excerpt -%}
+  {%- capture meta_description -%}
+    {{ page.excerpt | strip_html | strip | escape }}
+  {%- endcapture -%}
+{%- else %}
+  {%- assign meta_description = site.description -%}
+{%- endif -%}
+
+{%- if page.url -%}
+  {%- capture meta_url -%}
+    {{ site.url }}{{ page.url }}
+  {%- endcapture -%}
+{%- else -%}
+  {%- assign meta_url = site.url -%}
+{%- endif %}
 
 <head>
   <meta charset="utf-8" />
@@ -10,7 +34,7 @@
   <meta name="author" content="Apple Inc." />
   <meta name="viewport" content="width=device-width initial-scale=1" />
   {% if page.excerpt %}
-  <meta name="description" content="{{ page.excerpt | strip_html | escape }}">
+  <meta name="description" content="{{ meta_description }}">
   {% endif %}
   <link rel="license" href="/LICENSE.txt" />
   <link rel="stylesheet" media="all" href="/assets/stylesheets/application.css" />
@@ -25,41 +49,33 @@
   <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
   <link rel="mask-icon" href="/assets/images/icon-swift.svg" color="#F05339" />
-  {% if page.atom %}
+  {%- if page.atom %}
   <link rel="alternate" type="application/atom+xml" title="Swift.org (Atom Feed)" href="/atom.xml" />
   {% endif %}
 
-  {% if page.url %}
+  {%- if page.url -%}
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
+  {%- endif %}
+  {% if page.robots %}
+  <meta name="robots" content="{{page.robots}}" />
   {% endif %}
-
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@SwiftLang" />
-  {% if page.id %}
-  <meta name="twitter:title" content="{{ page.title | escape }}" />
-  <meta name="twitter:description" content="{{ page.excerpt | strip_html | escape }}" />
-  {% else %}
-  <meta name="twitter:title" content="{{ site.title }}" />
-  <meta name="twitter:description" content="{{ site.description | strip_html | escape}}" />
-  {% endif %}
+  <meta name="twitter:title" content="{{ meta_title }}" />
+  <meta name="twitter:description" content="{{ meta_description }}" />
 
   <meta property="og:site_name" content="{{ site.title }}" />
   <meta property="og:image" content="{{ site.url }}/apple-touch-icon-180x180.png" />
-  {% if page.robots %}
-    <meta name="robots" content="{{page.robots}}" />
-  {% endif %}
-  {% if page.id %}
+  {%- if page.id -%}
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="{{ page.title }}" />
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
-  <meta property="og:description" content="{{ page.excerpt | strip_html | escape }}" />
+  {%- endif %}
+  <meta property="og:title" content="{{ meta_title }}" />
+  <meta property="og:url" content="{{ meta_url }}" />
+  <meta property="og:description" content="{{ meta_description }}" />
+  {%- if page.id %}
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
   <meta property="article:modified_time" content="{{ site.time | date_to_xmlschema }}" />
-  {% else %}
-  <meta property="og:title" content="{{ site.title }}" />
-  <meta property="og:url" content="{{ site.url }}" />
-  <meta property="og:description" content="{{ site.description | strip_html | escape}}" />
-  {% endif %}
+  {%- endif %}
 </head>
 
 <body>

--- a/blog/index.html
+++ b/blog/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: Blog
 atom: true
+excerpt: "The Swift.org blog helps to keep the Swift community informed of recent developments in the language, the release roadmap, interesting new features, libraries, tools, as well as announcing project and community initiatives, and developer experiences."
 ---
 
 {% for post in site.posts %}

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Documentation
+excerpt: "Whether you are new to Swift or an experienced Swift developer, documentation like The Swift Programming Language book, API Guidelines, and reference documentation for tools and libraries, serves as an invaluable resource in discovering all that Swift has to offer. "
 ---
 
 If you are new to Swift, you may want to check out these additional resources.

--- a/download/index.md
+++ b/download/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Download Swift
+excerpt: "Download both releases and development snapshots of Swift for all supported development platforms."
 ---
 
 

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Getting Started
+excerpt: "Get started with the Swift programming language by downloading and installing the current version. From there you can explore interactively with the REPL. "
 ---
 
 Here, you’ll find information about the how to use the Swift programming language.

--- a/server/guides/deployment.md
+++ b/server/guides/deployment.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Deploying to Servers or Public Cloud
+excerpt: "Servers built with Swift can be deployed on a variety of public cloud providers. The guides listed on this page show you how."
 ---
 
 The following guides can help with the deployment to public cloud providers:

--- a/server/guides/llvm-sanitizers.md
+++ b/server/guides/llvm-sanitizers.md
@@ -3,8 +3,7 @@ layout: page
 title: LLVM TSAN / ASAN
 ---
 
-For multithreaded and low-level unsafe interfacing server code, the ability to use LLVM's [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) and
-[AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) can help troubleshoot invalid thread usage and invalid usage/access of memory.
+For multithreaded and low-level unsafe interfacing server code, the ability to use LLVM's [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) and [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) can help troubleshoot invalid thread usage and invalid usage/access of memory.
 
 There is a [blog post](/blog/tsan-support-on-linux/) outlining the usage of TSAN.
 

--- a/server/guides/memory-leaks-and-usage.md
+++ b/server/guides/memory-leaks-and-usage.md
@@ -3,8 +3,7 @@ layout: page
 title: Debugging Memory Leaks and Usage
 ---
 
-There are many different tools for troubleshooting memory leaks both on Linux and macOS, each with different strengths and ease-of-use. One excellent tool is the Xcode's [Memory Graph Debugger](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/debugging_with_xcode/chapters/special_debugging_workflows.html#//apple_ref/doc/uid/TP40015022-CH9-DontLinkElementID_1).
-[Instruments](https://help.apple.com/instruments/mac/10.0/#/dev022f987b) and `leaks` can also be very useful. If you cannot run or reproduce the problem on macOS, there are a number of server-side alternatives below.
+There are many different tools for troubleshooting memory leaks both on Linux and macOS, each with different strengths and ease-of-use. One excellent tool is the Xcode's [Memory Graph Debugger](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/debugging_with_xcode/chapters/special_debugging_workflows.html#//apple_ref/doc/uid/TP40015022-CH9-DontLinkElementID_1). [Instruments](https://help.apple.com/instruments/mac/10.0/#/dev022f987b) and `leaks` can also be very useful. If you cannot run or reproduce the problem on macOS, there are a number of server-side alternatives below.
 
 ## Example program
 

--- a/server/guides/performance.md
+++ b/server/guides/performance.md
@@ -3,7 +3,9 @@ layout: page
 title: Debugging Performance Issues
 ---
 
-First of all, it's very important to make sure that you compiled your Swift code in _release mode_. The performance difference between debug and release builds is huge in Swift. You can compile your Swift code in release mode using
+First of all, it's very important to make sure that you compiled your Swift code in _release mode_. The performance difference between debug and release builds is huge in Swift.
+
+You can compile your Swift code in release mode using:
 
     swift build -c release
 

--- a/server/guides/setup-and-ide-alternatives.md
+++ b/server/guides/setup-and-ide-alternatives.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Installing Swift and using with IDEs
+excerpt: "Swift is supported on a number of platforms, integrated development environments (IDEs), and editors."
 ---
 
 ## Installing Swift

--- a/server/index.md
+++ b/server/index.md
@@ -2,6 +2,7 @@
 redirect_from: "/server-apis/"
 layout: page
 title: Swift on Server
+excerpt: "Swift has unique characteristics that make it specifically suitable for Server applications, including a small memory footprint, fast startup times, and deterministic performance."
 ---
 
 Swift is a general-purpose programming language built using a modern approach to safety, performance, and software design patterns.

--- a/sswg/index.md
+++ b/sswg/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Swift Server Workgroup (SSWG)
 ---
 
-The Swift Server workgroup is a steering team that promotes the use of Swift for developing and deploying server applications. The Swift Server workgroup will:
+The Swift Server workgroup is a steering team that promotes the use of Swift for developing and deploying server applications. <!--end excerpt--> The Swift Server workgroup will:
 
 * Define and prioritize efforts that address the needs of the Swift server community
 * Define and run an incubation process for these efforts to reduce duplication of effort, increase compatibility and promote best practices

--- a/website-governance/index.md
+++ b/website-governance/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Swift.org website governance
+excerpt: "The Swift.org website has group of maintainers which includes a subset of the Swift core team and the Swift website workgroup members. The maintainers are in charge of reviewing and merging pull requests from contributors. The Swift.org website source code consists of several distinct parts. Each one of these areas is governed by a slightly different contribution process that matches their nature."
 ---
 
 See [website overview](/website) for more information about the Swift.org website goals and contribution guidelines.

--- a/website-workgroup/index.md
+++ b/website-workgroup/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Swift.org website workgroup (SWWG)
+excerpt: "The Swift website workgroup is a steering team that helps guide the evolution on the Swift.org website."
 ---
 
 See [website overview](/website) for more information about the Swift.org website goals, content governance and contribution guidelines.

--- a/website/index.md
+++ b/website/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Swift.org website
+excerpt: "Swift.org is the website of the Swift programming language providing newcomers and experienced developers with documentation, announcements, and news about Swift and the Swift community in a safe, friendly environment."
 ---
 
 Swift.org website goals include:


### PR DESCRIPTION
This PR addresses the issues in Issue #203:

- In _config.yml file:
  - Enable page excerpts
  - Set excerpt separator
- In base layout:
  - Calculate title, description, URL in one place for meta tags
  - Always use page values for meta tags when present, fallback to site values
  - Replace conditional tags with single tag that uses calculated value
  - Move robots meta tag out from the middle of Open Graph tags
  - Reduce excessive whitespace from generated newlines
- Add explicit excerpts to front matter of pages where automatic excerpt was not suitable / sufficient
- Small adjustments to page first paragraphs to generate better description meta tags
- Resolves #203