### PR TITLE
Fix download footnotes for older releases

### DIFF
--- a/download/_build-platform.html
+++ b/download/_build-platform.html
@@ -67,5 +67,5 @@
     </tbody>
 </table>
 
-<sup>1</sup> Swift {{ site.data.builds.swift_releases.last.name }} is available as part of <a href="https://itunes.apple.com/app/xcode/id497799835">{{ include.platform.xcode }}</a>.<br>
-<sup>2</sup> Swift {{ site.data.builds.swift_releases.last.name }} Windows 10 toolchain is provided by <a href="https://github.com/compnerd">Saleem Abdulrasool</a>. Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br>
+<sup>1</sup> Swift {{ include.platform.name }} is available as part of <a href="https://itunes.apple.com/app/xcode/id497799835">{{ include.platform.xcode }}</a>.<br>
+<sup>2</sup> Swift {{ include.platform.name }} Windows 10 toolchain is provided by <a href="https://github.com/compnerd">Saleem Abdulrasool</a>. Saleem is the platform champion for the Windows port of Swift and this is an official build from the Swift project. <br><br>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Fixes #410.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Used the included `platform` data in the build platform component instead of always the latest available version.

### Result:

<!-- _[After your change, what will change.]_ -->

Correct Swift version in footnotes:

<img width="794" alt="CleanShot 2023-09-26 at 18 19 36" src="https://github.com/apple/swift-org-website/assets/35671299/a554642d-501e-4be8-aa27-772f951b4371">

