### PR TITLE
Swift 5.9 release blog post

### DIFF
--- a/_posts/2023-08-29-swift-5.9-released.md
+++ b/_posts/2023-08-29-swift-5.9-released.md
@@ -1,0 +1,99 @@
+---
+layout: post
+published: true
+date: 2023-08-29 15:00:00
+title: Swift 5.9 Released!
+author: [alexandersandberg]
+---
+
+Swift 5.9 is now officially released! 🎉 <!-- TODO: Summary of what's included in the release -->
+
+Thank you to everyone in the Swift community who made this release possible. Your Swift Forums discussions, bug reports, pull requests, educational content, and other contributions are always appreciated!
+
+<!-- TODO: Link to Swift 5.9 showcase resource -->
+
+[The Swift Programming Language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/) book has been updated for Swift 5.9 and is now published with DocC. This is the official Swift guide and a great entry point for those new to Swift. The Swift community also maintains a number of [translations](/documentation/#translations).
+
+If you’re new to Swift, [The Swift Programming Language](https://docs.swift.org/swift-book/) is the official Swift guide and has been updated for version 5.9. The Swift community maintains a number of [translations](https://www.swift.org/documentation/#translations).
+
+## Language and Standard Library
+
+<!-- TODO: Add section content -->
+
+You can find the complete list of Swift Evolution proposals that were implemented in Swift 5.9 in the [Swift Evolution Appendix](#swift-evolution-appendix) below.
+
+## Developer Experience
+
+<!-- TODO: Add more sections with content? -->
+
+### Debugging
+
+New features have been introduced to [LLDB](https://lldb.llvm.org/ "LLDB project home page") and the Swift compiler to improve the debugging experience, including faster `p` and `po` and use of generic type parameters in expressions.
+
+Learn more in this dedicated blog post: [What’s new in Swift debugging on the 5.9 branch?](#). <!-- TODO: add link to blog post once it's published -->
+
+## Ecosystem
+
+<!-- TODO: Add more sections with content? -->
+
+### Swift Package Manager
+
+Following are some highlights from the changes introduced to the [Swift Package Manager](https://github.com/apple/swift-package-manager) in Swift 5.9:
+
+- SwiftPM packages can now use `package` as a new access modifier, allowing accessing symbols in another target / module within the same package without making it public.
+
+- New `swift experimental-sdk` experimental command is now available for managing Swift SDK bundles that follow the format described in [SE-0387](https://github.com/apple/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md).
+
+- SwiftPM can now publish to a registry following the publishing spec as defined in [SE-0391](https://github.com/apple/swift-evolution/blob/main/proposals/0391-package-registry-publish.md). SwiftPM also gains support for signed packages. Trust-on-first-use (TOFU) check which includes only fingerprints (e.g., checksums) previously has been extended to include signing identities, and it is enforced for source archives as well as package manifests.
+
+- Add a new `CompilerPluginSupport` module which contains the definition for macro targets. Macro targets allow authoring and distribution of custom Swift macros such as [expression macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md).
+
+See the [Swift Package Manager changelog](https://github.com/apple/swift-package-manager/blob/main/CHANGELOG.md#swift-59) for the complete list of changes.
+
+### SwiftSyntax
+
+[SwiftSyntax](https://github.com/apple/swift-syntax) has become an essential tool to create macros in Swift 5.9. In addition to the introduction of the modules that allow the creation of macros, SwiftSyntax has received huge focus on quality:
+
+- The documentation of SwiftSyntax has been greatly expanded and can be viewed at [swiftpackageindex.com](https://swiftpackageindex.com/apple/swift-syntax)
+
+- The names of all syntax nodes and their children have been audited to be more consistent and accurately reflect the Swift language.
+
+- The error messages produced by the new SwiftParser have been greatly improved and it now produces better errors than the C++ parser in almost all cases.
+
+- As part of the Google Summer of Code project, incremental parsing has been introduced to SwiftSyntax, allowing e.g. an editor to only reparse those parts of a syntax tree that have changed.
+
+Over the last year, SwiftSyntax has been a huge success as an open source project. Since the release of Swift 5.8, more than 30 distinct open source contributors have contributed to the package accounting for more than 30% of the commits. And community tools like [swift-ast-explorer.com](https://swift-ast-explorer.com) are an invaluable tool to explore and understand the SwiftSyntax tree. Thanks to everyone who contributed!
+
+### Windows Platform
+
+<!-- TODO: Add section content -->
+
+## Downloads
+
+<!-- TODO: Add section content -->
+
+## Swift Evolution Appendix
+
+The following language, standard library, and Swift Package Manager proposals were accepted through the [Swift Evolution](https://github.com/apple/swift-evolution) process and [implemented in Swift 5.9](https://apple.github.io/swift-evolution/#?version=5.9).
+
+- SE-0366: [`consume` operator to end the lifetime of a variable binding](https://github.com/apple/swift-evolution/blob/main/proposals/0366-move-function.md)
+- SE-0374: [Add sleep(for:) to Clock](https://github.com/apple/swift-evolution/blob/main/proposals/0374-clock-sleep-for.md)
+- SE-0377: [`borrowing` and `consuming` parameter ownership modifiers](https://github.com/apple/swift-evolution/blob/main/proposals/0377-parameter-ownership-modifiers.md)
+- SE-0380: [`if` and `switch` expressions](https://github.com/apple/swift-evolution/blob/main/proposals/0380-if-switch-expressions.md)
+- SE-0381: [DiscardingTaskGroups](https://github.com/apple/swift-evolution/blob/main/proposals/0381-task-group-discard-results.md)
+- SE-0382: [Expression Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0382-expression-macros.md)
+- SE-0384: [Importing Forward Declared Objective-C Interfaces and Protocols](https://github.com/apple/swift-evolution/blob/main/proposals/0384-importing-forward-declared-objc-interfaces-and-protocols.md)
+<!-- TODO: include this one? - SE-0386: [New access modifier: `package`](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md) -->
+- SE-0388: [Convenience Async[Throwing]Stream.makeStream methods](https://github.com/apple/swift-evolution/blob/main/proposals/0388-async-stream-factory.md)
+- SE-0389: [Attached Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0389-attached-macros.md)
+- SE-0390: [Noncopyable structs and enums](https://github.com/apple/swift-evolution/blob/main/proposals/0390-noncopyable-structs-and-enums.md)
+- SE-0392: [Custom Actor Executors](https://github.com/apple/swift-evolution/blob/main/proposals/0392-custom-actor-executors.md)
+- SE-0393: [Value and Type Parameter Packs](https://github.com/apple/swift-evolution/blob/main/proposals/0393-parameter-packs.md)
+- SE-0394: [Package Manager Support for Custom Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0394-swiftpm-expression-macros.md)
+- SE-0396: [Conform `Never` to `Codable`](https://github.com/apple/swift-evolution/blob/main/proposals/0396-never-codable.md)
+- SE-0397: [Freestanding Declaration Macros](https://github.com/apple/swift-evolution/blob/main/proposals/0397-freestanding-declaration-macros.md)
+- SE-0398: [Allow Generic Types to Abstract Over Packs](https://github.com/apple/swift-evolution/blob/main/proposals/0398-variadic-types.md)
+- SE-0399: [Tuple of value pack expansion](https://github.com/apple/swift-evolution/blob/main/proposals/0399-tuple-of-value-pack-expansion.md)
+- SE-0400: [Init Accessors](https://github.com/apple/swift-evolution/blob/main/proposals/0400-init-accessors.md)
+- SE-0401: [Remove Actor Isolation Inference caused by Property Wrappers](https://github.com/apple/swift-evolution/blob/main/proposals/0401-remove-property-wrapper-isolation.md)
+- SE-0402: [Generalize `conformance` macros as `extension` macros](https://github.com/apple/swift-evolution/blob/main/proposals/0402-extension-macros.md)


### PR DESCRIPTION
This PR adds the announcement blog post for the upcoming Swift 5.9 release.

We have tried to improve this process since [last time](https://github.com/apple/swift-org-website/pull/257), and one of the more notable things this time around is that we're trying to include the community a bit more.

We're still exploring ways of doing this, but as an example, it would be nice to link to blog posts, articles, videos, open-source projects, and other resources that the community has created that relate to what's new in Swift 5.9.

I will start a thread on the forums later today to let the community know.

### TODOs

- [ ] Add community resources
- [ ] Write release summary for first paragraph
- [ ] More **Developer Experience** sections?
- [ ] More **Ecosystem** sections?
- [ ] **Language and Standard Library** content (@beccadax)
- [ ] Add link to the Debugging blog post once it's available
- [ ] **Windows Platform** content (@compnerd)
- [ ] **Downloads** content (@shahmishal)
- [ ] Include SE-0386 in the evolutions appendix? (@hborla)

---

Closes #330.