### PR TITLE
Add version 5.10 to evolution dashboard script

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -35,6 +35,7 @@ var languageVersions = [
   '5.7',
   '5.8',
   '5.9',
+  '5.10',
   'Next'
 ]
 


### PR DESCRIPTION
The Swift 5.10 release process was [announced](https://forums.swift.org/t/swift-5-10-release-process/66911).

Adding version 5.10 to the evolution dashboard script so proposals implemented in 5.10 will filter properly.