### PR TITLE
download page: fix mis-labeled older 5.8 release

### DIFF
--- a/download/_older-releases.md
+++ b/download/_older-releases.md
@@ -1,7 +1,7 @@
 <details class="download" style="margin-bottom: 0em">
   <summary>Swift 5.x</summary>
 
-<h3>Swift 5.7.3</h3>
+<h3>Swift 5.8</h3>
 
 Date: March 30, 2023<br>
 Tag: <a href="https://github.com/apple/swift/releases/tag/swift-5.8-RELEASE">swift-5.8-RELEASE</a>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

download page: fix mis-labeled older 5.8 release
-->

### Motivation:

On the downloads page, the older release 5.8 is mislabeled as 5.7.3.

![Screen Shot 2023-07-06 at 11 02 31 AM](https://github.com/apple/swift-org-website/assets/191733/9151f1e5-4ce9-4e1b-9883-9e7522c07d9b)

### Modifications:

Fix the heading text.

### Result:

The heading will reflect the right version: 5.8.