### PR TITLE
Project ideas page for GSoC 2024

### DIFF
--- a/gsoc2024/index.md
+++ b/gsoc2024/index.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: Project Ideas for GSoC 2024
+---
+
+This page contains a non-exhaustive list of potential project ideas that we are keen to develop during [Google Summer of Code 2024](https://summerofcode.withgoogle.com/). If you would like to apply to GSoC as a contributor, please follow these steps to get started:
+
+1. Read through this page and the Google Summer of Code guides,
+2. Identify, or come up with your own project ideas you find interesting.
+3. Check out the [Development forum](https://forums.swift.org/c/development) to connect with potential mentors.
+- Feel free to mention the project mentors on the forums, when starting a thread about your interest in participating in a specific project they are offering to mentor.
+
+When posting on the forums about GSoC this year, please use the [`gsoc-2024` tag](https://forums.swift.org/tag/gsoc-2024), so it is easy to identify.
+
+## Tips for contacting mentors
+
+The Swift forums are powered by discourse, a discussion forums platform which also has a number of spam avoidance mechanisms built-in. If this is your first time joining the forums, you _may_ not be able to send mentors a direct-message, as this requires a minimum amount of prior participation before the "send private message" feature is automatically enabled.
+
+If you would like to reach out to a mentor privately, rather than making a public forums post, and the forums are not allowing you to send private messages (yet), please reach out to Konrad Malawski at `ktoso AT apple.com` directly via email with the `[gsoc2024]` tag in the email subject and describe the project you would like to work on – and we'll route you to the appropriate mentor.
+
+## Potential Projects
+
+We are currently collecting project ideas on the forums in the dedicated [GSoC](https://forums.swift.org/tag/gsoc-2024).
+
+Potential mentors, please feel free to propose project ideas to this page directly, by [opening a pull request]() over here to the Swift website. 
+
+You can browse previous year's project ideas here: [2023](https://www.swift.org/gsoc2023/), [2022](https://www.swift.org/gsoc2022/), [2021](https://www.swift.org/gsoc2021/), [2020](https://www.swift.org/gsoc2020/), [2019](https://www.swift.org/gsoc2019/).
+
+### Project topic proposal template 
+
+#### Project name
+
+**Project size**: Small / Medium
+
+**Recommended skills**
+
+- E.g. Proficiency in Swift, and/or C++
+- Knowledge of ...
+- Optional, experience in ... 
+
+**Description**
+
+Brief description of the project, its goals and what areas of the Swift project it relates to.
+
+**Expected outcomes/benefits/deliverables**
+
+Description of expected outcomes. Like some specific feature being implemented, or a performance improvement, or guide being written.
+This will be the basis for passing the Summer of Code assignment and the final submission of the project. 
+
+**Potential mentors**
+
+- Your name (and link to github, or other means of reaching you)
+- Optionally: additional mentors
+
+


### PR DESCRIPTION
This is necessary for our GSoC 2024 application so we need to get this merged right now, even if still empty.

It is the same shape of page and content as we did for all previous years -- could I request a quick merge here and we can then follow up with adding more content? @alexandersandberg @0xTim et al?