### PR TITLE
Add an invitation to contribute to TSPL below its docs links.

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -25,6 +25,8 @@ offering a guided tour, a comprehensive guide, and a formal reference of the lan
   </div>
 </div>
 
+We welcome your contributions to the book --- pull requests, new issues, and comments on existing topics --- in [the book's repository](https://github.com/apple/swift-book).
+
 #### Translations
 We encourage you to participate in translating _The Swift Programming Language_ into other languages.
 Get involved with an existing translation project, or start a new one.


### PR DESCRIPTION
### Motivation:

Someone suggested that such an invitation in this part of the site might make it more obvious that we're open to contributions.

### Modifications:

Added a link and encouragement to contribute below the links to the Swift book on documentation/index.md.

### Result:

Readers are more aware that the book is open to contributions.