### PR TITLE
Fix SSWG incubation badges and update links

### DIFF
--- a/sswg/incubation-process.md
+++ b/sswg/incubation-process.md
@@ -123,9 +123,9 @@ The SSWG reserves the right to define a singular solution for critical building 
 
 It is recommended for projects that have been accepted to any of the maturity levels to list the maturity level in their project's README with the appropriate badge as defined:
 
-[![sswg:sandbox|94x20](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#sandbox-level)
-[![sswg:incubating|104x20](https://img.shields.io/badge/sswg-incubating-blue.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#incubating-level)
-[![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/main/process/incubation.md#graduated-level)
+[![sswg:sandbox](https://img.shields.io/badge/sswg-sandbox-lightgrey.svg)](https://swift.org/sswg/incubation-process.html#sandbox-level){: style="display: inline-block; width: 94px; height: 20px"}
+[![sswg:incubating](https://img.shields.io/badge/sswg-incubating-blue.svg)](https://swift.org/sswg/incubation-process.html#incubating-level){: style="display: inline-block; width: 104px; height: 20px"}
+[![sswg:graduated](https://img.shields.io/badge/sswg-graduated-green.svg)](https://swift.org/sswg/incubation-process.html#graduated-level){: style="display: inline-block; width: 104px; height: 20px"}
 
 The SSWG will meet every 6 months to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements.
 For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Fixed broken SSWG incubation badges and updated their links to point to Swift.org instead of a 404 on GitHub.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

I noticed that the incubation process badges on https://www.swift.org/sswg/incubation-process.html were broken:

<img width="966" alt="CleanShot 2023-05-09 at 09 03 24" src="https://user-images.githubusercontent.com/35671299/237019905-98a6c0cf-fe6d-457a-9602-918418abc3bf.png">

Also, the links were outdated and linked to a missing document on GitHub.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Fixed the badges by moving the width/height sizing to CSS
- I added a `display: inline-block;` to the badges' styling as well to make them stack horizontally
- I changed the links from `https://github.com/swift-server/sswg/blob/main/process/incubation.md` to `https://swift.org/sswg/incubation-process.html` (we should use an absolute link to Swift.org in case someone reuses them outside Swift.org)

### Result:

<!-- _[After your change, what will change.]_ -->

This is what it looks like now:

<img width="956" alt="CleanShot 2023-05-09 at 09 04 58" src="https://user-images.githubusercontent.com/35671299/237019970-8438f919-76f0-4af9-9261-cae4571b9a40.png">

