### PR TITLE
re-arrange main navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -41,25 +41,10 @@
           name: deployment-only
         - title: Platform Owners
           name: platform-owners
-    - title: Documentation
-      url: /documentation/
-      sections:
-        - title: Swift Language
-          name: swift-language
-        - title: Standard Library
-          name: standard-library
-        - title: Packages
-          name: packages
-        - title: API Design Guidelines
-          name: api-design-guidelines
-        - title: C++ Interoperability
-          name: mixing-swift-and-c
-        - title: Tools
-          name: tools
 
 - header: Community
   pages:
-    - title: Community Overview
+    - title: Overview
       url: /community/
       sections:
         - title: Communication
@@ -70,6 +55,8 @@
           name: license
         - title: Forums
           name: forums
+    - title: Code of Conduct
+      url: /code-of-conduct/
     - title: Diversity
       url: /diversity/
       sections:
@@ -113,10 +100,127 @@
           name: adding-external-library-dependencies
         - title: LLVM and Swift
           name: llvm-and-swift
-    - title: Code of Conduct
-      url: /code-of-conduct/
 
-- header: Open Source Development
+    - title: Contributor Experience Workgroup
+      url: /contributor-experience-workgroup/
+    - title: Server Workgroup
+      url: /sswg/
+      sections:
+        - title: Community Participation
+          name: community-participation
+        - title: Governance
+          name: governance
+        - title: Website workgroup
+          name: website-workgroup
+    - title: Website Workgroup
+      url: /website/
+      sections:
+        - title: Community Participation
+          name: community-participation
+        - title: Governance
+          name: governance
+        - title: Website workgroup
+          name: website-workgroup
+    - title: Language Workgroup
+      url: /language-workgroup/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Decision making
+          name: decision-making
+        - title: Communication
+          name: communication
+        - title: Evolution process
+          name: evolution-process
+        - title: Community participation
+          name: community-participation
+    - title: C++ Interoperability Workgroup
+      url: /cxx-interop-workgroup/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Communication
+          name: communication
+    - title: Documentation Workgroup
+      url: /documentation-workgroup/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Communication
+          name: communication
+        - title: Community Participation
+          name: community-participation
+
+- header: Documentation
+  pages:
+    - title: Overview
+      url: /documentation/
+      sections:
+        - title: Swift Language
+          name: swift-language
+        - title: Standard Library
+          name: standard-library
+        - title: Packages
+          name: packages
+        - title: API Design Guidelines
+          name: api-design-guidelines
+        - title: C++ Interoperability
+          name: mixing-swift-and-c
+        - title: Tools
+          name: tools
+    - title: Swift Compiler
+      url: /swift-compiler/
+      sections:
+        - title: Compiler Architecture
+          name: compiler-architecture
+    - title: Standard Library
+      url: /standard-library/
+      sections:
+        - title: Standard Library Preview Package
+          name: standard-library-preview-package
+        - title: Standard Library Design
+          name: standard-library-design
+    - title: Package Manager
+      url: /package-manager/
+      sections:
+        - title: Conceptual Overview
+          name: conceptual-overview
+        - title: Example Usage
+          name: example-usage
+    - title: Core Libraries
+      url: /core-libraries/
+      sections:
+        - title: Foundation
+          name: foundation
+        - title: libdispatch
+          name: libdispatch
+        - title: xctest
+          name: xctest
+    - title: REPL, Debugger & Playgrounds
+      url: /lldb/
+      sections:
+        - title: Combined REPL + Debugger
+          name: why-combine-the-repl-and-debugger
+        - title: Xcode Playgrounds
+          name: xcode-playground-support
+    - title: Swift on Server
+      url: /server/
+      sections:
+        - title: Why Swift on Server?
+          name: why-swift-on-server
+        - title: Swift Server Workgroup
+          name: swift-server-workgroup
+        - title: Swift Server Guides
+          name: development-guides
+
+
+- header: Governance
   pages:
     - title: Swift Evolution
       url: /swift-evolution/
@@ -168,96 +272,3 @@
           name: security-process
         - title: Security Updates
           name: security-updates
