### PR TITLE
Fix issue 467

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -928,17 +928,18 @@ function _setProposalVisibility(matchingProposals) {
  *   fragment --> `#?` parameter-value-list
  *   parameter-value-list --> parameter-value-pair | parameter-value-pair `&` parameter-value-list
  *   parameter-value-pair --> parameter `=` value
- *   parameter --> `proposal` | `status` | `version` | `search`
+ *   parameter --> `proposal` | `status` | `version` | `upcoming` | `search`
  *   value --> ** Any URL-encoded text. **
  *
  * For example:
  *   /#?proposal=SE-0180,SE-0123
  *   /#?status=rejected&version=3&search=access
  *
- * Four types of parameters are supported:
+ * Five types of parameters are supported:
  * - proposal: A comma-separated list of proposal IDs. Treated as an 'or' search.
- * - filter: A comma-separated list of proposal statuses to apply as a filter.
+ * - status: A comma-separated list of proposal statuses to apply as a filter.
  * - version: A comma-separated list of Swift version numbers to apply as a filter.
+ * - upcoming: A value of 'true' to apply the Upcoming Feature Flag filter.
  * - search: Raw, URL-encoded text used to filter by individual term.
  *
  * @param {string} fragment - A URI fragment to use as the basis for a search.

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -988,18 +988,20 @@ function _applyFragment(fragment) {
     document.querySelector('#search-filter').value = actions.search
   }
 
+  let hasVersionSelections = false
   if (actions.version.length) {
     var versionSelections = actions.version.map(function (version) {
       return document.querySelector('#filter-by-swift-' + _idSafeName(version))
     }).filter(function (version) {
       return !!version
     })
+    hasVersionSelections = versionSelections.length > 0
 
     versionSelections.forEach(function (versionSelection) {
       versionSelection.checked = true
     })
 
-    if (versionSelections.length) {
+    if (hasVersionSelections) {
       document.querySelector(
         '#filter-by-' + states['.implemented'].className
       ).checked = true
@@ -1008,6 +1010,7 @@ function _applyFragment(fragment) {
 
   // Track this state specifically for toggling the version panel
   var implementedSelected = false
+  let hasStatusSelections = false
 
   // Update the filter selections in the nav
   if (actions.status.length) {
@@ -1025,6 +1028,7 @@ function _applyFragment(fragment) {
     }).filter(function (status) {
       return !!status
     })
+    hasStatusSelections = statusSelections.length > 0
 
     statusSelections.forEach(function (statusSelection) {
       statusSelection.checked = true
@@ -1032,7 +1036,7 @@ function _applyFragment(fragment) {
   }
 
   // The version panel needs to be activated if any are specified
-  if (actions.version.length || implementedSelected) {
+  if (hasVersionSelections || implementedSelected) {
     ;['#version-options', '#version-options-label'].forEach(function (selector) {
       document.querySelector('.filter-options')
         .querySelector(selector).classList
@@ -1041,7 +1045,7 @@ function _applyFragment(fragment) {
   }
 
   // Specifying any filter in the fragment should activate the filters in the UI
-  if (actions.version.length || actions.status.length) {
+  if (hasVersionSelections || hasStatusSelections) {
     toggleFilterPanel()
     toggleStatusFiltering()
   }


### PR DESCRIPTION
This PR addresses Issue #467 

Without this fix, an invalid version or status in the fragment query of an evolution dashboard URL would display the filter interface. For an invalid version, it also gets the interface in a state where selecting the Implemented status hides the version filters.

Prior to this change, the script was checking the raw parameters in the query string rather than the array of validated values.

Finally this PR updates the comment that describes the fragment query syntax. 