### PR TITLE
Tweak landing page preamble

### DIFF
--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -6,6 +6,15 @@
   strong {
     font-weight: 600;
   }
+
+  span {
+    display: block;
+    padding-top: .5rem;
+  }
+
+  @media only screen and(max-width: 767px) { // same media query as in _mobile.css
+    font-size: 24px;
+  }
 }
 
 .featured-snippet {

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -12,7 +12,7 @@
     padding-top: .5rem;
   }
 
-  @media only screen and(max-width: 767px) { // same media query as in _mobile.css
+  @media only screen and(max-width: 767px) {
     font-size: 24px;
   }
 }

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Welcome to Swift.org
 atom: true
 ---
 
-<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</h1>
+<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. <span>It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</span></h1>
 
 {% for snippet in site.data.featured_snippets %}
 ```swift

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Welcome to Swift.org
 atom: true
 ---
 
-<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that's <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. <span>It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</span></h1>
+<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that’s <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. <span>It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</span></h1>
 
 {% for snippet in site.data.featured_snippets %}
 ```swift


### PR DESCRIPTION
This PR makes three minor changes to the preamble text on the swift.org landing page:

1. Begins the second sentence on a new line with a little padding above it. This makes the preamble feel less like a wall of text giving each sentence more breathing room.
2. Uses a smaller font size on mobile devices. This mirrors how other H1 headings are styled on the site.
3. Uses a typographer’s quote in the preamble.

The following screen captures show the before and after for both desktop and mobile:

### Desktop Current:
<img width="1053" alt="Screenshot 2023-12-20 at 8 40 54 AM" src="https://github.com/apple/swift-org-website/assets/470139/5efc4053-6c0a-4660-816c-fca41981193d">

---

### Desktop With Changes:
<img width="1053" alt="Screenshot 2023-12-20 at 8 39 35 AM" src="https://github.com/apple/swift-org-website/assets/470139/a3444af4-d09f-42d8-a038-1bf032ec36e1">

---

### iPhone SE Current:
<img src="https://github.com/apple/swift-org-website/assets/470139/81f381b3-7f62-4ea0-b1c6-9f9b6b5e969e" data-canonical-src="https://github.com/apple/swift-org-website/assets/470139/81f381b3-7f62-4ea0-b1c6-9f9b6b5e969e" width="300" border="1" />

---

### iPhone SE With Changes:
<img src="https://github.com/apple/swift-org-website/assets/470139/fe389d0c-0f37-46c0-b089-f82bab8f728e" data-canonical-src="https://github.com/apple/swift-org-website/assets/470139/fe389d0c-0f37-46c0-b089-f82bab8f728e-9f9b6b5e969e" width="300"/>