### PR TITLE
Fixed swift mailing lists links

### DIFF
--- a/_posts/2016-03-21-swift-2.2-released.md
+++ b/_posts/2016-03-21-swift-2.2-released.md
@@ -54,7 +54,6 @@ The tag `swift-2.2-RELEASE` designates the specific revisions in those repositor
 
 The `swift-2.2-branch` will remain open &mdash; but under the same [release management process](/blog/swift-2-2-release-process/) &mdash; to accumulate changes for a potential future bug-fix "dot" release.
 
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2016-05-06-swift-3.0-release-process.md
+++ b/_posts/2016-05-06-swift-3.0-release-process.md
@@ -139,6 +139,10 @@ goes into effect for the Swift 3.0 release as the release converges:
 Please feel free to email [swift-dev] or [Ted Kremenek] directly concerning any
 questions about the release management process.
 
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}).
+
 ## Pull Requests for Developer Previews
 
 All pull requests nominating changes for inclusion in developer preview
@@ -169,7 +173,7 @@ useful.
 pull requests** that are accepted by the corresponding release manager.
 
 [Ted Kremenek]: https://github.com/tkremenek
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
+[swift-dev]: https://lists.swift.org/pipermail/swift-dev/
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2016-09-13-swift-3.0-released.md
+++ b/_posts/2016-09-13-swift-3.0-released.md
@@ -144,7 +144,6 @@ The tag `swift-3.0-RELEASE` designates the specific revisions in those repositor
 
 The `swift-3.0-branch` will remain open, but under the same [release management process](/blog/swift-3-0-release-process/), to accumulate changes for a potential future bug-fix "dot" release.
 
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2016-1-05-swift-2.2-release-process.md
+++ b/_posts/2016-1-05-swift-2.2-release-process.md
@@ -114,6 +114,10 @@ goes into effect for the Swift 2.2 release as the release converges:
 Please feel free to email [swift-dev] or Ted directly concerning any
 questions about the release management process.
 
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}).
+
 ### Pull Requests
 
 All pull requests nominating changes for inclusion in the
@@ -147,7 +151,7 @@ aforementioned technical review.  Once restrictive change control is
 in place, only the release manager is allowed to accept a pull request
 into `swift-2.2-branch`.
 
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
+[swift-dev]: https://lists.swift.org/pipermail/swift-dev/
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2016-12-9-swift-3.1-release-process.md
+++ b/_posts/2016-12-9-swift-3.1-release-process.md
@@ -17,7 +17,7 @@ Swift 3.1 is intended to be released in the spring of 2017.
 
 It is a strong goal that the vast majority of sources that built with the Swift 3.0 compiler continue to build with the Swift 3.1 compiler.  The exception will be bug fixes to the compiler that cause it to reject code that should never have been accepted in the first place.  These cases should be relatively rare in practice.
 
