### PR TITLE
Add back missing target=blank on Package page Community Showcase source links

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -22,7 +22,7 @@ categories:
           Linux
         license: MIT
         url: https://swiftpackageindex.com/jrothwell/VersionedCodable
-        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd).
+        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
       - name: CalendarKit
         description: CalendarKit is a Swift calendar UI library for iOS and Mac Catalyst.
           It looks similar to the Apple Calendar app out-of-the-box, while allowing customization
@@ -34,7 +34,7 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/richardtop/CalendarKit
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6).
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6){:target='_blank'}.
       - name: SQLite.swift
         description: SQLite.swift is a type-safe, pure-Swift layer over SQLite3. It provides
           a compile-time confident SQL syntax and intent, with features like type-safe
@@ -48,7 +48,7 @@ categories:
           Linux
         license: MIT
         url: https://swiftpackageindex.com/stephencelis/SQLite.swift
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19).
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19){:target='_blank'}.
       - name: swift-markdown-ui
         description: MarkdownUI is a powerful library for displaying and customizing Markdown
           text in SwiftUI. It is compatible with GitHub Flavored Markdown and can display
@@ -60,7 +60,7 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/gonzalezreal/swift-markdown-ui
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24).
+        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
       - name: Vortex
         description: Vortex is a powerful particle system library for SwiftUI, enabling
           the creation of various effects like fire, rain, and snow. It supports iOS,
@@ -72,7 +72,7 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/twostraws/Vortex
-        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd).
+        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
       - name: SwiftSummarize
         description: The easiest way to create a summary from a String. Internally it's
           a simple wrapper around CoreServices SKSummary.
@@ -83,7 +83,7 @@ categories:
         platform_compatibility_tooltip: Apple (macOS, visionOS)
         license: MIT
         url: https://swiftpackageindex.com/StefKors/SwiftSummarize
-        note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62).
+        note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
   - name: Packages with Macros
     slug: macros
     brief: New in Swift 5.9, Swift packages can include macro targets. Browse a selection


### PR DESCRIPTION
### Motivation:

This month's links to the sources for community showcase nominations lost their `target=blank` attributes.

### Modifications:

Add back the `target=blank` attributes.

### Result:

Blank targets everywhere! 🫨