### PR TITLE
Trim proposal titles and adjust spacing in evolution dashboard

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -366,7 +366,7 @@ function renderProposals() {
                   target: "_blank",
                   className: "proposal-title",
                 },
-                [proposal.title]
+                [proposal.title.trim()]
               ),
             ]),
           ]),

--- a/assets/stylesheets/pages/_swift-evolution.scss
+++ b/assets/stylesheets/pages/_swift-evolution.scss
@@ -171,7 +171,7 @@
 
     .proposal-id {
         color: var(--color-evolution-secondary-fill);
-        margin-right: .2em;
+        margin-right: .45em;
         vertical-align: top;
     }
 


### PR DESCRIPTION
The proposal.json file that provides the evolution dashboard its data always puts a space character at the beginning of every title.

This change trims the title and adjusts the margin of the preceding element so there is no visual change to the page.