### PR TITLE
Center page content

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -282,8 +282,6 @@ nav[role="navigation"] {
 }
 
 main {
-    max-width: 798px;
-    min-width: 320px;
     margin-left: 250px;
     padding: 35px 30px 0;
     min-height: 100%;
@@ -351,6 +349,10 @@ footer[role="contentinfo"] {
 }
 
 article {
+    margin: auto;
+    max-width: 798px;
+    min-width: 320px;
+
     &:first-of-type {
         padding-bottom: 36px;
     }


### PR DESCRIPTION
Updates the scss to center the article content on the page. This makes the dead space when opening the page in a wide browser less apparent.

before:
<img width="1634" alt="Screenshot 2024-01-17 at 1 13 44 PM" src="https://github.com/apple/swift-org-website/assets/9739930/65222a66-af2e-4d5d-bbf4-87ebd1f93d0b">

after:
<img width="1634" alt="Screenshot 2024-01-17 at 1 14 15 PM" src="https://github.com/apple/swift-org-website/assets/9739930/8d26da44-182e-43a9-b3b0-7f1ee1a38a73">
