### PR TITLE
Fix #394, aarch64 download links broken

### DIFF
--- a/download/_build-platform.html
+++ b/download/_build-platform.html
@@ -46,6 +46,10 @@
                     {% assign platform_name_url = platform.name | remove: '.' | remove: ' ' | downcase %}
                     {% assign platform_name = platform.name | remove : ' ' | downcase %}
                 {% endif %}
+                {% if arch != "x86_64" %}
+                    {% assign platform_name_url = platform_name_url | append: "-" | append: arch %}
+                    {% assign platform_name = platform_name | append: "-" | append: arch %}
+                {% endif %}
                 {% assign tag_downcase = include.platform.tag | downcase %}
                 <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ include.platform.tag}}/{{ include.platform.tag}}-{{ platform_name }}.{{ package_extension }}">{{ arch }}</a>
                 <a href="https://download.swift.org/{{ tag_downcase }}/{{ platform_name_url }}/{{ include.platform.tag}}/{{ include.platform.tag}}-{{ platform_name }}.{{ package_extension }}.sig" title="PGP Signature" class="signature">Signature ({{ arch }})</a>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->
Fixed aarch64 download links for the current stable release.

### Motivation:

Currently the `x86_64` and `aarch64` downloads for the current release point both to the `x86_64` download artifact for the release.

### Modifications:

Added a condition in the download template which appends the arch to the url if it's not the default `x86_64`

### Result:

Download links for `aarch64` will point to `aarch64` downlaod artifacts and `x86_64` to the `x86_64` ones.
