### PR TITLE
Add missing .html suffix to documentation article link

### DIFF
--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -45,7 +45,7 @@
       Swift has support for bidirectional interoperability with C++.
       A great variety of C++ APIs can be called directly from Swift, and select Swift APIs can be used from C++.
   - title: Value and Reference types
-    url: /documentation/articles/value-and-reference-types
+    url: /documentation/articles/value-and-reference-types.html
     description: |
       Types in Swift are grouped in two categories: value types and reference types.
       Each behave differently and understanding the difference is an important part of understanding Swift.


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Fixes a broken link reported by @mrcnski [here](https://github.com/apple/swift-org-website/pull/369#issuecomment-1913265108).

Once #369 is merged these should be caught in CI, but for now, we have to fix them manually.
