### PR TITLE
Fixed typo in a code sample in the 5.9 debugging post

### DIFF
--- a/_posts/2023-09-28-whats-new-swift-debugging-5.9.md
+++ b/_posts/2023-09-28-whats-new-swift-debugging-5.9.md
@@ -51,7 +51,7 @@ func use<T>(_ t: T) {
 }
 
 use(5)
-use("Hello!”)
+use("Hello!")
 ```
 
 Running `po T.self`, when stopped in `use`, will print `Int` when coming in through the first call, and `String` in the second.
@@ -100,7 +100,7 @@ error: <EXPR>:3:1: error: cannot find 'a' in scope
 42
 ```
 
-<!--- 
+<!---
 In fact, the Swift language's scoping rules allow some astonishing things to be done with variable bindings:
 
 ```swift


### PR DESCRIPTION
Reported to me by a member of the community. Just a incorrect quote typo.