### PR TITLE
Add upcoming feature flag for SE-0383

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -1,6 +1,6 @@
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -49,6 +49,7 @@ const upcomingFeatureFlags = new Map([
   ['SE-0286', 'ForwardTrailingClosures'],
   ['SE-0335', 'ExistentialAny'],
   ['SE-0354', 'BareSlashRegexLiterals'],
+  ['SE-0383', 'DeprecateApplicationMain'],
   ['SE-0384', 'ImportObjcForwardDeclarations'],
   ['SE-0401', 'DisableOutwardActorInference'],
   ['SE-0409', 'InternalImportsByDefault'],


### PR DESCRIPTION
Add upcoming feature flag for [SE-0383](https://github.com/apple/swift-evolution/blob/main/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md)

### Motivation:

Swift 5.10 has `DeprecateApplicationMain` in [Features.def](https://github.com/apple/swift/blob/release/5.10/include/swift/Basic/Features.def)

### Modifications:

Update swift-evolution.js

### Result:

<https://www.swift.org/swift-evolution/#?upcoming=true>