### PR TITLE
Refine Swift version filter buttons on evolution dashboard

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -295,7 +295,7 @@ function renderSearchBar () {
 
   if (implementedCheckboxIfPresent) {
     // Add an extra row of options to filter by language version
-    var versionRowHeader = html('h5', { id: 'version-options-label', className: 'hidden' }, 'Language Version')
+    var versionRowHeader = html('h5', { id: 'version-options-label', className: 'hidden' }, 'Swift Version')
     var versionRow = html('ul', { id: 'version-options', className: 'filter-list hidden' })
 
     var versionOptions = languageVersions.map(function (version) {
@@ -310,7 +310,7 @@ function renderSearchBar () {
           tabindex: '0',
           role: 'button',
           'for': 'filter-by-swift-' + _idSafeName(version)
-        }, 'Swift ' + version)
+        }, version)
       ])
     })
 


### PR DESCRIPTION
This PR reduces visual clutter and enables a more compact interface by using only version number on version filter buttons.

- This removes 20 repeated occurrences of 'Swift', one on each button.
- Changes 'Language Version' heading to 'Swift Version' preserving the clarity of the repeated usages of 'Swift'

This change has been tested on the desktop as well as on an iPhone SE and iPhone 14 Pro, to verify adequate tap target areas.

See Issue #295 for a detailed discussion of other variations.

### Current:
In the current version filter on the evolution dashboard, the word ’Swift’ is repeated 20 times, once per filter:

<img width="673" alt="Screenshot 2023-09-30 at 5 54 31 AM" src="https://github.com/apple/swift-org-website/assets/470139/d994e7a3-1341-4311-8369-02ebb8fed723">

### With PR:
The pull request changes ‘Language Version’ to ’Swift Version’ and removes ’Swift’ from each button:

<img width="671" alt="Screenshot 2023-09-30 at 5 54 47 AM" src="https://github.com/apple/swift-org-website/assets/470139/6a91bd99-92fc-4071-a358-1d9608021e5d">

