### PR TITLE
GSoC 2024 fix formatting

### DIFF
--- a/gsoc2024/index.md
+++ b/gsoc2024/index.md
@@ -240,7 +240,7 @@ This project is aimed at simplifying the alignement with an ever-evolving SAM te
 
 **Potential mentors**
 
-- [Sebastien Stormacq](mailto:stormacq@amazon.com) | ([GitHub](https://github.com/sebsto))
+- [Sebastien Stormacq](mailto:stormacq@amazon.com), ([GitHub](https://github.com/sebsto))
 
 ### Building Swift Macros with WebAssembly
 


### PR DESCRIPTION
The `|` makes markdown think the name is a table and render it weird:

![Screenshot 2024-02-14 at 08 03 23](https://github.com/apple/swift-org-website/assets/120979/2b83be4c-e15e-4575-b581-3f2af7d69055)
