### PR TITLE
Add a more prominent CTA to the nomination thread for Community Showcase packages

### DIFF
--- a/assets/stylesheets/pages/_packages.scss
+++ b/assets/stylesheets/pages/_packages.scss
@@ -1,7 +1,7 @@
 .cta {
   background-color: var(--color-fill-tertiary);
   border-radius: 0.5rem;
-  padding: 15px;
+  padding: 1em;
 }
 
 .category-list {

--- a/assets/stylesheets/pages/_packages.scss
+++ b/assets/stylesheets/pages/_packages.scss
@@ -1,3 +1,9 @@
+.cta {
+  background-color: var(--color-fill-tertiary);
+  border-radius: 0.5rem;
+  padding: 15px;
+}
+
 .category-list {
   list-style: none;
   padding-left: 0;

--- a/packages/_get-involved.html
+++ b/packages/_get-involved.html
@@ -1,0 +1,6 @@
+<p class="cta">
+  <strong>Get involved!</strong> Packages in the Community Showcase are nominated by community members like you. This is
+  your chance to share new or interesting packages with others. The only restriction is that you can't nominate your own
+  packages. <a href="https://forums.swift.org/t/68168">Nominate packages here</a> and you could see them featured here
+  next month!
+</p>

--- a/packages/_get-involved.html
+++ b/packages/_get-involved.html
@@ -1,6 +1,6 @@
 <p class="cta">
   <strong>Get involved!</strong> Packages in the Community Showcase are nominated by community members like you. This is
-  your chance to share new or interesting packages with others. The only restriction is that you can't nominate your own
-  packages. <a href="https://forums.swift.org/t/68168">Nominate packages here</a> and you could see them featured here
+  your chance to share new or interesting packages with others. The only restriction is that you can't nominate packages
+  you maintain. <a href="https://forums.swift.org/t/68168">Nominate packages here</a> and you could see them featured
   next month!
 </p>

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -6,6 +6,19 @@
   </nav>
 
   {{ category.description | markdownify }}
+
+  <!-- Only shown on the showcase page -->
+
+  {% if category.slug == "showcase" %}
+  <p class="cta">
+    <strong>Get involved!</strong> Packages in this showcase came from from community nominations from people like you.
+    Did you find a new or interesting package, or maybe you have one you've been using that you love. The only
+    restriction on nominations is that the package must be written by someone else.
+    <a href="https://forums.swift.org/t/68168">Nominate packages through this thread in the Swift forums</a>
+    and you could see them featured here next month!
+  </p>
+  {% endif %}
+
   <ul>
     {% for package in category.packages %}
     <li class="{% if package.note %}with-note{% endif %}">

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -5,19 +5,8 @@
     <a href="{% link packages/index.md %}#package-ecosystem" rel="parent">Explore the Swift package ecosystem</a>
   </nav>
 
-  {{ category.description | markdownify }}
-
-  <!-- Only shown on the showcase page -->
-
-  {% if category.slug == "showcase" %}
-  <p class="cta">
-    <strong>Get involved!</strong> Packages in this showcase came from from community nominations from people like you.
-    Did you find a new or interesting package, or maybe you have one you've been using that you love. The only
-    restriction on nominations is that the package must be written by someone else.
-    <a href="https://forums.swift.org/t/68168">Nominate packages through this thread in the Swift forums</a>
-    and you could see them featured here next month!
-  </p>
-  {% endif %}
+  {{ category.description | markdownify }} {% if category.slug == "showcase" %} {% include_relative _get-involved.html
+  %} {% endif %}
 
   <ul>
     {% for package in category.packages %}

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -5,8 +5,11 @@
     <a href="{% link packages/index.md %}#package-ecosystem" rel="parent">Explore the Swift package ecosystem</a>
   </nav>
 
-  {{ category.description | markdownify }} {% if category.slug == "showcase" %} {% include_relative _get-involved.html
-  %} {% endif %}
+  {{ category.description | markdownify }}
+
+  {% if category.slug == "showcase" %}
+  {% include_relative _get-involved.html %}
+  {% endif %}
 
   <ul>
     {% for package in category.packages %}

--- a/packages/index.md
+++ b/packages/index.md
@@ -10,6 +10,8 @@ The Swift package ecosystem has thousands of packages to help you with all kinds
 Browse a small selection of interesting packages in popular categories from around the community, as well as a hand-picked selection of new and notable packages.
 
 {% include_relative _package-lists.html %}
+{% include_relative _get-involved.html %}
+
 
 ## Create Your Own
 

--- a/packages/index.md
+++ b/packages/index.md
@@ -12,7 +12,6 @@ Browse a small selection of interesting packages in popular categories from arou
 {% include_relative _package-lists.html %}
 {% include_relative _get-involved.html %}
 
-
 ## Create Your Own
 
 Creating a Swift package is a great way to modularise your code either for personal use, for private use inside your company, or to release an open source package for the rest of the Swift community to use.


### PR DESCRIPTION
### Motivation:

As discussed in the SWWG, we should make the [nominations thread](https://forums.swift.org/t/68168) for Community Showcase packages more prominent to encourage more community members to get involved if they are not frequent visitors to the Swift forums.

### Modifications:

Adds a CTA to both the Packages overview page, and the Community Showcase package list.

### Result:

![Screenshot 2024-02-22 at 14 05 01@2x](https://github.com/apple/swift-org-website/assets/5180/8e866088-3ac1-4e73-86fb-8f0c49b5f390)
