### PR TITLE
Reduce H1 and H2 sizes

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -53,7 +53,7 @@ p {
 
 h1 {
   margin-bottom: 0.5em;
-  font-size: 3em;
+  font-size: 2.75em;
   font-weight: 300;
   line-height: 1;
   &.active + .main-nav {
@@ -63,7 +63,7 @@ h1 {
 
 h2 {
   margin-bottom: 0.5em;
-  font-size: 2.5em;
+  font-size: 2.25em;
   font-weight: 300;
   line-height: 1;
 }
@@ -481,10 +481,13 @@ article {
   header {
     width: 100%;
     display: inline-block;
-    padding-bottom: 1.5em;
 
     h1 {
       padding-bottom: 0.125em;
+    }
+
+    h2 {
+      padding-top: 0em;
     }
 
     time {

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,7 +7,7 @@ atom: true
 {% for post in site.posts %}
   <article id="{{ post.id }}" class="summary">
     <header>
-      <h1 class="title"><a href="{{ post.url }}">{{ post.title }}</a></h1>
+      <h2 class="title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
       <time pubdate datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
     </header>
     <section class="excerpt">


### PR DESCRIPTION
Slightly reduces header sizes to improve readability and removes excess whitespace.

before:
<img width="1131" alt="before" src="https://github.com/apple/swift-org-website/assets/9739930/86555da7-5ac3-4a4b-a5bb-dad17bdb6446">


after:
<img width="1131" alt="after" src="https://github.com/apple/swift-org-website/assets/9739930/184911cd-0cb8-498c-98a3-f061f15de9e4">
