### PR TITLE
Fix DiscordBM link

### DIFF
--- a/_data/server-workgroup/projects.yml
+++ b/_data/server-workgroup/projects.yml
@@ -185,7 +185,7 @@
   maturity: Sandbox
   pitched: 2023-05-05
   accepted: 2023-10-04
-  url: https://github.com/apple/swift-distributed-tracing
+  url: https://github.com/DiscordBM/DiscordBM
 
 - name: Swift OpenAPI Generator
   description: A Swift package plugin that can generate the ceremony code required to make API calls, or implement API servers


### PR DESCRIPTION
DiscordBM currently has swift-distributed-tracing link.