### PR TITLE
Fix download footnotes links

### DIFF
--- a/download/_build-platform.html
+++ b/download/_build-platform.html
@@ -67,5 +67,5 @@
     </tbody>
 </table>
 
-<sup>1</sup> Swift {{ site.data.builds.swift_releases.last.name }} is available as part of [{{ include.platform.xcode }}](https://itunes.apple.com/app/xcode/id497799835).<br>
-<sup>2</sup> Swift {{ site.data.builds.swift_releases.last.name }} Windows 10 toolchain is provided by [Saleem Abdulrasool](https://github.com/compnerd). Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br>
+<sup>1</sup> Swift {{ site.data.builds.swift_releases.last.name }} is available as part of <a href="https://itunes.apple.com/app/xcode/id497799835">{{ include.platform.xcode }}</a>.<br>
+<sup>2</sup> Swift {{ site.data.builds.swift_releases.last.name }} Windows 10 toolchain is provided by <a href="https://github.com/compnerd">Saleem Abdulrasool</a>. Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br>


### PR DESCRIPTION
Fixes the links in downloads > older releases blocks in `download/_build-platform.html`. The links used markdown syntax in a html file, and hence would not render correctly.

The first block of footnotes on the page rendered correctly, only the "Older releases" were broken. I've only spotted them because some of the Xcode download links were broken.

After/before:
<img width="1512" alt="Screenshot 2023-09-17 at 12 26 04 PM" src="https://github.com/apple/swift-org-website/assets/43633/c8c7b174-c84a-4aa8-9c97-1c2d410e996c">