-
-- header: Open Source Efforts
-  pages:
-    - title: Contributor Experience
-      url: /contributor-experience-workgroup/
-    - title: Swift Compiler
-      url: /swift-compiler/
-      sections:
-        - title: Compiler Architecture
-          name: compiler-architecture
-    - title: Standard Library
-      url: /standard-library/
-      sections:
-        - title: Standard Library Preview Package
-          name: standard-library-preview-package
-        - title: Standard Library Design
-          name: standard-library-design
-    - title: Package Manager
-      url: /package-manager/
-      sections:
-        - title: Conceptual Overview
-          name: conceptual-overview
-        - title: Example Usage
-          name: example-usage
-    - title: Core Libraries
-      url: /core-libraries/
-      sections:
-        - title: Foundation
-          name: foundation
-        - title: libdispatch
-          name: libdispatch
-        - title: xctest
-          name: xctest
-    - title: REPL, Debugger & Playgrounds
-      url: /lldb/
-      sections:
-        - title: Combined REPL + Debugger
-          name: why-combine-the-repl-and-debugger
-        - title: Xcode Playgrounds
-          name: xcode-playground-support
-    - title: Swift on Server
-      url: /server/
-      sections:
-        - title: Why Swift on Server?
-          name: why-swift-on-server
-        - title: Swift Server Workgroup
-          name: swift-server-workgroup
-        - title: Swift Server Guides
-          name: development-guides
-    - title: Swift.org website
-      url: /website/
-      sections:
-        - title: Community Participation
-          name: community-participation
-        - title: Governance
-          name: governance
-        - title: Website workgroup
-          name: website-workgroup
-    - title: Language Workgroup
-      url: /language-workgroup/
-      sections:
-        - title: Charter
-          name: charter
-        - title: Membership
-          name: membership
-        - title: Decision making
-          name: decision-making
-        - title: Communication
-          name: communication
-        - title: Evolution process
-          name: evolution-process
-        - title: Community participation
-          name: community-participation
-    - title: C++ Interoperability
-      url: /cxx-interop-workgroup/
-      sections:
-        - title: Charter
-          name: charter
-        - title: Membership
-          name: membership
-        - title: Communication
-          name: communication
-    - title: Documentation Workgroup
-      url: /documentation-workgroup/
-      sections:
-        - title: Charter
-          name: charter
-        - title: Membership
-          name: membership
-        - title: Communication
-          name: communication
-        - title: Community Participation
-          name: community-participation

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -41,7 +41,112 @@
           name: deployment-only
         - title: Platform Owners
           name: platform-owners
-
+# ------------------------------------------------------------------------------
+- header: Documentation
+  pages:
+    - title: Overview
+      url: /documentation/
+      sections:
+        - title: Swift Language
+          name: swift-language
+        - title: Standard Library
+          name: standard-library
+        - title: Packages
+          name: packages
+        - title: API Design Guidelines
+          name: api-design-guidelines
+        - title: C++ Interoperability
+          name: mixing-swift-and-c
+        - title: Tools
+          name: tools
+    - title: Swift Compiler
+      url: /swift-compiler/
+      sections:
+        - title: Compiler Architecture
+          name: compiler-architecture
+    - title: Standard Library
+      url: /standard-library/
+      sections:
+        - title: Standard Library Preview Package
+          name: standard-library-preview-package
+        - title: Standard Library Design
+          name: standard-library-design
+    - title: Package Manager
+      url: /package-manager/
+      sections:
+        - title: Conceptual Overview
+          name: conceptual-overview
+        - title: Example Usage
+          name: example-usage
+    - title: Core Libraries
+      url: /core-libraries/
+      sections:
+        - title: Foundation
+          name: foundation
+        - title: libdispatch
+          name: libdispatch
+        - title: xctest
+          name: xctest
+    - title: REPL, Debugger & Playgrounds
+      url: /lldb/
+      sections:
+        - title: Combined REPL + Debugger
+          name: why-combine-the-repl-and-debugger
+        - title: Xcode Playgrounds
+          name: xcode-playground-support
+    - title: Swift on Server
+      url: /server/
+      sections:
+        - title: Why Swift on Server?
+          name: why-swift-on-server
+        - title: Swift Server Workgroup
+          name: swift-server-workgroup
+        - title: Swift Server Guides
+          name: development-guides
+    - title: Swift Evolution
+      url: /swift-evolution/
+    - title: Source Code
+      url: /source-code/
+      sections:
+        - title: Compiler and Standard Library
+          name: compiler-and-standard-library
+        - title: Core Libraries
+          name: core-libraries
+        - title: Package Manager
+          name: package-manager
+        - title: Xcode Playground Support
+          name: xcode-playground-support
+        - title: Source Tooling
+          name: source-tooling
+        - title: SourceKit-LSP Service
+          name: sourcekit-lsp-service
+        - title: Swift.org Website
+          name: swiftorg-website
+        - title: Cloned Repositories
+          name: cloned-repositories
+    - title: Continuous Integration
+      url: /continuous-integration/
+      sections:
+        - title: Configuration
+          name: configuration
+        - title: Usage
+          name: usage
+        - title: Community Involvement
+          name: community-involvement
+    - title: Source Compatibility
+      url: /source-compatibility/
+      sections:
+        - title: Current List of Projects
+          name: current-list-of-projects
+        - title: Adding Projects
+          name: adding-projects
+        - title: Maintaining Projects
+          name: maintaining-projects
+        - title: Pull Request Testing
+          name: pull-request-testing
+        - title: Building Projects
+          name: building-projects
+# ------------------------------------------------------------------------------
 - header: Community
   pages:
     - title: Overview
