### PR TITLE
[Windows] Fixes version of the Python needed for LLDB to working properly

### DIFF
--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -6,7 +6,7 @@
 
    ~~~ batch
    winget install Git.Git
-   winget install Python.Python.3.10
+   winget install Python.Python.3.9
    winget install Microsoft.VisualStudio.2019.Community —force —custom "—add Microsoft.VisualStudio.Component.Windows10SDK.19041 —add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
    ~~~
 


### PR DESCRIPTION
### Motivation:

It seems, Installation Guide for Windows has incorrect version of Python specified.
See https://forums.swift.org/t/unable-to-debug-on-windows/67609

### Modifications:

I've changed version of Python required from `3.10` to `3.9`

### Result:

The issue with debugger is solved.
