### PR TITLE
Highlight current page in the navigation bar

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,7 +10,7 @@
       <ul class="navigation-links">
         {% for nav in site.data.navigation %}
           <li class="nav-item">
-            <span>
+            <span class="{% if page.url == nav.url %}active{% endif %}">
               {% if nav.url %}
                 <a href="{{ nav.url }}">{{ nav.header }}</a>
               {% else %}
@@ -51,7 +51,7 @@
   <nav class="mobile-navigation" role="navigation">
     <ul class="mobile-navigation-links">
       {% for nav in site.data.navigation %}
-        <li class="nav-item">
+        <li class="nav-item {% if page.url == nav.url %}active{% endif %}">
           <div class="link-container">
             {% if nav.url %}
               <a href="{{ nav.url }}">{{ nav.header }}</a>

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -219,11 +219,9 @@ cite {
     display: inline-block;
     margin-left: .5em;
 
-    &.active {
-      a {
-        font-weight: 700;
-        color: #F05138; // TODO: Use variable
-      }
+    .active a{
+      font-weight: 700;
+      color: var(--color-active-nav-item); 
     }
 
     &.nav-section {

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -219,7 +219,7 @@ cite {
     display: inline-block;
     margin-left: .5em;
 
-    .active a{
+    .active a {
       font-weight: 700;
       color: var(--color-active-nav-item); 
     }

--- a/assets/stylesheets/core/colors/_dark.scss
+++ b/assets/stylesheets/core/colors/_dark.scss
@@ -2,7 +2,7 @@
   --color-nav-background: var(--color-fill-tertiary);
   --color-nav-rule: #{dark-color(fill-gray-tertiary)};
   --color-active-menu-group: #{light-color(fill-tertiary)};
-
+  --color-active-nav-item: #{light-color(figure-orange)};
   --color-fill: #{dark-color(fill)};
   --color-fill-secondary: #{dark-color(fill-secondary)};
   --color-fill-tertiary: #{dark-color(fill-tertiary)};

--- a/assets/stylesheets/core/colors/_light.scss
+++ b/assets/stylesheets/core/colors/_light.scss
@@ -2,7 +2,7 @@
   --color-nav-background: var(--color-fill-secondary);
   --color-nav-rule: rgb(230, 230, 230);
   --color-active-menu-group: #{dark-color(fill-tertiary)};
-
+  --color-active-nav-item: #{dark-color(figure-orange)};
   --color-fill: #{light-color(fill)};
   --color-fill-secondary: #{light-color(fill-secondary)};
   --color-fill-tertiary: #{light-color(fill-tertiary)};


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:
As per,
- #502 
<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->
made changes to highlight current page in the navigation bar.
### Modifications:
- Updated `navigation.html`
- Updated active color to a variable `--color-active-nav-item`
<!-- _[Describe the modifications you've done.]_ -->

### Result:
The current page will be highlighted in the navigation bar.

![image](https://github.com/apple/swift-org-website/assets/73813549/b343a75e-2d94-40cd-b0c1-6ab1d4f738a0)
![image](https://github.com/apple/swift-org-website/assets/73813549/aedd3c7f-7ab9-4e8d-8155-f9e54f8d2037)

![image](https://github.com/apple/swift-org-website/assets/73813549/e33d9348-684c-42f4-bb40-7e8f11e86681)
![image](https://github.com/apple/swift-org-website/assets/73813549/56a0c904-0744-4179-b73e-3cac0959a62d)


<!-- _[After your change, what will change.]_ -->
