### PR TITLE
Removed the top-level Packages menu’s sub-menu items

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,21 +9,6 @@
 # ------------------------------------------------------------------------------
 - header: Packages
   url: /packages/
-  pages:
-    - title: Overview
-      url: /packages/
-    - title: Community Showcase
-      url: /packages/showcase.html
-    - title: Packages with Macros
-      url: /packages/macros.html
-    - title: Server
-      url: /packages/server.html
-    - title: Networking
-      url: /packages/networking.html
-    - title: Testing
-      url: /packages/testing.html
-    - title: Debug Logging
-      url: /packages/logging.html
 # ------------------------------------------------------------------------------
 - header: Community
   url: /community/


### PR DESCRIPTION
### Motivation:

As discussed with the SWWG, having sub-menu items under Packages might make visitors think that these are the only categories of packages available, and the context that the [Packages overview page](https://www.swift.org/packages/) gives them.

### Modifications:

Remove the sub-menu items under the top-level Packages menu. All previous sub-menu links are still available from the Packages overview page.

### Result:

No more disclosure triangle or drop-down menu on Packages:

![Screenshot 2024-02-22 at 13 56 50@2x](https://github.com/apple/swift-org-website/assets/5180/75dfdeef-53d7-45ff-8872-abea67c80754)
