### PR TITLE
Fix Github swift-cmake-examples link

### DIFF
--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -81,7 +81,7 @@ To use custom implementation instead of what comes with the C/C++ library:
 
 ## CMake
 
-This example is geared toward importing a C library into Swift. You'll need to obtain the library, provide a modulemap so that Swift can import it, and then link against it. The mechanics are largely the same for C++, and an example of how to bi-directionally interop with a C++ library built as part of a single project is available in the bidirectional cxx interop project in the [Swift-CMake examples repository](http:// https://github.com/apple/swift-cmake-examples/tree/main/3_bidirectional_cxx_interop).
+This example is geared toward importing a C library into Swift. You'll need to obtain the library, provide a modulemap so that Swift can import it, and then link against it. The mechanics are largely the same for C++, and an example of how to bi-directionally interop with a C++ library built as part of a single project is available in the bidirectional cxx interop project in the [Swift-CMake examples repository](https://github.com/apple/swift-cmake-examples/tree/main/3_bidirectional_cxx_interop).
 
 
 ### Obtaining the library


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
--> 
Fixed the link to the Swift-CMake examples repository on Github in the article [Wrapping C/C++ Library in Swift](https://www.swift.org/documentation/articles/wrapping-c-cpp-library-in-swift.html) in the CMake section.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ --> Improve swift documentation

### Modifications:

<!-- _[Describe the modifications you've done.]_ --> Fixed the link to the Github repository

### Result:

<!-- _[After your change, what will change.]_ --> The correct link
