### PR TITLE
Resolve issue with Red Hat download links

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1333,6 +1333,7 @@
         - aarch64
     - name: Red Hat Universal Base Image 9
       docker: 5.8.1-rhel-ubi9
+      dir: ubi9
       archs:
         - x86_64
         - aarch64

--- a/download/_build-platform.html
+++ b/download/_build-platform.html
@@ -38,8 +38,13 @@
             </td>
             <td class="arch-tag"> 
             {% for arch in platform.archs %}
-                {% assign platform_name_url = platform.name | remove : '.' | remove : ' ' | downcase %}
-                {% assign platform_name = platform.name | remove : ' ' | downcase %}
+                {% if platform.dir %}
+                    {% assign platform_name_url = platform.dir %}
+                    {% assign platform_name = platform_name_url %}
+                {% else %}
+                    {% assign platform_name_url = platform.name | remove: '.' | remove: ' ' | downcase %}
+                    {% assign platform_name = platform.name | remove : ' ' | downcase %}
+                {% endif %}
                 {% assign tag_downcase = include.platform.tag | downcase %}
                 <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ include.platform.tag}}/{{ include.platform.tag}}-{{ platform_name }}.tar.gz">{{ arch }}</a>
                 <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ include.platform.tag}}/{{ include.platform.tag}}-{{ platform_name }}.tar.gz.sig" title="PGP Signature" class="signature">Signature ({{ arch }})</a>


### PR DESCRIPTION
This PR proposes a solution to links for Red Hats download links being broken due to a mismatch between the logic constructing the URL and the actual URL.
