### PR TITLE
Update Swift Debugger project link to current active repository

### DIFF
--- a/lldb/index.md
+++ b/lldb/index.md
@@ -4,7 +4,7 @@ title: REPL and Debugger
 ---
 
 The Swift.org community makes use of the
-[LLDB debugger](https://github.com/apple/swift-lldb) to provide a
+[LLDB debugger](https://github.com/apple/llvm-project/tree/next/lldb) to provide a
 rich REPL as well as the debugging environment for the Swift Language.
 Swift is tightly coupled to the version of the  Swift compiler embedded in the
 debugger.  Tight integration of compiler and debugger enables accurate


### PR DESCRIPTION
Update Swift Debugger project link to current active repository
Currently if you click through the link on this page it takes you to the archived swift-lldb repository.

Update Swift Debugger project link to point to the current active repository's lldb subdirectory.

### Motivation:

Currently if you click through the link on swift.org lldb page it takes you to the archived swift-lldb repository. The motivation for this change is to make it easier for visitors to the site to find the up-to-date lldb source code in the apple/llvm-project repository.

### Modifications:

Changed the URL for the "LLDB debugger" link from:

https://github.com/apple/swift-lldb 

to:

https://github.com/apple/llvm-project/tree/next/lldb


### Result:

After this change clicking the "LLDB debugger" link will take the reader to the lldb subdirectory of the llvm-project repopsitory.
