### PR TITLE
Fix Windows Python install version

### DIFF
--- a/download/_windows.md
+++ b/download/_windows.md
@@ -38,7 +38,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    #### With Winget (Windows Package Manager):
    ~~~ pwsh
    winget install Git.Git
-   winget install Python.Python.3 --version 3.10.2150.0
+   winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    start /w vs_community.exe --passive --wait --norestart --nocache ^

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -87,7 +87,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    #### With Winget (Windows Package Manager):
    ~~~ pwsh
    winget install Git.Git
-   winget install Python.Python.3 --version 3.10.2150.0
+   winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    start /w vs_community.exe --passive --wait --norestart --nocache ^


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

Fix the Windows Python install version in Installation instructions.
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The current Python install instructions for Windows point to a version of Python that does not exist.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Updating this to install version `Python.Python.3.10`.
