### PR TITLE
Update liquid dependency to 4.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 4.2.1'
 gem 'jekyll-redirect-from'
 
+gem 'liquid', '~> 4.0.4'
+
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -66,6 +66,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2.1)
   jekyll-redirect-from
+  liquid (~> 4.0.4)
   webrick (~> 1.7)
 
 BUNDLED WITH


### PR DESCRIPTION
Adds a minimum version requirement to the "liquid" dependency to allow development with ruby 3.2 and newer
