### PR TITLE
Updated _basic-usage.md, changed swift version in commented section

### DIFF
--- a/documentation/package-manager/_basic-usage.md
+++ b/documentation/package-manager/_basic-usage.md
@@ -131,7 +131,7 @@ the `DeckOfPlayingCards` package must declare their packages as dependencies
 in its `Package.swift` manifest file.
 
 ~~~ swift
-// swift-tools-version:4.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -187,7 +187,7 @@ However, because the Swift Package Manager automatically resolves transitive dep
 you only need to declare the `DeckOfPlayingCards` package as a dependency.
 
 ~~~ swift
-// swift-tools-version:4.0
+// swift-tools-version:5.5
 
 import PackageDescription
 


### PR DESCRIPTION
Updated to the latest versions of swift referring #506 to resolve any confusion

### Motivation:
Just a commented code change to update the referred swift version on the latest, this is my first PR so sorry for any inconveniences

### Modifications: 
```swift

~~~ swift //(playing cards)
// swift-tools-version:4.0
~~~ swift //(Dealer)
// swift-tools-version:4.0
``` 
### Result:
```swift

 ~~~ swift //(playing cards)
// swift-tools-version: 5.3
~~~ swift //(Dealer)
// swift-tools-version: 5.5
```
