### PR TITLE
Update README with min Ruby 3.1 to Ruby 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Swift.org uses [Jekyll](https://jekyllrb.com), a blog-aware, static site generat
 
 Requirements
 - Git
-- Ruby 3.1 or higher
+- Ruby 3.2 or higher
   _(a Ruby installation manager, such as
   [rbenv](https://github.com/sstephenson/rbenv) or
   [RVM](https://rvm.io) is recommended, but not required)_


### PR DESCRIPTION
### Motivation:

The README file list Ruby 3.1 as min version, instead it should say Ruby 3.2

### Modifications:

Update README file with Ruby upgraded version

### Result:

README has Ruby 3.2
