### PR TITLE
Documentation correction

### DIFF
--- a/server/guides/deploying/ubuntu.md
+++ b/server/guides/deploying/ubuntu.md
@@ -31,7 +31,7 @@ Once inside the project folder, use the following command to build the app thoug
 docker run --rm \
   -v "$PWD:/workspace" \
   -w /workspace \
-  swift:5.2-bionic  \
+  swift:5.7-bionic  \
   /bin/bash -cl ' \
      swift build && \
      rm -rf .build/install && mkdir -p .build/install && \

--- a/server/guides/deploying/ubuntu.md
+++ b/server/guides/deploying/ubuntu.md
@@ -25,7 +25,7 @@ git clone https://github.com/apple/swift-nio.git
 cd swift-nio
 ```
 
-Once inside the project folder, use the following command to build the app though Docker and copy all build arifacts into `.build/install`. Since this example will be deploying to Ubuntu 18.04, the `-bionic` Docker image is used to build.
+Once inside the project folder, use the following command to build the app though Docker and copy all build artifacts into `.build/install`. Since this example will be deploying to Ubuntu 18.04, the `-bionic` Docker image is used to build.
 
 ```sh
 docker run --rm \


### PR DESCRIPTION
Hi ! I found an error for the docker command from the Ubuntu deployment guide : 

**/workspace: error: package at '/workspace' is using Swift tools version 5.7.0 but the installed version is 5.2.0**

### Modifications:

I just changed le bionic version from 2 to 7. The final command looks like this : 

```
docker run --rm \
  -v "$PWD:/workspace" \
  -w /workspace \
  swift:5.7-bionic  \
  /bin/bash -cl ' \
     swift build && \
     rm -rf .build/install && mkdir -p .build/install && \
     cp -P .build/debug/NIOHTTP1Server .build/install/ && \
     cp -P /usr/lib/swift/linux/lib*so* .build/install/'

```

This version works !
