### PR TITLE
Added Overview links to the Packages and Community menus

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,6 +10,8 @@
 - header: Packages
   url: /packages/
   pages:
+    - title: Overview
+      url: /packages/
     - title: Community Showcase
       url: /packages/showcase.html
     - title: Packages with Macros
@@ -26,6 +28,8 @@
 - header: Community
   url: /community/
   pages:
+    - title: Overview
+      url: /community/
     - title: Swift Evolution
       url: /swift-evolution/
     - title: Diversity


### PR DESCRIPTION
### Motivation:

The last couple of times I’ve used the Swift.org menu to look at the package pages I’ve found myself wishing there was a more obvious way to figure out that there’s information on the top-level page, too.

### Modifications:

This PR adds “Overview” menu items at the top of the Packages and Community menus that take visitors to `/packages/` and `/community/` respectively. It does not remove the links from the top-level menu item, only adds one more link.

### Result:


![Screenshot 2024-02-19 at 16 44 00@2x](https://github.com/apple/swift-org-website/assets/5180/109c6048-25b8-468d-823c-000a23f45099)

![Screenshot 2024-02-19 at 16 44 24@2x](https://github.com/apple/swift-org-website/assets/5180/02179275-0833-4de7-98eb-f81ebdc3912f)
