### PR TITLE
Fix typo in the 'BareSlashRegexLiterals' upcoming feature flag in 5.8 blog post

### DIFF
--- a/_posts/2023-03-30-swift-5.8-released.md
+++ b/_posts/2023-03-30-swift-5.8-released.md
@@ -25,7 +25,7 @@ Swift 5.8 includes upcoming features for the following Swift evolution proposals
 - SE-0274: [Concise magic file names](https://github.com/apple/swift-evolution/blob/main/proposals/0274-magic-file.md) (`ConciseMagicFile`)
 - SE-0286: [Forward-scan matching for trailing closures](https://github.com/apple/swift-evolution/blob/main/proposals/0286-forward-scan-trailing-closures.md) (`ForwardTrailingClosures`)
 - SE-0335: [Introduce existential any](https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md) (`ExistentialAny`)
-- SE-0354: [Regex literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md) (`BaseSlashRegexLiterals`)
+- SE-0354: [Regex literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md) (`BareSlashRegexLiterals`)
 
 For example, building the following file at `/Users/example/Desktop/0274-magic-file.swift` in a module called `MagicFile` with `-enable-experimental-feature ConciseMagicFile` will opt into the concise format for `#file` and `#filePath` described in SE-0274:
 


### PR DESCRIPTION
Fixes a typo the upcoming feature flag for regex literals in the 5.8 blog post.

FYI, I noticed the typo by copying flag out of the blog post and into Xcode to try out the new 'upcoming feature' functionality. I would guess other readers might do the same leading to confusion.