### PR TITLE
Remove SE-0374 from Swift 5.8 post

### DIFF
--- a/_posts/2023-03-30-swift-5.8-released.md
+++ b/_posts/2023-03-30-swift-5.8-released.md
@@ -132,7 +132,6 @@ The following language, standard library, and Swift Package Manager proposals we
 - SE-0370: [Pointer Family Initialization Improvements and Better Buffer Slices](https://github.com/apple/swift-evolution/blob/main/proposals/0370-pointer-family-initialization-improvements.md)
 - SE-0372: [Document Sorting as Stable](https://github.com/apple/swift-evolution/blob/main/proposals/0372-document-sorting-as-stable.md)
 - SE-0373: [Lift all limitations on variables in result builders](https://github.com/apple/swift-evolution/blob/main/proposals/0373-vars-without-limits-in-result-builders.md)
-- SE-0374: [Add sleep(for:) to Clock](https://github.com/apple/swift-evolution/blob/main/proposals/0374-clock-sleep-for.md)
 - SE-0375: [Opening existential arguments to optional parameters](https://github.com/apple/swift-evolution/blob/main/proposals/0375-opening-existential-optional.md)
 - SE-0376: [Function Back Deployment](https://github.com/apple/swift-evolution/blob/main/proposals/0376-function-back-deployment.md)
 


### PR DESCRIPTION
- The proposal is now listed as being implemented in 5.9

There was some back and forth over this issue in the original post PR.

The proposal is now listed on the evolution page as implemented in 5.9, so it should be removed from the Swift 5.8 post.

Here is the link to the proposal: https://www.swift.org/swift-evolution/#?proposal=SE-0374