### PR TITLE
Make the Community Showcase archives directly linkable

### DIFF
--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -21,7 +21,7 @@
 </section>
 
 {% if category.slug == "showcase" %}
-<h2>Archive</h2>
+<h2 id="archive">Archive</h2>
 <p>
   The Community Showcase <a href="{% post_url 2023-10-31-packages-page %}">launched in November 2023</a> and features a
   new set of packages every month. Browse the archive below to see the history of featured Community Showcase packages:


### PR DESCRIPTION
I just went to link directly to the Archive heading in the new section and because it's an HTML file not a Markdown file, it doesn't get the automatic `id` attribute. This PR adds that for the heading element.

Linked to from https://github.com/apple/swift-org-website/issues/566
