### PR TITLE
Add Swift 5.8 Docker image links to download page

### DIFF
--- a/_data/builds/swift-5_8-release/amazonlinux2-aarch64.yml
+++ b/_data/builds/swift-5_8-release/amazonlinux2-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-amazonlinux2-aarch64.tar.gz
   download_signature: swift-5.8-RELEASE-amazonlinux2-aarch64.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-amazonlinux2
+  docker: 5.8-amazonlinux2

--- a/_data/builds/swift-5_8-release/amazonlinux2.yml
+++ b/_data/builds/swift-5_8-release/amazonlinux2.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-amazonlinux2.tar.gz
   download_signature: swift-5.8-RELEASE-amazonlinux2.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-amazonlinux2
+  docker: 5.8-amazonlinux2

--- a/_data/builds/swift-5_8-release/centos7.yml
+++ b/_data/builds/swift-5_8-release/centos7.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-centos7.tar.gz
   download_signature: swift-5.8-RELEASE-centos7.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-centos7
+  docker: 5.8-centos7

--- a/_data/builds/swift-5_8-release/ubi9-aarch64.yml
+++ b/_data/builds/swift-5_8-release/ubi9-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubi9-aarch64.tar.gz
   download_signature: swift-5.8-RELEASE-ubi9-aarch64.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-rhel-ubi9
+  docker: 5.8-rhel-ubi9

--- a/_data/builds/swift-5_8-release/ubi9.yml
+++ b/_data/builds/swift-5_8-release/ubi9.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubi9.tar.gz
   download_signature: swift-5.8-RELEASE-ubi9.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-rhel-ubi9
+  docker: 5.8-rhel-ubi9

--- a/_data/builds/swift-5_8-release/ubuntu1804.yml
+++ b/_data/builds/swift-5_8-release/ubuntu1804.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubuntu18.04.tar.gz
   download_signature: swift-5.8-RELEASE-ubuntu18.04.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-bionic
+  docker: 5.8-bionic

--- a/_data/builds/swift-5_8-release/ubuntu2004-aarch64.yml
+++ b/_data/builds/swift-5_8-release/ubuntu2004-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubuntu20.04-aarch64.tar.gz
   download_signature: swift-5.8-RELEASE-ubuntu20.04-aarch64.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-focal
+  docker: 5.8-focal

--- a/_data/builds/swift-5_8-release/ubuntu2004.yml
+++ b/_data/builds/swift-5_8-release/ubuntu2004.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubuntu20.04.tar.gz
   download_signature: swift-5.8-RELEASE-ubuntu20.04.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-focal
+  docker: 5.8-focal

--- a/_data/builds/swift-5_8-release/ubuntu2204-aarch64.yml
+++ b/_data/builds/swift-5_8-release/ubuntu2204-aarch64.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubuntu22.04-aarch64.tar.gz
   download_signature: swift-5.8-RELEASE-ubuntu22.04-aarch64.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-jammy
+  docker: 5.8-jammy

--- a/_data/builds/swift-5_8-release/ubuntu2204.yml
+++ b/_data/builds/swift-5_8-release/ubuntu2204.yml
@@ -4,4 +4,4 @@
   download: swift-5.8-RELEASE-ubuntu22.04.tar.gz
   download_signature: swift-5.8-RELEASE-ubuntu22.04.tar.gz.sig
   dir: swift-5.8-RELEASE
-  docker: Coming Soon #5.8-jammy
+  docker: 5.8-jammy


### PR DESCRIPTION
The Swift 5.8 Docker images are now available on hub.docker.com. 