### PR TITLE
[SE-0401] DisableOutwardActorInference (dashboard)

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -47,7 +47,8 @@ const upcomingFeatureFlags = new Map([
   ['SE-0286', 'ForwardTrailingClosures'],
   ['SE-0335', 'ExistentialAny'],
   ['SE-0354', 'BareSlashRegexLiterals'],
-  ['SE-0384', 'ImportObjcForwardDeclarations']
+  ['SE-0384', 'ImportObjcForwardDeclarations'],
+  ['SE-0401', 'DisableOutwardActorInference']
 ])
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -48,7 +48,7 @@ const upcomingFeatureFlags = new Map([
   ['SE-0335', 'ExistentialAny'],
   ['SE-0354', 'BareSlashRegexLiterals'],
   ['SE-0384', 'ImportObjcForwardDeclarations'],
-  ['SE-0401', 'DisableOutwardActorInference']
+  ['SE-0401', 'DisableOutwardActorInference'],
 ])
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */


### PR DESCRIPTION
Add an entry to the `upcomingFeatureFlags` map.

### Motivation:

SE-0401 has been accepted and implemented (Swift 5.9).

### Modifications:

Update the "swift-evolution.js" file.

### Result:

SE-0401 will be included in the <https://www.swift.org/swift-evolution/#?upcoming=true> filter.