### PR TITLE
Add Swift 6.0 to evolutions list filter

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -37,6 +37,7 @@ var languageVersions = [
   '5.9',
   '5.9.2',
   '5.10',
+  '6.0',
   'Next'
 ]
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

Add version 6.0 to the evolution list's implemented filter.

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

As we have some proposals marked as implemented in Swift 6.0, we should add this version to the evolutions filter as well.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Adds `6.0` to the filter

### Result:

<!-- _[After your change, what will change.]_ -->

You can filter the evolutions list by "implemented in Swift 6.0" (currently 8 results).

![CleanShot 2024-02-20 at 20 31 56](https://github.com/apple/swift-org-website/assets/35671299/e97e825d-7a28-4b06-8d9f-8a320e958d84)



