### PR TITLE
Prefer linking to GitHub profiles in blog post bylines

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,10 +18,10 @@ layout: base
         {% endif %}
 
         <span class="author">
-          {% if author.twitter %}
-            <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
-          {% elsif author.github %}
+          {% if author.github %}
             <a href="https://github.com/{{ author.github }}/" rel="nofollow" title="{{ author.name }} (@{{ author.github}}) on GitHub">{{ author.name }}</a>
+          {% elsif author.twitter %}
+            <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
           {% else %}
             {{ author.name }}
           {% endif %}


### PR DESCRIPTION
This PR reverses the preference order of the link used in blog post bylines.

This change will link to the author’s GitHub profile if present, then fall back to link to the Twitter/X profile if present, finally displaying no link if neither is present.

Twitter/X now requires being logged-in to view profile information. GitHub displays profile information without being logged-in. This change provides a better experience by not requiring a user to be logged into any service to view the profile information linked from a blog post byline.

The change is minor, changing the order in which presence of the account info is checked. I’ve tested this on a local copy of the site.