### PR TITLE
Add top section layout change

### DIFF
--- a/_data/featured_snippets.yml
+++ b/_data/featured_snippets.yml
@@ -5,10 +5,10 @@
       var subspecies: String?
   }
 
-  let momiji = ScientificName(genus: "Acer", species: "palmatum")
+  let momiji = ScientificName(genus: "Pin", species: "oak")
   let jsonData = try JSONEncoder().encode(momiji)
 
-  // {"genus":"Acer","species":"palmatum"}
+  // {"genus":"Pin","species":"oak"}
 - |
   struct ScientificName {
       var genus: String
@@ -18,35 +18,26 @@
       var description: String {
           var text = "\(genus) \(species)"
           if let subspecies {
-              // subspecies is guaranteed to be non-nil here.
+              // subspecies is guaranteed to be non-nil.
               text += "subsp. \(subspecies)"
           }
           return text
       }
   }
 - |
-  func squareWave(phase: Float, overtones: UInt) -> Float {
-      return (0...overtones)
-          .map {
-              let harmonic = Float($0 * 2 + 1)
-              return sinf(phase * harmonic) / harmonic
-          }
-          .reduce(0, +)
-  }
-- |
   let hello = "Hello, world!"
   let multilineString = """
-                    @@@         
-        @@          @@@@       
-      @@  @@@         @@@@@     
-      @@@@@@@@@       @@@@@    
-        @@@@@@@@@@    @@@@@@   
-          @@@@@@@@@@  @@@@@@   
-            @@@@@@@@@@@@@@@@@  
-  @           @@@@@@@@@@@@@@@  
-  @@@@@@        @@@@@@@@@@@@@  
-    @@@@@@@@@@@@@@@@@@@@@@@@@@ 
-      @@@@@@@@@@@@@@@@@@@@@@@@ 
-          @@@@@@@@@@@@@     @ 
+                    @@@
+        @@          @@@@
+      @@  @@@         @@@@@
+      @@@@@@@@@       @@@@@
+        @@@@@@@@@@    @@@@@@
+          @@@@@@@@@@  @@@@@@
+            @@@@@@@@@@@@@@@@@
+  @           @@@@@@@@@@@@@@@
+  @@@@@@        @@@@@@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@@
+      @@@@@@@@@@@@@@@@@@@@@@@@
+          @@@@@@@@@@@@@     @
                         \(hello)
   """

--- a/_data/featured_snippets.yml
+++ b/_data/featured_snippets.yml
@@ -1,11 +1,11 @@
 - |
