### PR TITLE
Fixed header markup in /blog/forums

### DIFF
--- a/_posts/2018-01-19-forums.md
+++ b/_posts/2018-01-19-forums.md
@@ -14,7 +14,7 @@ The following @swift.org email lists will continue to function as before:
  * [conduct@swift.org](mailto:conduct@swift.org)
  * [swift-infrastructure@swift.org](mailto:swift-infrastructure@swift.org)
 
-####Forum Structure
+#### Forum Structure
 After discussion with the Swift Discourse working group, the forum has been slightly restructured, as opposed to simply mirroring the existing mailing list categories.  There will be four main categories, **Evolution**, **Development**, **Using Swift**, and **Site Feedback**.  The Evolution and Development categories will have a number of subcategories as follows:
 
 * **Evolution:** Announce, Pitches, Proposal Reviews, Discussion
@@ -25,18 +25,18 @@ Some of these categories, such as the announcement and CI Notification sub-categ
 
 In addition to categories, forum posts can also be categorized by use of tags.  A forum post can have many different tags added by the poster.  This is a great way to make it easy to find posts relating to certain topics, and to mark topics of interest (such as issues relating to specific projects) so that they can be easily found.
 
-####Accounts
+#### Accounts
 Accounts can be set up using either email registration, or GitHub accounts.  For those who have previously sent messages to the various Swift mailing lists, a staged account will already be set up, and you can [take control of the account](https://forums.swift.org/faq), provided you still have control of that email address.
 
 Within the forums, users can be tagged as “@Username” and can get notifications based on that tagging.
 
-####Email
+#### Email
 You can choose to get email notifications for tracked categories tags, and can also choose to mute certain categories or topics within tracked categories.  Replies via email to forum topics will be posted in the forums.  In order to create new topics via email, there will be an email address corresponding to each category/subcategory (similar to a mailing list email address) that can be used.
 
-####Code of Conduct
+#### Code of Conduct
 All forum activity is expected to conform to the Swift Code of Conduct.  The Code of Conduct will be prominently posted on the site. Violations can be anonymously flagged via the forum for review by administrators.
 
-####FAQ
+#### FAQ
 Please visit the [FAQ](https://forums.swift.org/faq) for  answers to common questions, procedures, and links.
 
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

I was working on #369 and looking for an announcement of Swift Forums launch, so that I could replace links to Swift Mailing lists, and add a little snippet on why that change was made. 

Found the post — it was slightly broken, so I thought I'd fix it while I'm here.

### Modifications:

Uh, well, I slammed the space bar five times. I'm shy to even blast the email notification about this pull request because of how small this change is, but hey. Since this change is not directly related to the link URL checker, it goes into it's own little PR.

| Before | After|
|--------|------|
| <img width="1612" alt="Screenshot 2023-09-14 at 9 33 29 PM" src="https://github.com/apple/swift-org-website/assets/43633/ac645f3c-6c53-4630-8c10-b99bddfa8c1c"> | <img width="1612" alt="Screenshot 2023-09-14 at 9 34 19 PM" src="https://github.com/apple/swift-org-website/assets/43633/85a8cb50-1f17-4cc1-83d8-1e249363c1d9"> |