-A description of the intent for source compatibility for Swift releases can be found on a [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161128/029099.html) on the [swift-evolution](https://lists.swift.org/mailman/listinfo/swift-evolution) mailing list.
+A description of the intent for source compatibility for Swift releases can be found on a [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161128/029099.html) on the [swift-evolution](https://lists.swift.org/pipermail/swift-evolution/) mailing list.
 
 Please file [bug reports](https://bugs.swift.org) if you encounter cases where the Swift 3.1 compiler unexpectedly rejects code that previously compiled with the Swift 3.0 compiler.
 
@@ -97,6 +97,10 @@ The overall management of the release will be overseen by the following individu
 Please feel free to email [swift-dev] or [Ted Kremenek] directly concerning any
 questions about the release management process.
 
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}).
+
 ## Pull Requests for Release Branch
 
 All pull requests nominating changes for inclusion in the release branch
@@ -126,7 +130,7 @@ useful.
 **All change** going into the `swift-3.1-branch` (outside changes being merged in automatically from `master`) **must go through pull requests** that are accepted by the corresponding release manager.
 
 [Ted Kremenek]: https://github.com/tkremenek
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
+[swift-dev]: https://lists.swift.org/pipermail/swift-dev/
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2017-01-26-bridging-pch.md
+++ b/_posts/2017-01-26-bridging-pch.md
@@ -37,4 +37,10 @@ To try it out in the meantime, install a compiler that supports it, open the bui
 
 If you have a project with a large bridging header, please try using this new mode.
 If you encounter problems, please file a bug in either [Swift.org's bug-tracking system](https://bugs.swift.org/) or [Apple's](https://bugreport.apple.com/).
-General feedback is also welcome by emailing the [swift-users@swift.org](https://lists.swift.org/mailman/listinfo/swift-users) mailing list, or on [Twitter](https://twitter.com/swiftlang) (mention `#SwiftBridgingPCH`).
+General feedback is also welcome by emailing the [swift-users mailing list](https://lists.swift.org/pipermail/swift-users/) mailing list, or on [Twitter](https://twitter.com/swiftlang) (mention `#SwiftBridgingPCH`).
+
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}). A place for general
+> feedback is the [Using Swift](https://forums.swift.org/c/swift-users/)
+> category on the forums.

--- a/_posts/2017-08-22-swift-local-refactoring.md
+++ b/_posts/2017-08-22-swift-local-refactoring.md
@@ -344,7 +344,7 @@ Swift's [issue database] contains [several ideas of refactoring transformations]
 If you'd like to propose new refactoring ideas, filing a task in Swift's [issue database] with
 label `Refactoring` will be sufficient.
 
-For further help with implementing refactoring transformations, please see the [documentation] or feel free to ask questions on the [swift-dev](https://lists.swift.org/mailman/listinfo/swift-dev) mailing list.
+For further help with implementing refactoring transformations, please see the [documentation] or feel free to ask questions on the [swift-dev](https://lists.swift.org/pipermail/swift-dev/) mailing list.
 
 [sourcekitd]: https://github.com/apple/swift/tree/master/tools/SourceKit
 [ResolvedCursorInfo]: https://github.com/apple/swift/blob/7f29b362d68eb990a592257850aabadb24de61df/include/swift/IDE/Utils.h#L158

--- a/_posts/2017-10-17-swift-4.1-release-process.md
+++ b/_posts/2017-10-17-swift-4.1-release-process.md
@@ -93,6 +93,10 @@ The overall management of the release will be overseen by the following individu
 Please feel free to email [swift-dev] or [Ted Kremenek] directly concerning any
 questions about the release management process.
 
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}).
+
 ## Pull Requests for Release Branch
 
 In order for a pull request to be considered for inclusion in the release branch it must include the following information:
@@ -119,7 +123,7 @@ useful.
 **All change** going into the `swift-4.1-branch` (outside changes being merged in automatically from `master`) **must go through pull requests** that are accepted by the corresponding release manager.
 
 [Ted Kremenek]: https://github.com/tkremenek
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
+[swift-dev]: https://lists.swift.org/pipermail/swift-dev/
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2017-2-16-swift-4.0-release-process.md
+++ b/_posts/2017-2-16-swift-4.0-release-process.md
@@ -39,7 +39,7 @@ Here are some examples of what this interoperability enables:
 
 Overall, this scheme will allow existing Swift 3 code to more gradually migrate to Swift 4 (e.g., a target or package at a time).
 
-A more detailed description of the intent for source compatibility for Swift releases can be found on a [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161128/029099.html) on the [swift-evolution](https://lists.swift.org/mailman/listinfo/swift-evolution) mailing list.
+A more detailed description of the intent for source compatibility for Swift releases can be found on a [thread](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161128/029099.html) on the [swift-evolution](https://lists.swift.org/pipermail/swift-evolution/) mailing list.
 
 ## Snapshots of Swift 4
 
@@ -114,6 +114,10 @@ The overall management of the release will be overseen by the following individu
 Please feel free to email [swift-dev] or [Ted Kremenek] directly concerning any
 questions about the release management process.
 
+> Note: Swift mailing lists have been shut down, archived, and replaced with
+> [Swift Forums](https://forums.swift.org). See
+> [the announcement here]({% post_url 2018-01-19-forums %}).
+
 ## Pull Requests for Release Branch
 
 All pull requests nominating changes for inclusion in the release branch
@@ -143,7 +147,7 @@ useful.
 **All change** going into the `swift-4.0-branch` (outside changes being merged in automatically from `master`) **must go through pull requests** that are accepted by the corresponding release manager.
 
 [Ted Kremenek]: https://github.com/tkremenek
-[swift-dev]: https://lists.swift.org/mailman/listinfo/swift-dev
+[swift-dev]: https://lists.swift.org/pipermail/swift-dev/
 [swift]: https://github.com/apple/swift
 [swift-llvm]: https://github.com/apple/swift-llvm
 [swift-clang]: https://github.com/apple/swift-clang

--- a/_posts/2018-01-19-forums.md
+++ b/_posts/2018-01-19-forums.md
@@ -6,7 +6,7 @@ title: Swift Forums Now Open!
 author: najacque
 ---
 
-We are delighted to announce that the Swift project has completed the process of migrating to the [Swift Forums](https://forums.swift.org) as the primary method for discussion and communication!  The former mailing lists have been shut down and [archived](https://lists.swift.org/mailman/listinfo), and all mailing list content has been imported into the new forum system.
+We are delighted to announce that the Swift project has completed the process of migrating to the [Swift Forums](https://forums.swift.org) as the primary method for discussion and communication!  The former mailing lists have been shut down and [archived](https://lists.swift.org/pipermail/), and all mailing list content has been imported into the new forum system.
 
 The following @swift.org email lists will continue to function as before:
 


### PR DESCRIPTION
## Motivation
- This commit is part of the work to clean up all our broken links in #369. This can be shipped on its own, so I'm separating it out to keep the main PR as small as possible.

## Modifications 
- This commit replaces links to `https://lists.swift.org/mailman/listinfo` with `https://lists.swift.org/pipermail/`
- In cases where we guide users to submit feedback, I've also added a `> Note` that explains that mailing lists are now closed and archived, and they should use forums instead.

### Result:
- The posts with links to mailing lists are pretty old, but that fixes about 20-25% of all our broken links.