### PR TITLE
Update the minimum deployment version

### DIFF
--- a/platform-support/_platform-support.md
+++ b/platform-support/_platform-support.md
@@ -27,10 +27,10 @@ This table shows the minimum OS version for which a Swift application can be dep
 
 | Platform running Swift application | Minimum deployment version |
 |:------------------:|:--------------------------:|
-| **macOS**          |10.9                        |
-| **iOS**            |7.0                         |
-| **watchOS**        |2.0                         |
-| **tvOS**           |9.0                         |
+| **macOS**          |10.13                       |
+| **iOS**            |11.0                        |
+| **watchOS**        |4.0                         |
+| **tvOS**           |11.0                        |
 | **Ubuntu**         |18.04                       |
 | **CentOS**         |7                           |
 | **Amazon Linux**   |2                           |


### PR DESCRIPTION
Starting Swift 5.8 the min deployment has been updated

```
DARWIN_DEPLOYMENT_VERSION_OSX = '10.13'
DARWIN_DEPLOYMENT_VERSION_IOS = '11.0'
DARWIN_DEPLOYMENT_VERSION_TVOS = '11.0'
DARWIN_DEPLOYMENT_VERSION_WATCHOS = '4.0'
```
