### PR TITLE
download: add Windows docker tag

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1623,5 +1623,6 @@
         - aarch64
     - name: Windows 10
       platform: Windows
+      docker: 5.9.1-windowsservercore-ltsc2022
       archs:
         - x86_64


### PR DESCRIPTION
We finally have managed to figure out how to create docker images for Windows and have created an image starting from 5.9.1. Add the tag for the release. While this requires that the host is Windows, it still is a step forward.