### PR TITLE
Fix mobile layout of use cases section

### DIFF
--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -139,10 +139,10 @@
 .use-cases {
   @media (min-width: 1000px) {
     grid-template-columns: repeat(2, 1fr);
-  }
-  
-  li:nth-child(2n-1):nth-last-of-type(1) {
-    grid-column: span 2;
+
+    li:nth-child(2n-1):nth-last-of-type(1) {
+      grid-column: span 2;
+    }
   }
 }
 

--- a/getting-started/_go-further.md
+++ b/getting-started/_go-further.md
@@ -1,6 +1,6 @@
 ## Go Further
 
-Ready to dive deeper? Here are some hand-picked resources covering about various Swift features and use.
+Ready to dive deeper? Here are some hand-picked resources covering various Swift features.
 
 <ul class="go-further-list">
   {% for resource in site.data.go_further %}


### PR DESCRIPTION
### Motivation:

This PR fixes the mobile layout of the use cases section in the landing page.

### Modifications:

- Make the children grid properties only applicable within the large viewport media query.

### Before
<img width="547" alt="screenshot-2023-09-07-2" src="https://github.com/apple/swift-org-website/assets/519433/3ceccd60-0639-40d1-bee5-76892ec24d09">

### After
<img width="517" alt="screenshot-2023-09-07-1" src="https://github.com/apple/swift-org-website/assets/519433/6e373d9b-ff8d-40df-981c-3823ca15ec69">
