### PR TITLE
Upcoming feature flag filter

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -916,7 +916,7 @@ function _applyFragment(fragment) {
   fragment = fragment.substring(2) // remove the #?
 
   // Use this literal's keys as the source of truth for key-value pairs in the fragment
-  var actions = { proposal: [], search: null, status: [], version: [], flags: false }
+  var actions = { proposal: [], search: null, status: [], version: [], upcoming: false }
 
   // Parse the fragment as a query string
   Object.keys(actions).forEach(function (action) {
@@ -927,7 +927,7 @@ function _applyFragment(fragment) {
       var value = values[1] // 1st capture group from the RegExp
       if (action === 'search') {
         value = decodeURIComponent(value)
-      } else if (action === 'flags') {
+      } else if (action === 'upcoming') {
         value = value === 'true'
       } else {
         value = value.split(',')
@@ -1015,7 +1015,7 @@ function _applyFragment(fragment) {
   }
   
   // Toggle upcoming feature flag filter if needed
-  if (actions.flags && !upcomingFeatureFlagFilterEnabled) {
+  if (actions.upcoming && !upcomingFeatureFlagFilterEnabled) {
     toggleFlagFiltering()
   }
 
@@ -1070,7 +1070,7 @@ function _updateURIFragment() {
   if (actions.proposal.length) fragments.push('proposal=' + actions.proposal.join(','))
   if (actions.status.length) fragments.push('status=' + actions.status.join(','))
   if (actions.version.length) fragments.push('version=' + actions.version.join(','))
-  if (upcomingFeatureFlagFilterEnabled) fragments.push('flags=true')
+  if (upcomingFeatureFlagFilterEnabled) fragments.push('upcoming=true')
 
   // encoding the search lets you search for `??` and other edge cases.
   if (actions.search) fragments.push('search=' + encodeURIComponent(actions.search))

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -695,7 +695,6 @@ function toggleFilterPanel() {
 }
 
 function toggleFlagFiltering() {
-  console.log("toggleFlagFiltering()")
   var filterButton = document.querySelector('#flag-filter-button')
   var newValue = !filterButton.classList.contains('active')
   filterButton.setAttribute('aria-pressed', newValue ? 'true' : 'false')

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -594,7 +594,7 @@ function addEventListeners() {
     })
   })
 
-  document.querySelector('.filter-button').addEventListener('click', toggleFiltering)
+  document.querySelector('.filter-button').addEventListener('click', toggleStatusFiltering)
 
   var filterToggle = document.querySelector('.filter-toggle')
   filterToggle.querySelector('.toggle-filter-panel').addEventListener('click', toggleFilterPanel)
@@ -643,7 +643,7 @@ function addEventListeners() {
  * Toggles whether filters are active. Rather than being cleared, they are saved to be restored later.
  * Additionally, toggles the presence of the "Filtered by:" status indicator.
  */
-function toggleFiltering() {
+function toggleStatusFiltering() {
   var filterDescription = document.querySelector('.filter-toggle')
   var shouldPreserveSelection = !filterDescription.classList.contains('hidden')
 
@@ -967,7 +967,7 @@ function _applyFragment(fragment) {
   // specifying any filter in the fragment should activate the filters in the UI
   if (actions.version.length || actions.status.length) {
     toggleFilterPanel()
-    toggleFiltering()
+    toggleStatusFiltering()
   }
 
   filterProposals()

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -729,16 +729,17 @@ function filterProposals() {
       .map(function (part) { return _searchProposals(part) })
   }
 
-  var matchingProposals = matchingSets.reduce(function (intersection, candidates) {
+  var searchMatches = matchingSets.reduce(function (intersection, candidates) {
     return intersection.filter(function (alreadyIncluded) { return candidates.indexOf(alreadyIncluded) !== -1 })
   }, matchingSets[0] || [])
   
-  matchingProposals = _applyFlagFilter(matchingProposals)
-  matchingProposals = _applyStatusFilter(matchingProposals)
-  _setProposalVisibility(matchingProposals)
+  var searchAndFlagMatches = _applyFlagFilter(searchMatches)
+  var fullMatches = _applyStatusFilter(searchAndFlagMatches)
+  _setProposalVisibility(fullMatches)
   _updateURIFragment()
 
-  determineNumberOfProposals(matchingProposals)
+ // The per-status counts take only search string and flag filter matches into account
+  determineNumberOfProposals(searchAndFlagMatches)
   updateFilterStatus()
 }
 

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -902,7 +902,7 @@ function _applyFragment(fragment) {
   fragment = fragment.substring(2) // remove the #?
 
   // Use this literal's keys as the source of truth for key-value pairs in the fragment
-  var actions = { proposal: [], search: null, status: [], version: [] }
+  var actions = { proposal: [], search: null, status: [], version: [], flags: false }
 
   // Parse the fragment as a query string
   Object.keys(actions).forEach(function (action) {
@@ -913,6 +913,8 @@ function _applyFragment(fragment) {
       var value = values[1] // 1st capture group from the RegExp
       if (action === 'search') {
         value = decodeURIComponent(value)
+      } else if (action === 'flags') {
+        value = value === 'true'
       } else {
         value = value.split(',')
       }
@@ -997,6 +999,11 @@ function _applyFragment(fragment) {
     toggleFilterPanel()
     toggleStatusFiltering()
   }
+  
+  // Toggle upcoming feature flag filter if needed
+  if (actions.flags && !upcomingFeatureFlagFilterEnabled) {
+    toggleFlagFiltering()
+  }
 
   filterProposals()
 }
@@ -1049,6 +1056,7 @@ function _updateURIFragment() {
   if (actions.proposal.length) fragments.push('proposal=' + actions.proposal.join(','))
   if (actions.status.length) fragments.push('status=' + actions.status.join(','))
   if (actions.version.length) fragments.push('version=' + actions.version.join(','))
+  if (upcomingFeatureFlagFilterEnabled) fragments.push('flags=true')
 
   // encoding the search lets you search for `??` and other edge cases.
   if (actions.search) fragments.push('search=' + encodeURIComponent(actions.search))

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -816,7 +816,7 @@ function _searchProposals(filterText) {
  */
 function _applyFlagFilter(matchingProposals) {
   if (upcomingFeatureFlagFilterEnabled) {
-    matchingProposals = proposals.filter(function (proposal) {
+    matchingProposals = matchingProposals.filter(function (proposal) {
       return proposal.upcomingFeatureFlag ? true : false
     })
   }

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -1087,6 +1087,15 @@ function updateFilterDescription(selectedStateNames) {
   if (window.matchMedia('(max-width: 414px)').matches) {
     FILTER_DESCRIPTION_LIMIT = 1
   }
+  
+  // On very narrow screens, shorten long status names
+  if (window.matchMedia('(max-width: 360px)').matches) {
+    selectedStateNames.forEach((name, index) => {
+      var newName = name.replace('Scheduled for Review', 'Scheduled')
+      newName = newName.replace('Returned for Revision', 'Returned')
+      selectedStateNames[index] = newName
+    })
+  }
 
   var container = document.querySelector('.toggle-filter-panel')
 

--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -75,6 +75,10 @@
             .icon-line {
                 stroke: white;
             }
+            
+            .icon-flag {
+                fill: white;
+            }
 
             .icon-circle {
                 fill: var(--color-evolution-secondary-fill);

--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -292,12 +292,6 @@
         }
     }
 
-    @media (max-width: 414px) {
-        .filter-button {
-            order: 0;
-        }
-    }
-
     /* Status label colors */
 
     .color-awaiting-review {

--- a/swift-evolution/_dashboard.html
+++ b/swift-evolution/_dashboard.html
@@ -3,7 +3,7 @@
     <input id="search-filter" class="filter" title="Search proposals" placeholder="Search" type="search" incremental />
     
     <div class="filter-container">
-      <span role="button" id="status-filter-button" class="filter-button" aria-label="Toggle status filtering options" aria-pressed="false" tabindex="0">
+      <span role="button" id="status-filter-button" class="filter-button" aria-label="Toggle status filtering options" aria-pressed="false" tabindex="0" title="Toggle proposal status filter">
         <svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <g id="filter-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(1.381818, 0.400000)">
                 <ellipse class="icon-circle" id="filter-icon-circle" stroke="#888" cx="8.92443193" cy="9.85624994" rx="8.90625" ry="8.90625"></ellipse>
@@ -13,7 +13,7 @@
             </g>
         </svg>
       </span>
-      <span role="button" id="flag-filter-button" class="filter-button" aria-label="Toggle upcoming feature flag filtering" aria-pressed="false" tabindex="0">
+      <span role="button" id="flag-filter-button" class="filter-button" aria-label="Toggle upcoming feature flag filtering" aria-pressed="false" tabindex="0" title="Toggle upcoming feature flag filter">
         <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
           <g id="flag-button-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
               <g id="flag-button" transform="translate(1.000000, 1.000000)">

--- a/swift-evolution/_dashboard.html
+++ b/swift-evolution/_dashboard.html
@@ -3,7 +3,7 @@
     <input id="search-filter" class="filter" title="Search proposals" placeholder="Search" type="search" incremental />
     
     <div class="filter-container">
-      <span role="button" class="filter-button" aria-label="Toggle status filtering options" aria-pressed="false" tabindex="0">
+      <span role="button" id="status-filter-button" class="filter-button" aria-label="Toggle status filtering options" aria-pressed="false" tabindex="0">
         <svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <g id="filter-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(1.381818, 0.400000)">
                 <ellipse class="icon-circle" id="filter-icon-circle" stroke="#888" cx="8.92443193" cy="9.85624994" rx="8.90625" ry="8.90625"></ellipse>
@@ -11,6 +11,17 @@
                 <path d="M5.25846596,10.2124999 L12.7515909,10.2124999" class="icon-line" id="line-middle" stroke="#888" stroke-linecap="square"></path>
                 <path d="M6.9967741,13.7749999 L11.1173991,13.7749999" class="icon-line" id="line-bottom" stroke="#888" stroke-linecap="square"></path>  
             </g>
+        </svg>
+      </span>
+      <span role="button" id="flag-filter-button" class="filter-button" aria-label="Toggle upcoming feature flag filtering" aria-pressed="false" tabindex="0">
+        <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <g id="flag-button-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="flag-button" transform="translate(1.000000, 1.000000)">
+                  <circle class="icon-circle" id="filter-icon-circle" stroke="#888888" cx="8.90625" cy="8.90625" r="8.90625"></circle>
+                  <polygon class="icon-flag" id="Path" fill="#888888" fill-rule="nonzero" points="5.85770196 3.19092433 5.86399453 3.69088474 5.9999604 14.4937074 6.00625298 14.9936678 5.00633217 15.006253 5.0000396 14.5062926 4.86407373 3.70346988 4.85778115 3.20350948"></polygon>
+                  <path d="M6.97193141,3 C5.84463226,3 5,3.28070198 5,3.28070198 L5,9.48771889 C5,9.48771889 5.84463226,9.20701691 6.97193141,9.20701691 C8.09923056,9.20701691 9.29310099,10 10.4982444,10 C11.7033991,10 13.4771998,9.48771889 13.4771998,9.48771889 L13.4771998,3.28070198 C13.4771998,3.28070198 11.7002889,3.79298309 10.4982444,3.79298309 C9.29621116,3.79298309 8.09923056,3 6.97193141,3 Z" class="icon-flag" id="flag" fill="#888888"></path>
+              </g>
+          </g>
         </svg>
       </span>
       <span class="filter-toggle hidden">


### PR DESCRIPTION
This PR implements a dedicated filter button for proposals with an upcoming feature flag as described in Issue #261.

From my testing everything is working as intended. The feature flag filter correctly interacts with the status/version filter. The per-status count values update correctly. The URL fragment that includes the search/filter settings now includes the feature flag filter state and is read and written as expected.

I have tested with multiple iOS devices and the tap targets of the filter buttons seem to be large enough to tap each easily.

- Add click handler to flag filter button
- Add method that filters out proposals without a UFF
- Add a URL that links to info about upcoming feature flags
- Add suffix to status string 'with upcoming feature flags'
	- Include link to info about UFFs
	- Use correct pluralization for status string
- Add flag filter button element and SVG to _dashboard.html
- Add element id to status filter and flag filter buttons
- Add new CSS class for flag icon active state
- Resolves #261

## With Upcoming Feature Flag Filter Off:
<img width="657" alt="Screenshot 2023-04-11 at 6 44 25 PM" src="https://user-images.githubusercontent.com/470139/231326421-47288eca-165e-45eb-8ced-3adf891ee1aa.png">

## With Upcoming Feature Flag Filter On:
The text 'upcoming feature flag' links to info about upcoming feature flags, in this PR, the proposal that introduces them.
<img width="661" alt="Screenshot 2023-04-11 at 6 44 41 PM" src="https://user-images.githubusercontent.com/470139/231326540-9228c317-0ba9-4d14-a1e8-2dd0e62f1a28.png">
