### PR TITLE
Minor sentence tweak to avoid implying 2023 is just starting

### DIFF
--- a/_posts/2023-08-17-sswg-update-2023.md
+++ b/_posts/2023-08-17-sswg-update-2023.md
@@ -65,7 +65,7 @@ The SSWG has continued to work with the community to increase adoption of Swift 
 
 ## Goals for 2023
 
-The SSWG believes 2023 will be another exciting year for Swift on the server, with a continued focus on the following goals:
+The SSWG believes 2023 is turning out to be another exciting year for Swift on the server, with a continued focus on the following goals:
 
 * Continued focus on growing the ecosystem
 * Adoption of structured concurrency
@@ -126,3 +126,4 @@ Franz takes over from Fabian Fett who has completed a two year stint on the SSWG
 ## Going Forward
 
 If you have any ideas to share with the SSWG or want to pitch a library to the SSWG Incubation Process, please get in touch with us, either [via the forums](https://forums.swift.org/c/server/43) or through Slack.
+


### PR DESCRIPTION
Update a single sentence in today's SSWG blog post to avoid implying 2023 is just starting.