### PR TITLE
[Content Improvements] Move link to A Swift Tour to the Use Cases section

### DIFF
--- a/_data/go_further.yml
+++ b/_data/go_further.yml
@@ -1,11 +1,3 @@
-- title: "A Swift Tour"
-  description: "_The Swift Programming Language_, the authoritative reference for Swift, begins with a tour of the language. The tour gives you an introduction to the fundamental features, concepts, and syntax of Swift. The remainder of the book explains each topic in greater detail."
-  content_type: book
-  content_url: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/
-  thumbnail_url: #TBD
-  release_date: 2014-08-18
-  featured: true
-  external: true
 - title: "Value and Reference Types"
   description: "This article describes the differences in behavior between _value types_ and _reference types_—a fundamental part of learning Swift and choosing between structures and classes."
   content_type: article

--- a/assets/stylesheets/pages/_getting-started.scss
+++ b/assets/stylesheets/pages/_getting-started.scss
@@ -41,6 +41,7 @@
 }
 
 .use-case-list {
+  $grid-breakpoint: 1000px;
   list-style: none;
   padding-left: 0;
   display: grid;
@@ -52,10 +53,18 @@
     border-radius: 4px;
     display: flex;
     flex-direction: column;
+
+    @media (min-width: $grid-breakpoint) {
+      &.featured {
+        grid-column-start: 1;
+        grid-column-end: 3;
+      }
+    }
     
     h3 {
       line-height: 1.4;
       font-size: 1.4rem;
+      padding-top: 0;
     }
     
     p {

--- a/getting-started/_use-cases.md
+++ b/getting-started/_use-cases.md
@@ -2,7 +2,7 @@
 
 <ul class="use-case-list">
   <li class="use-case featured">
-    <h3>✨ New to Programming?</h3>
+    <h3>✨ New to Swift?</h3>
     <p class="description">
       Swift is a great first language if you are just starting your programming journey. For a brief tour of the language, check out this introductory chapter in The Swift Programming Language book.
     </p>

--- a/getting-started/_use-cases.md
+++ b/getting-started/_use-cases.md
@@ -1,11 +1,21 @@
 ## Using Swift
 
+<ul class="use-case-list">
+  <li class="use-case featured">
+    <h3>✨ New to Programming?</h3>
+    <p class="description">
+      Swift is a great first language if you are just starting your programming journey. For a brief tour of the language, check out this introductory chapter in The Swift Programming Language book.
+    </p>
+
+    <a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/" class="cta-secondary">Read A Swift Tour</a>
+  </li>
+</ul>
+
+---
+
 Here are some examples of the many use cases of Swift, in case you want to jump in and start writing some code right away.
 
-Looking for a language reference? [The Swift Programming Language (TSPL)](https://docs.swift.org/swift-book/) book is available in [multiple languages](/documentation/#translations).
-
 <ul class="use-case-list">
-
   <li class="use-case">
     <h3>Command-line Tool</h3>
     <p class="description">
@@ -44,3 +54,7 @@ Looking for a language reference? [The Swift Programming Language (TSPL)](https:
     <a href="/getting-started/swiftui" class="cta-secondary">Start tutorial</a>
   </li>
 </ul>
+
+---
+
+Looking for a language reference? [The Swift Programming Language (TSPL)](https://docs.swift.org/swift-book/) book is available in [multiple languages](/documentation/#translations).


### PR DESCRIPTION
### Motivation:

We discussed trying out this direction during a a recent feedback session.

### Modifications:

- Removed "A Swift Tour" from the Go Further section.
- Added a new "New to programming?" section in the Use cases section.
- Moved down the link to TSPL so that it comes after the use cases (we didn't consider this option during the meeting, but I think it looks better in terms of both flow and layout).

### Result:

<img width="782" alt="screenshot-2023-06-19-1" src="https://github.com/apple/swift-org-website/assets/519433/debf023c-7c27-4e71-b497-419c3651e3ee">