### PR TITLE
Use 'current version' instead of specific Xcode version

### DIFF
--- a/install/macos/_macos.md
+++ b/install/macos/_macos.md
@@ -4,7 +4,7 @@
   <li class="resource featured">
     <h3>Xcode</h3>
     <p class="description">
-       Download {{ site.data.builds.swift_releases.last.xcode }} which contains the latest Swift release. 
+       Download the current version of Xcode which contains the latest Swift release. 
     </p>
     <a href="https://itunes.apple.com/app/xcode/id497799835" class="cta-secondary">Download Xcode</a>
   </li>

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -7,7 +7,7 @@ title: macOS Installation Options
 
 ## Installation via Xcode
 
-Download [{{ site.data.builds.swift_releases.last.xcode }}](https://itunes.apple.com/app/xcode/id497799835) which contains the latest Swift release. 
+Download the [current version of Xcode](https://itunes.apple.com/app/xcode/id497799835) which contains the latest Swift release. 
 
 ## Installation via Swift.org package installer
 


### PR DESCRIPTION
The Xcode version is read from the last entry of swift_releases.yml. Multiple Xcode versions can ship with the same Swift version, so the Xcode version displayed can be out of date.

The exact Xcode version is not very important to display on the page. So, instead of creating and maintaining an Xcode version data file, the text changes to say 'current version'.

Since the user will clicking through to the Mac App Store, they will see the correct version number on the app page in the store.

This fixes #493.