### PR TITLE
Add layout for articles and standardize author bylines

### DIFF
--- a/_includes/authors.html
+++ b/_includes/authors.html
@@ -1,0 +1,33 @@
+<div class="authors">
+  {% for page_author in include.authors %}
+    {% assign author = site.data.authors[page_author] %}
+    {% if author.name %}
+      <div class="byline">
+        {% if author.gravatar %}
+          <img src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=64&d=mp" alt="{{ author.name }}"/>
+        {% elsif author.github %}
+          <img src="https://www.github.com/{{ author.github }}.png?size=64" alt="{{ author.name }}"/>
+        {% else %}
+          <img src="https://www.gravatar.com/avatar/dummy?s=64&d=mp&f=y" alt="{{ author.name }}"/>
+        {% endif %}
+        <span class="author">
+          {% if author.github %}
+            <a href="https://github.com/{{ author.github }}/" rel="nofollow" title="{{ author.name }} (@{{ author.github}}) on GitHub">{{ author.name }}</a>
+          {% elsif author.twitter %}
+            <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
+          {% else %}
+            {{ author.name }}
+          {% endif %}
+        </span>
+      </div>
+      {% if page.about %}
+        {% assign about = page.about %}
+      {% elsif author.about %}
+        {% assign about = author.about %}
+      {% endif %}
+      {% if about %}
+        <div class="about">{{ about }}</div>
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,0 +1,7 @@
+---
+layout: page
+---
+{{ content }}
+<hr>
+<p>Contributed by</p>
+{% include authors.html authors=page.author %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,10 +2,7 @@
 layout: default
 ---
 
-<article class="page">
   <header>
     <h1>{{ page.title }}</h1>
   </header>
-
   {{ content }}
-</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,38 +7,7 @@ layout: base
     <h1>{{ page.title }}</h1>
 
     <time pubdate datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
-    {% for page_author in page.author %}
-    {% assign author = site.data.authors[page_author] %}
-    {% if author.name %}
-      <div class="byline">
-        {% if author.gravatar %}
-          <img src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=64&d=mp" alt="{{ author.name }}"/>
-        {% elsif author.github %}
-          <img src="https://www.github.com/{{ author.github }}.png?size=64" alt="{{ author.name }}"/>
-        {% else %}
-          <img src="https://www.gravatar.com/avatar/dummy?s=64&d=mp&f=y" alt="{{ author.name }}"/>
-        {% endif %}
-
-        <span class="author">
-          {% if author.github %}
-            <a href="https://github.com/{{ author.github }}/" rel="nofollow" title="{{ author.name }} (@{{ author.github}}) on GitHub">{{ author.name }}</a>
-          {% elsif author.twitter %}
-            <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
-          {% else %}
-            {{ author.name }}
-          {% endif %}
-        </span>
-      </div>
-      {% if page.about %}
-        {% assign about = page.about %}
-      {% elsif author.about %}
-        {% assign about = author.about %}
-      {% endif %}
-      {% if about %}
-      <div class="about">{{ about }}</div>
-      {% endif %}
-    {% endif %}
-    {% endfor %}
+    {% include authors.html authors=page.author %}
   </header>
 
   {{ content }}

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -487,36 +487,6 @@ article {
       padding-bottom: 0.125em;
     }
 
-    .byline {
-      font-size: 14px;
-      margin-bottom: 1em;
-
-      img {
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        border: 1px var(--color-fill-gray) solid;
-        position: absolute;
-        margin-right: 0.25em;
-        margin-top: -6px;
-      }
-
-      span {
-        padding-left: 42px;
-      }
-    }
-
-    .about {
-      float: none;
-      clear: both;
-      font-size: 14px;
-      font-weight: 400;
-      color: var(--color-figure-gray-tertiary);
-      border-left: 1px var(--color-figure-gray-tertiary) solid;
-      margin: 23px 3em 23px 0;
-      padding: 4px 0 4px 10px;
-    }
-
     time {
       display: block;
       text-transform: uppercase;
@@ -1097,32 +1067,34 @@ article {
   text-align: center;
 }
 
-.article-byline {
-  font-size: 14px;
-  margin-bottom: 1em;
-
-  img {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 1px var(--color-fill-gray) solid;
-    position: absolute;
-    margin-right: 0.25em;
-    margin-top: -6px;
+.authors {
+  .byline {
+    font-size: 14px;
+    margin-bottom: 1em;
+  
+    img {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: 1px var(--color-fill-gray) solid;
+      position: absolute;
+      margin-right: 0.25em;
+      margin-top: -6px;
+    }
+  
+    span {
+      padding-left: 42px;
+    }
   }
-
-  span {
-    padding-left: 42px;
+  
+  .about {
+    float: none;
+    clear: both;
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--color-figure-gray-tertiary);
+    border-left: 1px var(--color-figure-gray-tertiary) solid;
+    margin: 23px 3em 23px 0;
+    padding: 4px 0 4px 10px;
   }
-}
-
-.article-about {
-  float: none;
-  clear: both;
-  font-size: 14px;
-  font-weight: 400;
-  color: var(--color-figure-gray-tertiary);
-  border-left: 1px var(--color-figure-gray-tertiary) solid;
-  margin: 23px 3em 23px 0;
-  padding: 4px 0 4px 10px;
 }

--- a/documentation/articles/value-and-reference-types.md
+++ b/documentation/articles/value-and-reference-types.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: article
 date: 2023-04-29 12:00:00
 title: Value And Reference Types In Swift
 author: [jamesdempsey]
@@ -133,50 +133,3 @@ This means a struct can contain an array of structs, maybe a dictionary of key v
 ### Conclusion
 Understanding what value types and reference types are and the differences in how they behave is an important part of learning Swift and being able to reason about your code. The choice between the two often comes down to a choice between declaring a type as a `struct` or a `class`. You can learn more about structures and class in the [Structures and Classes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/classesandstructures) chapter of *The Swift Programming Language*.
 
-<style>
-@media only print {
-  nav { display: none; }
-
-  article header h1::after {
-    content: "DRAFT POST for Swift.org";
-    display: block;
-    font-size: 1.75rem;
-    margin-top: .5em;
-    color: crimson;
-    font-weight: 600;
-  }
-}
-</style>
-
-<hr>
-Contributed by
-    {% for page_author in page.author %}
-{% assign author = site.data.authors[page_author] %}
-{% if author.name %}
-  <div class="article-byline">
-    {% if author.gravatar %}
-      <img src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=64&d=mp" alt="{{ author.name }}"/>
-    {% else %}
-      <img src="https://www.gravatar.com/avatar/dummy?s=64&d=mp&f=y" alt="{{ author.name }}"/>
-    {% endif %}
-
-    <span class="author">
-      {% if author.twitter %}
-        <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
-      {% elsif author.github %}
-        <a href="https://github.com/{{ author.github }}/" rel="nofollow" title="{{ author.name }} (@{{ author.github}}) on GitHub">{{ author.name }}</a>
-      {% else %}
-        {{ author.name }}
-      {% endif %}
-    </span>
-  </div>
-  {% if page.about %}
-    {% assign about = page.about %}
-  {% elsif author.about %}
-    {% assign about = author.about %}
-  {% endif %}
-  {% if about %}
-  <div class="article-about">{{ about }}</div>
-  {% endif %}
-{% endif %}
-{% endfor %}

--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: article
 date: 2023-11-08 12:00:00
 title: Wrapping C/C++ Library in Swift
 author: [etcwilde, ktoso, yim-lee]
@@ -352,51 +352,3 @@ public struct WriteOptions: ~Copyable {
 
 The downside of non-copyable types is that currently they cannot be used in all contexts. For example in Swift 5.9 it is not possible to store a non-copyable type as a field, or pass them through closures (as the closure could be used many times, which would break the uniqueness that a non-copyable type needs to guarantee). The upside is that, unlike classes, no reference counting is performed on non-copyable types.
 
-
-<style>
-@media only print {
-  nav { display: none; }
-
-  article header h1::after {
-    content: "DRAFT POST for Swift.org";
-    display: block;
-    font-size: 1.75rem;
-    margin-top: .5em;
-    color: crimson;
-    font-weight: 600;
-  }
-}
-</style>
-
-<hr>
-Contributed by
-    {% for page_author in page.author %}
-{% assign author = site.data.authors[page_author] %}
-{% if author.name %}
-  <div class="article-byline">
-    {% if author.gravatar %}
-      <img src="https://www.gravatar.com/avatar/{{ author.gravatar }}?s=64&d=mp" alt="{{ author.name }}"/>
-    {% else %}
-      <img src="https://www.gravatar.com/avatar/dummy?s=64&d=mp&f=y" alt="{{ author.name }}"/>
-    {% endif %}
-
-    <span class="author">
-      {% if author.twitter %}
-        <a href="https://twitter.com/{{ author.twitter }}/" rel="nofollow" title="{{ author.name }} (@{{ author.twitter}}) on Twitter">{{ author.name }}</a>
-      {% elsif author.github %}
-        <a href="https://github.com/{{ author.github }}/" rel="nofollow" title="{{ author.name }} (@{{ author.github}}) on GitHub">{{ author.name }}</a>
-      {% else %}
-        {{ author.name }}
-      {% endif %}
-    </span>
-  </div>
-  {% if page.about %}
-    {% assign about = page.about %}
-  {% elsif author.about %}
-    {% assign about = author.about %}
-  {% endif %}
-  {% if about %}
-  <div class="article-about">{{ about }}</div>
-  {% endif %}
-{% endif %}
-{% endfor %}


### PR DESCRIPTION
This is follow-on work from content improvements.

At that time one documentation article was added. The author bylines for articles are at the bottom of the page, as opposed to blog posts where they are at the top. The layout of the bylines are the same for both.

For expediency, the byline CSS was copied and the byline HTML was added directly to single article. Now there are two articles with more likely to come, so this PR adds a layout for article and factors out the author bylines into a single HTML include and CSS.

A few other incidental clean up items are also included as detailed in the list below.

I tested this PR comparing to the live site and there were no visual changes in the author bylines. 

- Add article.html layout for documentation articles
- Move existing authors byline code to authors.html include
- Replace byline code in post.html with new include
- Use new include in article.html layout
- Remove authors code from existing articles
- Have articles use new article layout
- Remove unneeded draft printing style from existing articles
- Consolidate author byline CSS
- Remove redundant article tag from page.html
- Resolves #378