### PR TITLE
Upcoming Features Blog Post: avoid smart quotes in code samples

### DIFF
--- a/_posts/2023-05-30-using-upcoming-feature-flags.md
+++ b/_posts/2023-05-30-using-upcoming-feature-flags.md
@@ -126,9 +126,9 @@ For a Swift package, enable upcoming features for a target in its `SwiftSetting`
 .target(name: "MyTarget",
   dependencies:[.fancyLibrary],
     swiftSettings:
-      [.enableUpcomingFeature(“ConciseMagicFile”),
-       .enableUpcomingFeature(“BareSlashRegexLiterals”),
-       .enableUpcomingFeature(“ExistentialAny”)])
+      [.enableUpcomingFeature("ConciseMagicFile"),
+       .enableUpcomingFeature("BareSlashRegexLiterals"),
+       .enableUpcomingFeature("ExistentialAny")])
 ```
 You will also need to update the tools version specified in the manifest to 5.8 or later:
 ```swift


### PR DESCRIPTION
Code samples shouldn't have smart quotes in them. Not only this breaks syntax highlighting, but won't build when pasted into actual source code.

<img width="600" alt="Screenshot 2023-07-24 at 14 31 14" src="https://github.com/apple/swift-org-website/assets/112310/e2aa8d1e-3ccd-4a4d-9d72-c3b1ce6f69c1">
