### PR TITLE
Stop using non-standard search event on evolution dashboard

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -580,7 +580,7 @@ function addEventListeners() {
   var searchInput = document.querySelector('#search-filter')
 
   // Typing in the search field causes the filter to be reapplied.
-  searchInput.addEventListener('search', filterProposals)
+  searchInput.addEventListener('input', filterProposals)
 
   // Each of the individual statuses needs to trigger filtering as well
   ;[].forEach.call(document.querySelectorAll('.filter-list input'), function (element) {

--- a/swift-evolution/_dashboard.html
+++ b/swift-evolution/_dashboard.html
@@ -1,6 +1,6 @@
 <section class="evolution-dashboard">
   <div class="search-bar">
-    <input id="search-filter" class="filter" title="Search proposals" placeholder="Search" type="search" incremental />
+    <input id="search-filter" class="filter" title="Search proposals" placeholder="Search" type="search" />
     
     <div class="filter-container">
       <span role="button" id="status-filter-button" class="filter-button" aria-label="Toggle status filtering options" aria-pressed="false" tabindex="0" title="Toggle proposal status filter">


### PR DESCRIPTION
The next version of Safari removes the non-standard `search` event. This causes the search field on the evolution dashboard to stop working. The issue can be reproduced in Safari Technology Preview and Firefox.

This fix makes two changes:
- Uses the standard 'input' event instead of 'search' event
- Removes the non-standard 'incremental' attribute

The input event triggers the event listener on each change of input.

The behavior with this fix is unchanged to the behavior in the current Safari version.

Tested on macOS 14.1 in Safari, Chrome, Firefox, and Safari Technology Preview.

Fixes #440