### PR TITLE
Change Windows installation instructions

### DIFF
--- a/download/_windows.md
+++ b/download/_windows.md
@@ -20,7 +20,7 @@ Windows has the following additional platform specific dependencies:
 
 #### Install using the Windows Package Manager
 
-The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
+The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [Microsoft Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
 #### Install using Scoop
 

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -39,10 +39,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    ~~~ cmd
    winget install Git.Git
    winget install Python.Python.3.10
-
-   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    winget install Microsoft.VisualStudio.2019.Community --force --custom "--add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-   del /q vs_community.exe
    ~~~
 
    #### With Scoop:

--- a/download/_windows.md
+++ b/download/_windows.md
@@ -36,20 +36,19 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    The platform dependencies cannot be installed through the Windows Package Manager as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
 
    #### With Winget (Windows Package Manager):
-   ~~~ pwsh
+   ~~~ cmd
    winget install Git.Git
    winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache ^
-     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
-     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
-     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   winget install Microsoft.VisualStudio.2019.Community --force --custom "--add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
    del /q vs_community.exe
    ~~~
 
    #### With Scoop:
-   ~~~ pwsh
+   > **NOTE:** This code snippet MUST be run in a traditional Command Prompt (`cmd.exe`)
+   
+   ~~~ cmd
    # Scoop already comes pre-installed with Git, so no need to re-install it.
    scoop bucket add versions
    scoop install python310

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -69,7 +69,7 @@ In order to develop applications, particularly with the Swift Package Manager, y
 
 ##### Install using the Windows Package Manager
 
-The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [App Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
+The [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) can be found in the [Microsoft Store](https://www.microsoft.com/en-us/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
 #### Install using Scoop
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -90,7 +90,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
 
@@ -101,7 +101,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    scoop install python310
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -82,26 +82,29 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
 
 0. Install required dependencies:
 
-   The platform dependencies cannot be installed through the currently supported package managers as the install rules do not install the components necessary.  They will be installed through Visual Studio installer.
+   The platform dependencies cannot be installed through the currently supported package managers as the install rules do not install the components necessary.  They will be installed through the Visual Studio installer.
 
    #### With Winget (Windows Package Manager):
-   ~~~ pwsh
+   ~~~ cmd
    winget install Git.Git
    winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   winget install Microsoft.VisualStudio.2019.Community --force --custom "--add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
    del /q vs_community.exe
    ~~~
+   <!-- del is an alias to Remove-Item, so no need to replace it -->
 
    #### With Scoop:
-   ~~~ pwsh
+   > **NOTE:** This code snippet MUST be run in a traditional Command Prompt (`cmd.exe`)
+
+   ~~~ cmd
    # Scoop already comes pre-installed with Git, so no need to re-install it.
    scoop bucket add versions
    scoop install python310
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   start /w vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -90,10 +90,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    winget install Python.Python.3.10
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache ^
-     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
-     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
-     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   start /w vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
 
@@ -104,10 +101,7 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    scoop install python310
 
    curl -sOL https://aka.ms/vs/16/release/vs_community.exe
-   start /w vs_community.exe --passive --wait --norestart --nocache ^
-     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" ^
-     --add Microsoft.VisualStudio.Component.Windows10SDK.19041 ^
-     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+   start /w vs_community.exe --passive --wait --norestart --nocache --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    del /q vs_community.exe
    ~~~
 

--- a/getting-started/_installing.md
+++ b/getting-started/_installing.md
@@ -89,11 +89,8 @@ Invoke-RestMethod -Url 'get.scoop.sh' | Invoke-Expression
    winget install Git.Git
    winget install Python.Python.3.10
 
-   curl -sOL https://aka.ms/vs/16/release/vs_community.exe
    winget install Microsoft.VisualStudio.2019.Community --force --custom "--add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-   del /q vs_community.exe
    ~~~
-   <!-- del is an alias to Remove-Item, so no need to replace it -->
 
    #### With Scoop:
    > **NOTE:** This code snippet MUST be run in a traditional Command Prompt (`cmd.exe`)


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

The Windows installation process errored out on my PC, complaining that `start` could not find the `vs_community.exe` file, which was however present after running `ls`. 

### Modifications:

- Change the installation code block for Windows to not use `start`, but instead execute the installer directly.
- Change the reference to the Microsoft Store from "App Store".

### Result:

The installation instructions for Windows have changed to 
a) not quit with an error
b) correctly reference the Microsoft Store