@@ -55,8 +160,6 @@
           name: license
         - title: Forums
           name: forums
-    - title: Code of Conduct
-      url: /code-of-conduct/
     - title: Diversity
       url: /diversity/
       sections:
@@ -156,115 +259,11 @@
           name: communication
         - title: Community Participation
           name: community-participation
-
-- header: Documentation
-  pages:
-    - title: Overview
-      url: /documentation/
-      sections:
-        - title: Swift Language
-          name: swift-language
-        - title: Standard Library
-          name: standard-library
-        - title: Packages
-          name: packages
-        - title: API Design Guidelines
-          name: api-design-guidelines
-        - title: C++ Interoperability
-          name: mixing-swift-and-c
-        - title: Tools
-          name: tools
-    - title: Swift Compiler
-      url: /swift-compiler/
-      sections:
-        - title: Compiler Architecture
-          name: compiler-architecture
-    - title: Standard Library
-      url: /standard-library/
-      sections:
-        - title: Standard Library Preview Package
-          name: standard-library-preview-package
-        - title: Standard Library Design
-          name: standard-library-design
-    - title: Package Manager
-      url: /package-manager/
-      sections:
-        - title: Conceptual Overview
-          name: conceptual-overview
-        - title: Example Usage
-          name: example-usage
-    - title: Core Libraries
-      url: /core-libraries/
-      sections:
-        - title: Foundation
-          name: foundation
-        - title: libdispatch
-          name: libdispatch
-        - title: xctest
-          name: xctest
-    - title: REPL, Debugger & Playgrounds
-      url: /lldb/
-      sections:
-        - title: Combined REPL + Debugger
-          name: why-combine-the-repl-and-debugger
-        - title: Xcode Playgrounds
-          name: xcode-playground-support
-    - title: Swift on Server
-      url: /server/
-      sections:
-        - title: Why Swift on Server?
-          name: why-swift-on-server
-        - title: Swift Server Workgroup
-          name: swift-server-workgroup
-        - title: Swift Server Guides
-          name: development-guides
-
-
+# ------------------------------------------------------------------------------
 - header: Governance
   pages:
-    - title: Swift Evolution
-      url: /swift-evolution/
-    - title: Source Code
-      url: /source-code/
-      sections:
-        - title: Compiler and Standard Library
-          name: compiler-and-standard-library
-        - title: Core Libraries
-          name: core-libraries
-        - title: Package Manager
-          name: package-manager
-        - title: Xcode Playground Support
-          name: xcode-playground-support
-        - title: Source Tooling
-          name: source-tooling
-        - title: SourceKit-LSP Service
-          name: sourcekit-lsp-service
-        - title: Swift.org Website
-          name: swiftorg-website
-        - title: Cloned Repositories
-          name: cloned-repositories
-    - title: Continuous Integration
-      url: /continuous-integration/
-      sections:
-        - title: Configuration
-          name: configuration
-        - title: Usage
-          name: usage
-        - title: Community Involvement
-          name: community-involvement
-    - title: Source Compatibility
-      url: /source-compatibility/
-      sections:
-        - title: Current List of Projects
-          name: current-list-of-projects
-        - title: Adding Projects
-          name: adding-projects
-        - title: Maintaining Projects
-          name: maintaining-projects
-        - title: Pull Request Testing
-          name: pull-request-testing
-        - title: Building Projects
-          name: building-projects
+    - title: Code of Conduct
+      url: /code-of-conduct/
     - title: Security
       url: /support/security.html
       sections:


### PR DESCRIPTION
motivation: clearer navigation structure

changes:
* remove "Open Source Development" and " "Open Source Efforts" sections
* create new "Documentation" section and move compiler, stdlibe, swiftpm and other docs previsouly under "Open Source Efforts" to this section
* move workgroup links from "Open Source Efforts" section to "Community" section
* create new "Governance" section and move CoC and security policy links to this section
