### PR TITLE
remove CLion because JetBrains is no longer supporting Swift

### DIFF
--- a/server/guides/setup-and-ide-alternatives.md
+++ b/server/guides/setup-and-ide-alternatives.md
@@ -14,8 +14,6 @@ A number of editors you may already be familiar with have support for writing Sw
 * [Atom IDE support](https://atom.io/packages/ide-swift)
     * [Atomic Blonde](https://atom.io/packages/atomic-blonde) a SourceKit based syntax highlighter for Atom.
 
-* [CLion](https://www.jetbrains.com/help/clion/swift.html)
-
 * [Emacs plugin](https://github.com/swift-emacs/swift-mode)
 
 * [VIM plugin](https://github.com/keith/swift.vim)


### PR DESCRIPTION
JetBrains has sunset its Swift support for CLion.
https://plugins.jetbrains.com/plugin/8240-swift

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
--> remove CLion because JetBrains is no longer supporting Swift

### Motivation:

Documentation for CLion Swift support is out of date and can be confusing for people who want to write Swift on other platforms.

### Modifications:

I removed the line referencing CLion.

### Result:

CLion will no longer be on the list of IDEs/Editors with Swift Support
