### PR TITLE
Add upcoming feature flag for SE-409

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -50,6 +50,7 @@ const upcomingFeatureFlags = new Map([
   ['SE-0354', 'BareSlashRegexLiterals'],
   ['SE-0384', 'ImportObjcForwardDeclarations'],
   ['SE-0401', 'DisableOutwardActorInference'],
+  ['SE-0409', 'InternalImportsByDefault'],
 ])
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */


### PR DESCRIPTION
Until the Swift evolution parsing tool is updated, upcoming feature flags are included in the JavaScript that generates the Swift evolution dashboard.

This adds the upcoming feature flag for SE-409.