### PR TITLE
New “Swift is…” and About page copy

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -3,15 +3,14 @@ layout: page
 title: About Swift
 ---
 
-Swift is a general-purpose programming language built using a modern approach to safety, performance, and software design patterns.
+Swift is a **general-purpose** programming language that is **quick** to write, **fast** to run, **modern**, and **safe**. It’s **approachable** for newcomers and **powerful** in expert hands.
 
-The goal of the Swift project is to create the best available language for uses ranging from systems programming, to mobile and desktop apps, scaling up to cloud services.  Most importantly, Swift is designed to make writing and maintaining *correct* programs easier for the developer. To achieve this goal, we believe that the most obvious way to write Swift code must also be:
+* Swift is **general-purpose** and **modern**. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
+* Swift is **safe**.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes should be caught before software is in production. Swift makes the obvious path the safest.
+* Swift is **fast** to run and **quick** to write. Predictable and consistent performance that is as quick as C-based languages, with all the advantages of developer-friendly language design.
+* Swift is **approachable** and **powerful**. From “Hello, World!” in one line of code to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 
-**Safe.**  The most obvious way to write code should also behave in a safe manner.  Undefined behavior is the enemy of safety, and developer mistakes should be caught before software is in production. Opting for safety sometimes means Swift will feel strict, but we believe that clarity saves time in the long run.
-
-**Fast.**  Swift is intended as a replacement for C-based languages (C, C++, and Objective-C). As such, Swift must be comparable to those languages in performance for most tasks.  Performance must also be predictable and consistent, not just fast in short bursts that require clean-up later.  There are lots of languages with novel features — being fast is rare.
-
-**Expressive.**  Swift benefits from decades of advancement in computer science to offer syntax that is a joy to use, with modern features developers expect.  But Swift is never done.  We will monitor language advancements and embrace what works, continually evolving to make Swift even better.
+## Tools
 
 Tools are a critical part of the Swift ecosystem. We strive to integrate well within a developer's toolset, to build quickly, to present excellent diagnostics, and to enable interactive development experiences. Tools can make programming so much more powerful, like Swift-based playgrounds do in Xcode, or a web-based REPL can when working with Linux server-side code.
 

--- a/about/index.md
+++ b/about/index.md
@@ -6,9 +6,9 @@ title: About Swift
 Swift is a general-purpose programming language that's approachable for newcomers and powerful in expert hands. It is quick to write, fast to run, modern, and safe.
 
 * Swift is general-purpose and modern. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
-* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software is in production. Swift makes the obvious path the safest.
-* Swift is fast to run and quick to write. Predictable and consistent performance that is as quick as C-based languages, with all the advantages of developer-friendly language design.
-* Swift is approachable and powerful. From “Hello, World!” in one line of code to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
+* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software goes into production. Swift makes the obvious path the safest.
+* Swift is fast to run and quick to write. Predictable and consistent performance that's as quick as C-based languages, with all the advantages of developer-friendly language design.
+* Swift is approachable and powerful. From a single-line “Hello, World!” to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 
 ## Tools
 

--- a/about/index.md
+++ b/about/index.md
@@ -7,7 +7,7 @@ Swift is a general-purpose programming language that's approachable for newcomer
 
 * Swift is general-purpose and modern. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
 * Swift is safe. Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software goes into production. Swift makes the obvious path the safest.
-* Swift is fast to run and quick to write. Predictable and consistent performance that's as quick as C-based languages, with all the advantages of developer-friendly language design.
+* Swift is fast to run and quick to write. Swift is fast to run and quick to write. It comes with predictable and consistent performance that is on-par with C-based languages without sacrificing developer friendliness.
 * Swift is approachable and powerful. From a single-line “Hello, World!” to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 
 ## Tools

--- a/about/index.md
+++ b/about/index.md
@@ -6,7 +6,7 @@ title: About Swift
 Swift is a general-purpose programming language that's approachable for newcomers and powerful in expert hands. It is quick to write, fast to run, modern, and safe.
 
 * Swift is general-purpose and modern. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
-* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes should be caught before software is in production. Swift makes the obvious path the safest.
+* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software is in production. Swift makes the obvious path the safest.
 * Swift is fast to run and quick to write. Predictable and consistent performance that is as quick as C-based languages, with all the advantages of developer-friendly language design.
 * Swift is approachable and powerful. From “Hello, World!” in one line of code to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 

--- a/about/index.md
+++ b/about/index.md
@@ -6,7 +6,7 @@ title: About Swift
 Swift is a general-purpose programming language that's approachable for newcomers and powerful in expert hands. It is quick to write, fast to run, modern, and safe.
 
 * Swift is general-purpose and modern. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
-* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software goes into production. Swift makes the obvious path the safest.
+* Swift is safe. Undefined behavior is the enemy of safety, and it’s best to catch mistakes before software goes into production. Swift makes the obvious path the safest.
 * Swift is fast to run and quick to write. Predictable and consistent performance that's as quick as C-based languages, with all the advantages of developer-friendly language design.
 * Swift is approachable and powerful. From a single-line “Hello, World!” to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 

--- a/about/index.md
+++ b/about/index.md
@@ -3,12 +3,12 @@ layout: page
 title: About Swift
 ---
 
-Swift is a **general-purpose** programming language that is **quick** to write, **fast** to run, **modern**, and **safe**. It’s **approachable** for newcomers and **powerful** in expert hands.
+Swift is a general-purpose programming language that's approachable for newcomers and powerful in expert hands. It is quick to write, fast to run, modern, and safe.
 
