### PR TITLE
GSoC Add pull request link to 2024 page

### DIFF
--- a/gsoc2024/index.md
+++ b/gsoc2024/index.md
@@ -22,7 +22,7 @@ If you would like to reach out to a mentor privately, rather than making a publi
 
 We are currently collecting project ideas on the forums in the dedicated [GSoC](https://forums.swift.org/tag/gsoc-2024).
 
-Potential mentors, please feel free to propose project ideas to this page directly, by [opening a pull request]() over here to the Swift website. 
+Potential mentors, please feel free to propose project ideas to this page directly, by [opening a pull request](https://github.com/apple/swift-org-website/edit/main/gsoc2024/index.md) to the Swift website. 
 
 You can browse previous year's project ideas here: [2023](https://www.swift.org/gsoc2023/), [2022](https://www.swift.org/gsoc2022/), [2021](https://www.swift.org/gsoc2021/), [2020](https://www.swift.org/gsoc2020/), [2019](https://www.swift.org/gsoc2019/).
 


### PR DESCRIPTION
Sorry, minor addition, follow up to https://github.com/apple/swift-org-website/pull/513 -- wanted to offer a direct link to make a pull request to the newly added website.
