### PR TITLE
Revise WinGet and Scoop installation guide

### DIFF
--- a/install/windows/_scoop.md
+++ b/install/windows/_scoop.md
@@ -13,12 +13,12 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
 
    ~~~ batch
    scoop bucket add versions
-   scoop install python310
+   scoop install python39
    ~~~
 
 0. Install platform dependencies:
 
-   The platform dependencies cannot be installed through Scoop as the install rules cannot install all required components. They will be installed through the Visual Studio installer.
+   The platform dependencies cannot be installed through Scoop as the install rules cannot install all required components. They will be installed through the Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
 
    <div class="warning" markdown="1">
    This code snippet must be run in a traditional Command Prompt (`cmd.exe`).

--- a/install/windows/_scoop.md
+++ b/install/windows/_scoop.md
@@ -16,12 +16,6 @@ Invoke-RestMethod get.scoop.sh | Invoke-Expression
    scoop install python310
    ~~~
 
-   Start up a new command-line shell (eg. Command Prompt, Windows PowerShell) and install the Python library `six`.
-
-   ~~~ batch
-   pip install six
-   ~~~
-
 0. Install platform dependencies:
 
    The platform dependencies cannot be installed through Scoop as the install rules cannot install all required components. They will be installed through the Visual Studio installer.

--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -17,11 +17,3 @@
    ~~~ batch
    winget install --id Swift.Toolchain -e
    ~~~
-
-0. Install required Python libraries:
-
-   Start up a new command-line shell (eg. Command Prompt, Windows PowerShell) and install the Python library `six`.
-
-   ~~~ batch
-   pip install six
-   ~~~

--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -2,22 +2,26 @@
 
 [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) (aka WinGet) comes pre-installed with Windows 11 (21H2 and later). It can also be found in the [Microsoft Store](https://www.microsoft.com/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
-0. Install required dependencies:
+0. Install required Visual Studio components:
+
+   Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.
 
    ~~~ batch
-   winget install --id Git.Git -e
-   winget install --id Python.Python.3.9 -e
    winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
    ~~~
+
+0. Install Swift and other dependencies:
+
+   Install the latest Swift developer package, as well as compatible Git and Python tools if they don't exist.
+
+   ~~~ batch
+   winget install --id Swift.Toolchain -e
+   ~~~
+
+0. Install required Python libraries:
 
    Start up a new command-line shell (eg. Command Prompt, Windows PowerShell) and install the Python library `six`.
 
    ~~~ batch
    pip install six
-   ~~~
-
-0. Install Swift:
-
-   ~~~ batch
-   winget install --id Swift.Toolchain -e
    ~~~


### PR DESCRIPTION
Revise the WinGet and Scoop installation guide to make them clearer and more robust.

### Motivation:

Due to different CI environments being used, different Swift on Windows releases depend on different minor releases of Python. I’ve managed to update all WinGet manifests based on the [analysis](https://github.com/stevapple/swift-windows-toolchain-analysis), and we should drop manual dependency installation step and let WinGet decide what dependencies to install instead.

### Modifications:

In `install/_winget.md`:
- No longer suggest users to manually install Git and Python;
- No longer require installing Python module `six`;
- Clarify the Visual Studio install step;
- Add a note about Visual Studio edition choosing.

In `install/_scoop.md`:
- No longer require installing Python module `six`;
- Add a note about Visual Studio edition choosing;
- Use Python 3.9 instead of 3.10 to match Swift 5.8.1+.

### Result:

- The WinGet installation guide now applies to all Swift on Windows releases (published in WinGet).
- The Scoop installation guide now works for Swift 5.8.1+.