### PR TITLE
[top naviagation] more docs cleanup

### DIFF
--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -28,28 +28,39 @@
     url: /documentation/lldb/
     description: |
       - The LLDB debugger provides a rich REPL as well as the debugging environment for the Swift Language.
+  - title: Compiler Architecture
+    url: /documentation/swift-compiler/
+    description: |
+      Overview of the Swift compiler architecture
 #----------------------------------------------------
-- header: Articles
+- header: Guides
   pages:
-  - title: Swift on Server
+  - title: Building server applications with Swift
     url: /documentation/server/
     description: |
       Swift is a general-purpose programming language with unique characteristics that make it specifically suitable for Server applications
-  - title: Mixing Swift and C++
-    url: /documentation/cxx-interop/
-    description: |
-      Swift has support for bidirectional interoperability with C++.
-      A great variety of C++ APIs can be called directly from Swift, and select Swift APIs can be used from C++.
   - title: Value and Reference types
     url: /documentation/articles/value-and-reference-types
     description: |
       Types in Swift are grouped in two categories: value types and reference types.
       Each behave differently and understanding the difference is an important part of understanding Swift.
-  - title: DocC
+  - title: Using C/C++ Library in Swift
+    url: /documentation/articles/wrapping-c-cpp-library-in-swift
+    description: |
+      There are many great libraries out there that are written in C/C++. It is possible to
+      make use of these libraries in your Swift code without having to rewrite any of them
+      in Swift.
+  - title: Mixing Swift and C++
+    url: /documentation/cxx-interop/
+    description: |
+      Swift has support for bidirectional interoperability with C++.
+      A great variety of C++ APIs can be called directly from Swift, and select Swift APIs can be used from C++.
+  - title: DocC, Swift documentation compiler
     url: /documentation/docc/
     description: |
       DocC is a documentation compiler that makes it easy for you to produce documentation for your Swift frameworks and packages.
       The compiler builds your documentation by combining the comments you write in source with extension files, articles, and tutorials that live alongside your package's source code.
+
 #----------------------------------------------------
 - header: Contributing
   pages:
@@ -72,7 +83,3 @@
     description: |
       Source compatibility test suite is a community owned resource designed to test for regressions
       in the compiler by building against a corpus of Swift source code.
-  - title: Compiler Architecture
-    url: /documentation/swift-compiler/
-    description: |
-      Overview of the Swift compiler architecture

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -17,8 +17,7 @@ If you are new to Swift, you may want to check out these additional resources.
   <div>
   {%- for entry in category.pages %}
     <div>
-    <a href="{{ entry.url }}">{{ entry.title }}</a>
-    {% if entry.description %}: {{ entry.description }}{% endif %}
+    <a href="{{ entry.url }}">{{ entry.title }}</a>{% if entry.description %}: {{ entry.description }}{% endif %}
     </div>  
     <br/>
   {% endfor %}

--- a/documentation/server/index.md
+++ b/documentation/server/index.md
@@ -33,7 +33,7 @@ It’s challenging to debug non-deterministic performance, and language-induced 
 
 ## Development guides
 
-The Swift Server Workgroup and Swift on Server community have developed a number of guides for using Swift on the server.
+The [Swift Server Workgroup](/sswg "Swift Server Workgroup") and Swift on Server community have developed a number of guides for using Swift on the server.
 They are designed to help teams and individuals running Swift Server applications on Linux and to provide orientation for those who want to start with such development.
 
 They focus on how to compile, test, deploy and debug such application and provides tips in those areas.
@@ -54,14 +54,3 @@ Additionally, there are specific guides for library developers:
 * [Adopting Swift Concurrency](/documentation/server/guides/libraries/concurrency-adoption-guidelines.html)
 
 _These guides are community effort, and all are invited to share their tips and know-how by submitting pull requests to the [Swift.org site](https://github.com/apple/swift-org-website)_.
-
-## Swift Server Workgroup
-
-The Swift Server workgroup is a steering team that promotes the use of Swift for developing and deploying server applications.
-The Swift Server workgroup:
-
-* Defines and prioritize efforts that address the needs of the Swift server community
-* Defines and run an incubation process for these efforts to reduce duplication of effort, increase compatibility and promote best practices
-* Channels feedback for Swift language features needed by the server development community to the Swift Core Team
-
-Read more about the workgroup and server incubator it runs [here](/sswg "Swift Server Workgroup").


### PR DESCRIPTION
changes:
* Articles -> Guides
* add link to new article (from rebase)
* Some article titles cleanup
* server guides landing page cleanup
* move compiler architecture under overview