### PR TITLE
Add informations about community packages/repositories for Linux

### DIFF
--- a/download/_linux.md
+++ b/download/_linux.md
@@ -17,6 +17,12 @@ Note that nothing prevents Swift from being ported to other Linux distributions 
 * CentOS 7
 * Amazon Linux 2
 
+### Other distributions that work using community packages and repositories
+
+* Fedora 38
+* Arch Linux
+* Ubuntu/Debian based distros (Using community package from community repository)
+
 * * *
 
 ### Installation

--- a/download/index.md
+++ b/download/index.md
@@ -534,7 +534,7 @@ makepkg -si
 
 #### Ubuntu/Debian community build
 
-There's also a community made package for Ubuntu/Debian based distros that is easy to install.
+There's also a community-made package for Ubuntu/Debian based distros that is easy to install.
 Just copy the commands below to add the repository and install Swift.
 
 More information about the community repository is available at [swiftlang.xyz](https://www.swiftlang.xyz/).

--- a/download/index.md
+++ b/download/index.md
@@ -478,12 +478,72 @@ $ yum install epel-release
 $ yum install swiftlang
 ```
 
+##### Fedora RPM repository
 
+```bash
+sudo dnf install swift-lang
+``` 
 
+[Here's link to Fedora Repository for more information](https://src.fedoraproject.org/rpms/swift-lang#)
 
 
 {% include_relative _older-releases.md %}
 
+
+#### Arch Linux
+
+On Arch Linux you can install Swift using AUR. You can either use a repackedged version of the Fedora RPM or get a native build for Arch Linux.
+
+[More information availble at Arch Linux Wiki](https://wiki.archlinux.org/title/Swift)
+
+##### Install using AUR helper tools
+
+Since Swift has AUR packages you can install it using AUR helper tools like yay.
+
+```bash
+yay -S swift-language
+```
+or
+```bash
+yay -S swift-bin
+```
+
+
+##### Native Arch Linux build using AUR
+
+[Source](https://aur.archlinux.org/packages/swift-language)
+
+To install it you will need git and base-devel packages installed.
+
+```bash
+git clone https://aur.archlinux.org/swift-language.git
+cd swift-language
+makepkg -si
+```
+After that you will be asked if you want to instal requiered dependencies. Answer yes and wait for the build to finish. By the way since its building the whole thing it will take a while.
+
+#####  Repackaged Fedora RPM
+
+Can be installed the same way as the previous one. Just change the repository. Also this package is faster to get up and running
+
+```bash
+git clone https://aur.archlinux.org/swift-bin.git
+cd swift-language
+makepkg -si
+```
+
+#### Ubuntu/Debian community build
+
+There's also a community made package for Ubuntu/Debian based distros that is easy to install.
+Just copy the commands below to add the repository and install Swift.
+
+[More information about the community repository](https://www.swiftlang.xyz/)
+
+```bash
+sudo apt install -y curl
+curl -s https://archive.swiftlang.xyz/install.sh | sudo bash
+sudo apt install swiftlang
+```
 
 ## Snapshots
 

--- a/download/index.md
+++ b/download/index.md
@@ -484,7 +484,7 @@ $ yum install swiftlang
 sudo dnf install swift-lang
 ``` 
 
-[Here's link to Fedora Repository for more information](https://src.fedoraproject.org/rpms/swift-lang#)
+Checkout [the corresponding Fedora Repository page](https://src.fedoraproject.org/rpms/swift-lang) for more information.
 
 
 {% include_relative _older-releases.md %}
@@ -492,13 +492,13 @@ sudo dnf install swift-lang
 
 #### Arch Linux
 
-On Arch Linux you can install Swift using AUR. You can either use a repackedged version of the Fedora RPM or get a native build for Arch Linux.
+On Arch Linux you can install Swift using AUR. You can either use a repackaged version of the Fedora RPM or get a native build for Arch Linux.
 
-[More information availble at Arch Linux Wiki](https://wiki.archlinux.org/title/Swift)
+You can find more information available at [Arch Linux Wiki](https://wiki.archlinux.org/title/Swift).
 
 ##### Install using AUR helper tools
 
-Since Swift has AUR packages you can install it using AUR helper tools like yay.
+Since Swift has AUR packages you can install it using AUR helper tools like `yay`:
 
 ```bash
 yay -S swift-language
@@ -524,7 +524,7 @@ After that you will be asked if you want to instal requiered dependencies. Answe
 
 #####  Repackaged Fedora RPM
 
-Can be installed the same way as the previous one. Just change the repository. Also this package is faster to get up and running
+Can be installed the same way as the previous one, and this package is faster to get up and running. Just change the repository like this:
 
 ```bash
 git clone https://aur.archlinux.org/swift-bin.git
@@ -537,7 +537,7 @@ makepkg -si
 There's also a community made package for Ubuntu/Debian based distros that is easy to install.
 Just copy the commands below to add the repository and install Swift.
 
-[More information about the community repository](https://www.swiftlang.xyz/)
+More information about the community repository is available at [swiftlang.xyz](https://www.swiftlang.xyz/).
 
 ```bash
 sudo apt install -y curl


### PR DESCRIPTION
Add information about Linux packages and repositories maintained by the community

### Motivation:

I already mentioned that in an issue I made recently (#319) about lack of information for easier installation methods on more common user Linux systems. I added that information into Linux downloads page so anyone interested in Swift can try it out on their Linux machine even easier. 

### Modifications:

Added information about methods of installing swift on Arch Linux, Fedora and about easier install for Ubuntu/Debian based distros to the Linux downloads page.

### Result:

Downloads page will have more options for installing Swift on Linux. Information about methods using community packages and repositories.
