### PR TITLE
add section about server workgroup membership

### DIFF
--- a/sswg/index.md
+++ b/sswg/index.md
@@ -63,6 +63,14 @@ These conversations will take place on the [Swift Server forum](https://forums.s
 
 The main goal of the Swift Server workgroup is to eventually recommend libraries and tools for server application development with Swift. The difference between this workgroup and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of workgroup efforts will exist outside of the Swift language project itself. The workgroup will work to nurture, mature and recommend projects as they move into their development and release stages.
 
+## Membership
+
+Membership in the workgroup is contribution-based and expected to evolve over time. Adding new members and removing inactive ones is subject to a SSWG vote and requires unanimous agreement. A cap of two members per company is in place to avoid overweight representation. A cap of ten members total is in place to keep the group small enough to be effective. Membership term is capped at 2 years, but exiting members may re-apply at the end of their term. When multiple candidates compete for the same seat, the SSWG will vote between all candidates, with a final voting round between the two candidates that received most votes in the first round.
+
+Companies or individuals that would like to join the workgroup should apply by posting a request to the [Swift Server forum](https://forums.swift.org/c/server). Applicants will then be invited to the next available SSWG meeting to present their case.
+
+Inactive members that do not participate in four consecutive workgroup meetings will be contacted to confirm their desire to stay with the group. After missing ten consecutive meetings, the SSWG will vote on removing them from the group.
+
 ## Voting
 
 In various situations the SSWG shall hold a vote. These votes can happen on the phone, email, or via a voting service, when appropriate. SSWG members can either respond "agree, yes, +1", "disagree, no, -1", or "abstain". A vote passes with two-thirds vote of votes cast based on the SSWG charter. An abstain vote equals not voting at all.


### PR DESCRIPTION
motivation: make the membership process more transperant

changes: bring over the sswg membership section from https://github.com/swift-server/sswg/edit/main/README.md to swift.org so it is more discoverable