-* Swift is **general-purpose** and **modern**. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
-* Swift is **safe**.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes should be caught before software is in production. Swift makes the obvious path the safest.
-* Swift is **fast** to run and **quick** to write. Predictable and consistent performance that is as quick as C-based languages, with all the advantages of developer-friendly language design.
-* Swift is **approachable** and **powerful**. From “Hello, World!” in one line of code to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
+* Swift is general-purpose and modern. Suitable for everything from systems programming, through mobile and desktop apps, to cloud services.
+* Swift is safe.  Undefined behavior is the enemy of safety, and it’s best to catch mistakes should be caught before software is in production. Swift makes the obvious path the safest.
+* Swift is fast to run and quick to write. Predictable and consistent performance that is as quick as C-based languages, with all the advantages of developer-friendly language design.
+* Swift is approachable and powerful. From “Hello, World!” in one line of code to large-scale apps with hundreds of thousands of lines. Swift scales with your needs.
 
 ## Tools
 

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,27 +1,11 @@
-.why-swift-list {
-  list-style: none;
-  padding-left: 0;
-  display: grid;
-  gap: 1rem;
+.preamble {
+  font-weight: normal;
+  font-size: 28px;
+  line-height: 30px;
+  margin-bottom: 30px;
 
-  li {
-    border: 1px solid var(--color-fill-tertiary);
-    padding: 1rem;
-    border-radius: 4px;
-    display: flex;
-    flex-direction: column;
-
-    h3 {
-      line-height: 1.4;
-      font-size: 1.4rem;
-      padding-top: 0;
-    }
-
-    p {
-      flex-grow: 1;
-      color: var(--color-secondary-label);
-      margin-bottom: 0;
-    }
+  strong {
+    font-weight: 600;
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -35,7 +35,7 @@ atom: true
       </a>
     </li>
 
-    <li>  
+    <li>
       <a href="/documentation">
         <img src="/assets/images/landing-page/book.svg" />
         Read the docs
@@ -57,7 +57,7 @@ atom: true
       Swift is a powerful and intuitive programming language optimized when running on iOS, macOS, and other Apple platforms.
       <br><br>
       Apple offers a wide variety of frameworks and APIs that make applications developed for these platforms unique and fun.
-    </p>  
+    </p>
     <a href="https://developer.apple.com/swift/resources/" class="cta-secondary">Learn more</a>
   </li>
   <li>

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Welcome to Swift.org
 atom: true
 ---
 
-<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that is <strong>quick</strong> to write, <strong>fast</strong> to run, <strong>modern</strong>, and <strong>safe</strong>. It’s <strong>approachable</strong> for newcomers and <strong>powerful</strong> in expert hands.</h1>
+<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> in expert hands. It is <strong>quick</strong> to write, <strong>fast</strong> to run, <strong>modern</strong>, and <strong>safe</strong></h1>.
 
 {% for snippet in site.data.featured_snippets %}
 ```swift

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Welcome to Swift.org
 atom: true
 ---
 
-<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> in expert hands. It is <strong>quick</strong> to write, <strong>fast</strong> to run, <strong>modern</strong>, and <strong>safe</strong></h1>.
+<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> in expert hands. It is <strong>quick</strong> to write, <strong>fast</strong> to run, <strong>modern</strong>, and <strong>safe</strong>.</h1>
 
 {% for snippet in site.data.featured_snippets %}
 ```swift

--- a/index.md
+++ b/index.md
@@ -4,9 +4,7 @@ title: Welcome to Swift.org
 atom: true
 ---
 
-# Welcome to Swift.org
-
-Swift is a general-purpose programming language built using a modern approach to safety, performance, and software design patterns.
+<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that is <strong>quick</strong> to write, <strong>fast</strong> to run, <strong>modern</strong>, and <strong>safe</strong>. It’s <strong>approachable</strong> for newcomers and <strong>powerful</strong> in expert hands.</h1>
 
 {% for snippet in site.data.featured_snippets %}
 ```swift
@@ -45,29 +43,6 @@ Swift is a general-purpose programming language built using a modern approach to
     </li>
   </ul>
 </div>
-
-## Why Swift?
-
-<ul class="why-swift-list">
-  <li>
-    <h3>Safe</h3>
-    <p>
-      Swift prioritizes safety and clarity, ensuring that code behaves in a safe manner while also promoting clear and concise programming practices.
-    </p>
-  </li>
-  <li>
-    <h3>Fast</h3>
-    <p>
-      Swift aims to replace C-based languages (C, C++, and Objective-C) and match their performance, while maintaining consistency and predictability.
-    </p>
-  </li>
-  <li>
-    <h3>Expressive</h3>
-    <p>
-      Swift builds upon decades of advancements in computer science, providing a modern syntax that is a joy to use.
-    </p>
-  </li>
-</ul>
 
 <div class="links links-list-nostyle" markdown="1">
   - [Learn more about Swift](/about)


### PR DESCRIPTION
During the last meeting, we discussed having a `h1` with “Safe, Fast, Modern“ above the “Swift is…“ copy here, but after playing with it, I don’t think that feels quite right.

I’d be happy to change it if the consensus is to have that strong three-word lead-in, but it didn’t feel quite right to me.

This is what felt best to me:

![Screenshot 2023-07-03 at 19 41 52@2x](https://github.com/apple/swift-org-website/assets/5180/4a2474b8-afbf-437d-8a6a-615ff5f1de84)

Then I also tackled the "Safe, Fast, Expressive" section that begins the "About" page as I think they should line up. This copy *definitely* needs work, this is just a first draft. Let's discuss in this PR.

![Screenshot 2023-07-03 at 19 52 20@2x](https://github.com/apple/swift-org-website/assets/5180/1804c2d0-ddbe-4bd2-87a1-7e6fdf795c33)

