### PR TITLE
Fix code typo in the "Swift 5.9 Released" blogpost

### DIFF
--- a/_posts/2023-09-18-swift-5.9-released.md
+++ b/_posts/2023-09-18-swift-5.9-released.md
@@ -75,7 +75,7 @@ func all<each Wrapped>(_ optional: repeat (each Wrapped)?) -> (repeat each Wrapp
 Calling an API that uses parameter packs is intuitive and requires no extra work:
 
 ```swift
-let (int, double, string, bool) = all(optionalInt, optionalDouble, optionalString, optionalBool) {
+if let (int, double, string, bool) = all(optionalInt, optionalDouble, optionalString, optionalBool) {
   print(int, double, string, bool)
 }
 else {


### PR DESCRIPTION
### Modifications:

Added the missing `if` keyword in front of let

### Result:

Code with valid syntax
