### PR TITLE
Remove extra space in person lists

### DIFF
--- a/sswg/index.md
+++ b/sswg/index.md
@@ -16,8 +16,8 @@ The current Swift Server workgroup consists of the following people:
 {% assign people = site.data.server-workgroup.members | sort: "name" %}
 <ul>
 {% for person in people %}
-<li> {{ person.name }}
-{% if person.affiliation %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
   , {{ person.affiliation }}
 {% endif %}
 {% if person.github %}
@@ -32,8 +32,8 @@ We are grateful for the service of the following emeritus workgroup members:
 {% assign people = site.data.server-workgroup.emeriti | sort: "name" %}
 <ul>
 {% for person in people %}
-<li> {{ person.name }}
-{% if person.affiliation %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
   , {{ person.affiliation }}
 {% endif %}
 {% if person.github %}

--- a/website-workgroup/index.md
+++ b/website-workgroup/index.md
@@ -19,8 +19,8 @@ The current website workgroup consists of the following people:
 {% assign people = site.data.website-workgroup.members | sort: "name" %}
 <ul>
 {% for person in people %}
-<li> {{ person.name }}
-{% if person.affiliation %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
   , {{ person.affiliation }}
 {% endif %}
 {% if person.github %}
@@ -35,8 +35,8 @@ We are grateful for the service of the following emeritus workgroup members:
 {% assign people = site.data.website-workgroup.emeriti | sort: "name" %}
 <ul>
 {% for person in people %}
-<li> {{ person.name }}
-{% if person.affiliation %}
+<li>{{ person.name }}
+{%- if person.affiliation -%}
   , {{ person.affiliation }}
 {% endif %}
 {% if person.github %}


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Fixes #558 

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Removed the extra space in the SSWG and SWWG lists

We can probably create a reusable list component for this at some point, but this is good enough for now.

### Result:

<!-- _[After your change, what will change.]_ -->

Clean!

<img src="https://github.com/apple/swift-org-website/assets/35671299/075bf18d-2e13-4b5b-9395-376521e2aef7" width=300 />