### PR TITLE
Improve image alt texts

### DIFF
--- a/_posts/2020-08-27-swift-cluster-membership.md
+++ b/_posts/2020-08-27-swift-cluster-membership.md
@@ -33,13 +33,13 @@ At a high level, SWIM works like this:
 * If those pings fail, the origin peer would receive `.nack` ("negative acknowledgement") messages back, and due to lack of `.ack`s resulting in the peer being marked as `.suspect`.
 
 
-![image](/assets/images/swim-blog/ping_pingreq_cycle.png)
+![SWIM ping diagram](/assets/images/swim-blog/ping_pingreq_cycle.png)
 
 The above mechanism, serves not only as a failure detection mechanism, but also as a gossip mechanism, which carries information about known members of the cluster. This way members eventually learn about the status of their peers, even without having them all listed upfront. It is worth pointing out however that this membership view is *[weakly-consistent](https://en.wikipedia.org/wiki/Weak_consistency)*, which means there is no guarantee (or way to know, without additional information) if all members have the same exact view on the membership at any given point in time. However, it is an excellent building block for higher-level tools and systems to build their stronger guarantees on top.
 
 Once the failure detection mechanism detects an unresponsive node, it eventually is marked as  `.dead` resulting in its irrevocable removal from the cluster. Our implementation offers an optional extension, adding an `.unreachable` state to the possible states, however most users will not find it necessary and it is disabled by default. For details and rules about legal status transitions refer to [`SWIM.Status`](https://github.com/apple/swift-cluster-membership/blob/main/Sources/SWIM/Status.swift#L18-L39) or the following diagram:
 
-![image](/assets/images/swim-blog/swim_lifecycle.png)
+![SWIM lifecycle diagram](/assets/images/swim-blog/swim_lifecycle.png)
 
 The way Swift Cluster Membership implements protocols, is by offering “*Instances*” of them. For example, the SWIM implementation is encapsulated in the runtime agnostic `SWIM.Instance` which needs to be “driven” or “interpreted” by some glue code between a networking runtime and the instance itself. We call those glue pieces of an implementation “*Shells*”, and the library ships with a `SWIMNIOShell` implemented using [SwiftNIO](https://www.github.com/apple/swift-nio)’s `DatagramChannel` that performs all messaging asynchronously over [UDP](https://searchnetworking.techtarget.com/definition/UDP-User-Datagram-Protocol). Alternative implementations can use completely different transports, or piggy back SWIM messages on some other existing gossip system etc.
 

--- a/_posts/2022-12-05-swift-summer-of-code-2022-summary.md
+++ b/_posts/2022-12-05-swift-summer-of-code-2022-summary.md
@@ -116,7 +116,7 @@ Interactive mode will be included in a future ArgumentParser release, but you ca
 
 This feature creates a fast and accessible way to navigate and discover symbols in Swift-DocC documentation websites, similar to Open Quickly in Xcode.
 
-![image]({{ site.url }}/assets/images/gsoc-2022/quick-navigation.png)
+![Swift-DocC quick navigation](/assets/images/gsoc-2022/quick-navigation.png)
 
 ### Key features
 

--- a/_posts/2023-05-18-evolving-swift-project-workgroups.md
+++ b/_posts/2023-05-18-evolving-swift-project-workgroups.md
@@ -69,7 +69,7 @@ The current members and initiatives of the Diversity in Swift Workgroup will be 
 
 Over the coming weeks, the Swift project will add two new groups to provide support in areas of growing momentum in the Swift project.  This overall picture of groups will look as follows:
 
-![Swift Workgroups Diagram]({{ site.url }}/assets/images/evolving-workgroups-blog/community-structure.png)
+![Swift Workgroups Diagram](/assets/images/evolving-workgroups-blog/community-structure.png)
 
 ### Ecosystem Steering Group
 
@@ -89,7 +89,7 @@ This shift in stewardship will enable the Diversity in Swift champions to focus 
 
 The new Contributor Experience workgroup will explore providing community members with the best support system and mechanics. Some example investments from this new workgroup will be improvements to the process and documentation for contributing code, bug reports, discussion on the Swift Forums, and more.
 
-For more details, please see the [Contributor Experience Workgroup Charter]({{ site.url }}/contributor-experience-workgroup).
+For more details, please see the [Contributor Experience Workgroup Charter](/contributor-experience-workgroup).
 
 ## Next Steps and You
 

--- a/documentation/server/guides/allocations.md
+++ b/documentation/server/guides/allocations.md
@@ -265,7 +265,7 @@ Generally, in flame graphs, the X axis just means "count", it does **not** mean 
 
 Note that this flame graph is _not_ a CPU flame graph, 1 sample means 1 allocation here and not time spent on the CPU. Also be aware that stack frames that appear wide don't necessarily allocate directly, it means that they or something they call has allocated a lot. For example, `BaseSocketChannel.readable` is a very wide frame, and yet, it is not a function which allocates directly. However, it calls other functions (such as other parts of SwiftNIO and AsyncHTTPClient) that do allocate a lot. It may take a little while to get familiar with flame graphs but there are great resources available online.
 
-![](/assets/images/server-guides/perf-malloc-full.svg)
+![Flame graph](/assets/images/server-guides/perf-malloc-full.svg)
 
 ## Allocation flame graphs on macOS
 

--- a/documentation/server/guides/performance.md
+++ b/documentation/server/guides/performance.md
@@ -131,7 +131,7 @@ sudo perf script > out.perf
 
 The resulting file will look something like:
 
-![](/assets/images/server-guides/perf-issues-flamegraph.svg)
+![Flame graph](/assets/images/server-guides/perf-issues-flamegraph.svg)
 
 And we can see that almost all of our runtime is spent in `isFavouriteNumber` which is invoked from `addFavouriteNumber`. That should be a very good hint to the programmer on where to look for improvements. Maybe after all, we should use `Set<Int>` to store the favourite numbers, that should get is an answer to if a number is a favourite number in constant time (_O(1)_).
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Improve image alt texts across the website, to not simply be empty or "image".

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Alt texts are important for accessibility and to provide an alternative text in case the image fails to load.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Wrote alt texts for some images that were missing alt text or simply had an alt text of "image"
- Remove a few instances of `{{ site.url }}` being used in links, as it's not necessary

### Result:

<!-- _[After your change, what will change.]_ -->

- Better accessibility
