### PR TITLE
Add @ktoso as code owner for gsoc* pages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,3 +39,5 @@
 * @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @mschinis @shahmishal @TimTr @tomerd @cthielen
 
 /_posts/* @cthielen @TimTr @tkremenek @tomerd
+
+/gsoc*/ @ktoso


### PR DESCRIPTION
This is in order to help approving incoming proposals for google summer of code.

We discussed with @cthielen and @tkremenek earlier that in order to facilitate merging gsoc proposals easily I can be marked code owner for these pages.

I don't know how exactly this works -- happy to include "everyone else" if it's better to have more approvers for example.