### PR TITLE
fix redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,9 +21,6 @@ defaults:
             permalink: /blog/:title/
             layout: "post"
 
-gems:
-  - jekyll-redirect-from
-
 plugins:
   - jekyll-redirect-from
 

--- a/_config.yml
+++ b/_config.yml
@@ -24,5 +24,8 @@ defaults:
 gems:
   - jekyll-redirect-from
 
+plugins:
+  - jekyll-redirect-from
+
 whitelist:
   - jekyll-redirect-from


### PR DESCRIPTION
motivation: redirects seem to be broken atm, for example the https://www.swift.org/swift-compiler/ page has `redirect_from: compiler-stdlib` but that does not seem to work - https://www.swift.org/compiler-stdlib/ is not functional

changes: add the correct setup per https://github.com/jekyll/jekyll-redirect-from#how-it-works

