### PR TITLE
Add Christopher Thielen to website workgroup.

### DIFF
--- a/_data/website-workgroup/members.yml
+++ b/_data/website-workgroup/members.yml
@@ -2,6 +2,10 @@
   github: alexandersandberg
   affiliation:
 
+- name: Christopher Thielen
+  github: cthielen
+  affiliation: Apple
+
 - name: Dave Verwer
   github: daveverwer
   affiliation: Swift Package Index


### PR DESCRIPTION
Add Christopher Thielen to the website workgroup membership.
