### PR TITLE
Update outdated GitHub link

### DIFF
--- a/documentation-workgroup/index.md
+++ b/documentation-workgroup/index.md
@@ -23,7 +23,7 @@ The current Documentation Workgroup consists of the following people:
 * [Ethan Kusters](https://github.com/ethan-kusters)
 * [Franklin Schrans](https://github.com/franklinsch) (chair)
 * [Joe Heck](https://github.com/heckj)
-* [Kelvin Ma](https://github.com/kelvin13)
+* [Kelvin Ma](https://github.com/tayloraswift)
 * [Kyle Murray](https://github.com/krilnon)
 * [Kyle Ye](https://github.com/Kyle-Ye)
 * [Max Obermeier](https://github.com/theMomax)


### PR DESCRIPTION

### Motivation:

"Kelvin Ma" has changed the Github ID from "kelvin13" to "tayloraswift"

The old link will point to a 404 page instead of redirecting to homepage with the new ID.

cc @tayloraswift 

### Modifications:

Update outdated Github link

### Result:

Fix the Github link.