### PR TITLE
Removing Paul Hudson from Diversity in Swift

### DIFF
--- a/diversity/index.md
+++ b/diversity/index.md
@@ -19,7 +19,6 @@ The current Diversity in Swift workgroup consists of the following people:
 * Holly Borla ([@hborla](https://forums.swift.org/u/hborla/))
 * Kristina Fox ([@kristina](https://forums.swift.org/u/kristina/))
 * Marc Aupont ([@digimarktech](https://forums.swift.org/u/digimarktech))
-* Paul Hudson ([@paul_hudson](https://forums.swift.org/u/paul_hudson/))
 * Timirah James ([@timirahj](https://forums.swift.org/u/timirahj))
 
 You can reach the Diversity in Swift workgroup on the Swift Forums as [@diversity-workgroup](https://forums.swift.org/g/diversity-workgroup).


### PR DESCRIPTION
This removes my name from the list of Diversity in Swift workgroup members.

I had a great time working on the Diversity in Swift workgroup, and I am very grateful to the other members of the group for doing such a great job launching and supporting a range of initiatives. However, my two-year term has passed and I have now left the workgroup.

Given that the role of Swift workgroups is evolving (https://www.swift.org/blog/evolving-swift-project-workgroups/) this page may need further changes, but I'll leave that to folks who are more in the know.