### PR TITLE
Fix atom feed sort and limit

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -8,8 +8,8 @@
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>tag:swift.org,2015-12-03:Swift</id>
 
-  {% assign posts = site.posts | sort: 'date' | limit: 20 %}
-  {% for post in posts %}
+  {% assign posts = site.posts | sort: 'updated' %}
+  {% for post in posts limit: 20 %}
   <entry>
     <title>{{ post.title }}</title>
     {% assign author = site.data.authors[post.author] %}


### PR DESCRIPTION
Fix the [atom feed](https://www.swift.org/atom.xml) so it sorts by updated date in descending order and limits entries to 20.

### Motivation:

The current atom feed is sorted in ascending order and includes all entries. Since each entry has a `<content>` node the file ends up being 427 kb gzipped.

The sort issue happens because the sort key is `date` and not `updated`. Entries have an `updated` node, not a `date` node.

The limit happens because [limit](https://shopify.github.io/liquid/tags/iteration/#limit) should be applied in the `for` loop and not the variable assignment in the tag.

### Modifications:

Changed the sort key from `date` to `updated` and applied `limit` in the `for` loop.

### Result:

Entries are sorted in descending order and limited to 20.

Jekyll's dev server doesn't gzip the file, so I downloaded it and gzipped it. The file is now ~58kb.