-  struct ScientificName: Codable {
+  struct Binomial: Codable {
       var genus: String
       var species: String
       var subspecies: String?
   }
 
-  let momiji = ScientificName(genus: "Pin", species: "oak")
+  let momiji = Binomial(genus: "Pin", species: "oak")
   let jsonData = try JSONEncoder().encode(momiji)
 
   // {"genus":"Pin","species":"oak"}
@@ -18,7 +18,7 @@
       var description: String {
           var text = "\(genus) \(species)"
           if let subspecies {
-              // subspecies is guaranteed to be non-nil.
+              // subspecies guaranteed to be non-nil.
               text += "subsp. \(subspecies)"
           }
           return text

--- a/_data/featured_snippets.yml
+++ b/_data/featured_snippets.yml
@@ -5,8 +5,8 @@
       var subspecies: String?
   }
 
-  let momiji = Binomial(genus: "Pin", species: "oak")
-  let jsonData = try JSONEncoder().encode(momiji)
+  let tree = Binomial(genus: "Pin", species: "oak")
+  let jsonData = try JSONEncoder().encode(tree)
 
   // {"genus":"Pin","species":"oak"}
 - |
@@ -18,7 +18,7 @@
       var description: String {
           var text = "\(genus) \(species)"
           if let subspecies {
-              // subspecies guaranteed to be non-nil.
+              // subspecies guaranteed to be non-nil
               text += "subsp. \(subspecies)"
           }
           return text

--- a/assets/stylesheets/_mobile.scss
+++ b/assets/stylesheets/_mobile.scss
@@ -90,7 +90,6 @@
         max-width: 100%;
         min-width: 320px;
         margin-left: 0;
-        padding: 30px 30px 0;
     }
 
     footer[role="contentinfo"] {

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -385,6 +385,9 @@ main {
     display: grid;
     gap: 1rem;
     grid-template-columns: repeat(2, 1fr);
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 2rem;
 
     @media only screen and (max-width: 1280px) {
       display: block;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -848,6 +848,7 @@ code {
 }
 pre code {
   white-space: inherit;
+  font-size: 1.2em;
 }
 
 pre code .graphic {

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -105,10 +105,6 @@ h6 {
   color: var(--color-header-text);
 }
 
-div.highlighter-rouge {
-  margin-left: 13px;
-}
-
 pre {
   font-size: 14px;
   line-height: 1.6em;
@@ -382,13 +378,25 @@ cite {
 }
 
 main {
-  padding: 4rem 30px 0;
   margin: auto;
+  padding: 4rem 0 0;
+
+  .callout {
+    display: flex;
+
+    @media only screen and (max-width: 1280px) {
+      display: block;
+    }
+  }
 
   .page-wide {
     max-width: var(--content-mobile-breakpoint);
     padding: 0;
     margin: auto;
+
+    @media only screen and (max-width: 1280px) {
+      padding: 30px 30px 0;
+    }
   }
 
   .post, .page {
@@ -396,9 +404,17 @@ main {
     margin: 0 auto;
     padding: 0 30px;
 
-    @media only screen and (max-width: 767px) {
-      padding: 0;
+    @media only screen and (max-width: 1280px) {
+      padding-top: 30px;
     }
+
+    @media only screen and (max-width: 767px) {
+      padding: 30px 30px 0;
+    }
+  }
+
+  @media only screen and (max-width: 1280px) {
+    padding: 0;
   }
 }
 

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -382,7 +382,9 @@ main {
   padding: 4rem 0 0;
 
   .callout {
-    display: flex;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(2, 1fr);
 
     @media only screen and (max-width: 1280px) {
       display: block;
@@ -848,7 +850,6 @@ code {
 }
 pre code {
   white-space: inherit;
-  font-size: 1.2em;
 }
 
 pre code .graphic {

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,5 +1,5 @@
 .preamble {
-  font-size: 38px;
+  font-size: 40px;
   line-height: 1.4;
 
   strong {

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,10 +1,12 @@
 .preamble {
-  font-size: 28px;
+  font-size: 38px;
   line-height: 1.4;
   margin-bottom: 30px;
+  width: 46%;
 
   strong {
     font-weight: 600;
+    color: var(--color-figure-orange);
   }
 
   span {
@@ -12,7 +14,7 @@
     padding-top: .5rem;
   }
 
-  @media only screen and (max-width: 767px) {
+  @media only screen and (max-width: 1280px) {
     width: 100%;
     font-size: 24px;
   }
@@ -20,20 +22,29 @@
 
 .featured-snippet {
   display: none;
+  min-height: 18rem;
+  width: 52%;
+  margin-left: 2%;
 
   &.visible {
     display: block;
   }
 
-  &.highlighter-rouge {
-    margin-left: 0px;
+  .highlight {
+    height: 100%;
   }
 
   pre {
     border: 1px solid var(--color-fill-tertiary);
     border-radius: 4px;
-    padding: 1.25rem 1.5rem;
+    padding: 1rem;
     margin: 0px;
+  }
+
+  @media only screen and (max-width: 1280px) {
+    margin-left: 0;
+    width: 100%;
+    min-height: auto;
   }
 }
 

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,6 +1,7 @@
 .preamble {
   font-size: 40px;
   line-height: 1.4;
+  margin-bottom: 0;
 
   strong {
     font-weight: 600;
@@ -8,12 +9,18 @@
 
   span {
     display: block;
-    padding-top: .5rem;
+    padding-top: 2rem;
   }
 
   @media only screen and (max-width: 1280px) {
     width: 100%;
     font-size: 24px;
+    margin-bottom: 1.6rem;
+
+    span {
+      display: block;
+      padding-top: .5rem;
+    }
   }
 }
 

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,7 +1,7 @@
 .preamble {
   font-size: 38px;
   line-height: 1.4;
-  width: 42%;
+  width: 50%;
 
   strong {
     font-weight: 600;
@@ -22,8 +22,7 @@
 .featured-snippet {
   display: none;
   min-height: 18rem;
-  width: 56%;
-  margin-left: 1%;
+  width: 50%;
 
   &.visible {
     display: block;
@@ -31,6 +30,9 @@
 
   .highlight {
     height: 100%;
+    display: flex;
+    justify-content: space-evenly;
+    flex-direction: column;
   }
 
   pre {

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,11 +1,9 @@
 .preamble {
   font-size: 38px;
   line-height: 1.4;
-  width: 50%;
 
   strong {
     font-weight: 600;
-    text-decoration: underline;
   }
 
   span {
@@ -22,7 +20,7 @@
 .featured-snippet {
   display: none;
   min-height: 18rem;
-  width: 50%;
+  max-width: 536px;
 
   &.visible {
     display: block;
@@ -38,13 +36,23 @@
   pre {
     border: 1px solid var(--color-fill-tertiary);
     border-radius: 4px;
-    padding: 1rem;
     margin: 0px;
+    padding: 1rem;
+
+    code {
+      font-size: 1.2em;
+      line-height: 1.6em;
+
+      @media only screen and (max-width: 1280px) {
+        font-size: 1em;
+      }
+    }
   }
 
   @media only screen and (max-width: 1280px) {
     margin-left: 0;
     width: 100%;
+    max-width: 100%;
     min-height: auto;
   }
 }

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -1,12 +1,11 @@
 .preamble {
   font-size: 38px;
   line-height: 1.4;
-  margin-bottom: 30px;
-  width: 46%;
+  width: 42%;
 
   strong {
     font-weight: 600;
-    color: var(--color-figure-orange);
+    text-decoration: underline;
   }
 
   span {
@@ -23,8 +22,8 @@
 .featured-snippet {
   display: none;
   min-height: 18rem;
-  width: 52%;
-  margin-left: 2%;
+  width: 56%;
+  margin-left: 1%;
 
   &.visible {
     display: block;

--- a/index.md
+++ b/index.md
@@ -5,7 +5,8 @@ hideTitle: true
 atom: true
 ---
 
-<h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that’s <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. <span>It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</span></h1>
+<div class="callout" markdown="1">
+  <h1 class="preamble">Swift is a <strong>general-purpose</strong> programming language that’s <strong>approachable</strong> for newcomers and <strong>powerful</strong> for experts. <span>It is <strong>fast</strong>, <strong>modern</strong>, <strong>safe</strong>, and a <strong>joy</strong> to write.</span></h1>
 
 {% for snippet in site.data.featured_snippets %}
 ```swift
@@ -13,6 +14,7 @@ atom: true
 ```
 {: class="featured-snippet {% if forloop.first %}visible{% endif %}" }
 {% endfor %}
+</div>
 
 <div class="link-grid">
   <ul>


### PR DESCRIPTION
### Motivation:

Now that the homepage has a wider template we can move the Swift callout (and have it bigger) and the code box in the same row to reduce scrolling and have more content visible (without scrolling)

### Modifications:

Changed the CSS in:
```
assets/stylesheets/_screen.scss
assets/stylesheets/_mobile.scss
assets/stylesheets/pages/_landing.scss
```

Changed the structure of the `callout` section in homepage in:
```
index.md
```

### Result:

<img width="1559" alt="Screenshot 2024-02-12 at 1 52 24 PM" src="https://github.com/apple/swift-org-website/assets/59409/15c34e90-eada-4fa4-bf59-a44c4601221b">

<img width="1561" alt="Screenshot 2024-02-12 at 1 52 37 PM" src="https://github.com/apple/swift-org-website/assets/59409/42516d89-8539-460d-abfb-af5193bee425">

<img width="565" alt="Screenshot 2024-02-12 at 2 20 02 PM" src="https://github.com/apple/swift-org-website/assets/59409/f487d50d-144c-47a1-b148-6093dc2e4dcb">
