### PR TITLE
Fix punctuation

### DIFF
--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -9,7 +9,7 @@
     url: /documentation/api-design-guidelines/
     description: |
       Delivering a clear, consistent developer experience when writing Swift code is largely defined by the names and idioms that appear in APIs.
-      These design guidelines explain how to make sure that your code feels like a part of the larger Swift ecosystem
+      These design guidelines explain how to make sure that your code feels like a part of the larger Swift ecosystem.
   - title: Standard Library
     url: /documentation/standard-library/
     description: |
@@ -38,7 +38,7 @@
   - title: Swift on Server
     url: /documentation/server/
     description: |
-      Swift is a general-purpose programming language with unique characteristics that make it specifically suitable for Server applications
+      Swift is a general-purpose programming language with unique characteristics that make it specifically suitable for Server applications.
   - title: Mixing Swift and C++
     url: /documentation/cxx-interop/
     description: |
@@ -79,4 +79,4 @@
   - title: Compiler Architecture
     url: /documentation/swift-compiler/
     description: |
-      Overview of the Swift compiler architecture
+      Overview of the Swift compiler architecture.

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -13,19 +13,19 @@ In the interest of fostering an open and welcoming environment, we as contributo
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language (e.g., prefer non-gendered words like “folks” to “guys”, non-ableist words like “soundness check” to “sanity check”, etc.)
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Using welcoming and inclusive language (e.g., prefer non-gendered words like “folks” to “guys”, non-ableist words like “soundness check” to “sanity check”, etc.).
+* Being respectful of differing viewpoints and experiences.
+* Gracefully accepting constructive criticism.
+* Focusing on what is best for the community.
+* Showing empathy towards other community members.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others’ private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+* The use of sexualized language or imagery and unwelcome sexual attention or advances.
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission.
+* Other conduct which could reasonably be considered inappropriate in a professional setting.
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 

--- a/community/_forums.md
+++ b/community/_forums.md
@@ -21,22 +21,22 @@ A core principle for the Swift project is that the community is an open and incl
 
 ### Swift Users
 [Using Swift]: #using-swift
-**[Using Swift](https://forums.swift.org/c/swift-users)** - For newcomers or those primarily interested in using the Swift language, it is best to start by engaging within the Using Swift category.  This area is intended for users to get help with or ask questions about Swift or its related tools and is not for discussion about work being done to the language itself. This category will accept email sent to: swift+swift-users@forums.swift.org
+**[Using Swift](https://forums.swift.org/c/swift-users)** - For newcomers or those primarily interested in using the Swift language, it is best to start by engaging within the Using Swift category.  This area is intended for users to get help with or ask questions about Swift or its related tools and is not for discussion about work being done to the language itself. This category will accept email sent to: swift+swift-users@forums.swift.org.
 
 ### Development
 [Development]: #development
 
-**[Compiler](https://forums.swift.org/c/development/compiler)** - For developers to discuss the development and implementation of the Swift compiler, low-level runtime, and SourceKit.  This category will accept email sent to: swift+compiler@forums.swift.org
+**[Compiler](https://forums.swift.org/c/development/compiler)** - For developers to discuss the development and implementation of the Swift compiler, low-level runtime, and SourceKit.  This category will accept email sent to: swift+compiler@forums.swift.org.
 
-**[Standard Library](http://forums.swift.org/c/development/stdlib)** - For developers to discuss the implementation of the Swift standard library.  This category will accept email sent to: swift+stdlib@forums.swift.org
+**[Standard Library](http://forums.swift.org/c/development/stdlib)** - For developers to discuss the implementation of the Swift standard library.  This category will accept email sent to: swift+stdlib@forums.swift.org.
 
-**[Core Libraries](http://forums.swift.org/c/development/corelibs)** - For developers to discuss the implementation of the Swift core libraries.  This category will accept email sent to: swift+corelibs@forums.swift.org
+**[Core Libraries](http://forums.swift.org/c/development/corelibs)** - For developers to discuss the implementation of the Swift core libraries.  This category will accept email sent to: swift+corelibs@forums.swift.org.
 
-**[LLDB](http://forums.swift.org/c/development/lldb)** - For developers to discuss the implementation of the Swift REPL and Swift-specific aspects of LLDB. This category will accept email sent to: swift+lldb@forums.swift.org
+**[LLDB](http://forums.swift.org/c/development/lldb)** - For developers to discuss the implementation of the Swift REPL and Swift-specific aspects of LLDB. This category will accept email sent to: swift+lldb@forums.swift.org.
 
-**[Package Manager](http://forums.swift.org/c/development/SwiftPM)** - For developers to discuss the implementation of the Swift package manager. This category will accept email sent to: swift+swiftpm@forums.swift.org
+**[Package Manager](http://forums.swift.org/c/development/SwiftPM)** - For developers to discuss the implementation of the Swift package manager. This category will accept email sent to: swift+swiftpm@forums.swift.org.
 
-**[LLBuild](http://forums.swift.org/c/development/llbuild)** - For developers to discuss the implementation of the low level build system (llbuild). This category will accept email sent to: swift+llbuild@forums.swift.org
+**[LLBuild](http://forums.swift.org/c/development/llbuild)** - For developers to discuss the implementation of the low level build system (llbuild). This category will accept email sent to: swift+llbuild@forums.swift.org.
 
 **[Announcements](http://forums.swift.org/c/development/dev-announce)** - For announcements relevant to developers such as release announcements, branching, and infrastructure updates.
 
@@ -49,11 +49,11 @@ Please see the [Swift evolution repository](https://github.com/apple/swift-evolu
 
 **[Announcements](https://forums.swift.org/c/evolution/announce)** - For announcements of Swift evolution proposal reviews and results. All discussion and review of evolution proposals occurs on the swift-evolution mailing list.
 
-**[Pitches](https://forums.swift.org/c/evolution/pitches)** - For proposals for the evolution of Swift including new language features, new standard library APIs, and so on before they enter the review phase. This category will accept email sent to: swift+pitches@forums.swift.org
+**[Pitches](https://forums.swift.org/c/evolution/pitches)** - For proposals for the evolution of Swift including new language features, new standard library APIs, and so on before they enter the review phase. This category will accept email sent to: swift+pitches@forums.swift.org.
 
-**[Proposal Reviews](https://forums.swift.org/c/evolution/proposal-reviews)** - Posting and commentary on proposals in the review phase. This category will accept email sent to: swift+proposal-reviews@forums.swift.org
+**[Proposal Reviews](https://forums.swift.org/c/evolution/proposal-reviews)** - Posting and commentary on proposals in the review phase. This category will accept email sent to: swift+proposal-reviews@forums.swift.org.
 
-**[Discussion](https://forums.swift.org/c/evolution/discuss)** - For general discussion of the evolution of Swift. This category will accept email sent to: swift+evolution-discuss@forums.swift.org
+**[Discussion](https://forums.swift.org/c/evolution/discuss)** - For general discussion of the evolution of Swift. This category will accept email sent to: swift+evolution-discuss@forums.swift.org.
 
 ### Server
 [Server]: #server

--- a/community/index.md
+++ b/community/index.md
@@ -10,9 +10,9 @@ The Swift.org community has the singular goal of making the world's best general
 
 The Swift language is developed in the open, and all technical or administrative topics about the language or community processes should be directed to the Swift public forums. Public conversations are encouraged, and active developers of the Swift language should monitor the relevant forum categories.
 
-* Directory of forum categories and email instructions are in the [forum section](#forums)
-* Source code for all Swift projects can be found on GitHub at [github.com/apple][github]
-* The Swift language bug tracking system is maintained at [github.com/apple/swift/issues][bugtracker]
+* Directory of forum categories and email instructions are in the [forum section](#forums).
+* Source code for all Swift projects can be found on GitHub at [github.com/apple][github].
+* The Swift language bug tracking system is maintained at [github.com/apple/swift/issues][bugtracker].
 
 All communication within project spaces should adhere to Swift project's [Code of Conduct](/code-of-conduct).
 
@@ -22,16 +22,16 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 
 
 * __[Project Lead](#project-lead)__ appoints technical leaders from the community.  Apple Inc. is the project lead, and interacts with the community through its representative.
-* __[Core Team](#core-team)__ is the small group responsible for strategic direction and oversight of the Swift project
-* __[Code Owner](#code-owners)__ is the individual responsible for a specific area of the Swift codebase
-* __[Committer](/contributing/#commit-access)__ is anyone that has commit access to the Swift code base
-* __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review
+* __[Core Team](#core-team)__ is the small group responsible for strategic direction and oversight of the Swift project.
+* __[Code Owner](#code-owners)__ is the individual responsible for a specific area of the Swift codebase.
+* __[Committer](/contributing/#commit-access)__ is anyone that has commit access to the Swift code base.
+* __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review.
 * __Workgroups__
-   * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++
-   * __[Documentation Workgroup](/documentation-workgroup)__ is a steering team that helps guide the documentation experience for Swift
-   * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction
-   * __[Swift on Server Workgroup](/sswg)__ is a steering team that promotes the use of Swift for developing and deploying server applications
-   * __[Website Workgroup](/website-workgroup/)__ is a steering team that helps guide the evolution on the Swift.org website
+   * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
+   * __[Documentation Workgroup](/documentation-workgroup)__ is a steering team that helps guide the documentation experience for Swift.
+   * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
+   * __[Swift on Server Workgroup](/sswg)__ is a steering team that promotes the use of Swift for developing and deploying server applications.
+   * __[Website Workgroup](/website-workgroup/)__ is a steering team that helps guide the evolution on the Swift.org website.
 
 Most importantly, everyone that uses Swift is a valued member of our extended community.
 

--- a/contributing/_contributing-code.md
+++ b/contributing/_contributing-code.md
@@ -150,12 +150,12 @@ People depend on Swift to create their production software.  This means that a b
 
 Additionally, the committer is responsible for addressing any problems found in the future that the change may cause. This responsibility means that you may need to update your change in order to:
 
-* Ensure the code compiles cleanly on all primary platforms
-* Fix any correctness regressions found in other test suites
-* Fix any major performance regressions
-* Fix any performance or correctness regressions in the downstream Swift tools
-* Fix any performance or correctness regressions that result in customer code that uses Swift
-* Address any bugs that appear in the bug tracker as a result from your change
+* Ensure the code compiles cleanly on all primary platforms.
+* Fix any correctness regressions found in other test suites.
+* Fix any major performance regressions.
+* Fix any performance or correctness regressions in the downstream Swift tools.
+* Fix any performance or correctness regressions that result in customer code that uses Swift.
+* Address any bugs that appear in the bug tracker as a result from your change.
 
 We prefer that these issues be handled before submission, but we understand that it isn’t possible to test all of this for every submission. Our continuous integration (CI) infrastructure normally finds these problems. We recommend watching the CI infrastructure throughout the next day to look for regressions. The CI infrastructure will directly email you if a group of commits that included yours caused a failure. You are expected to check those messages to see whether they are your fault and, if so, fix the breakage.
 

--- a/contributor-experience-workgroup/index.md
+++ b/contributor-experience-workgroup/index.md
@@ -7,15 +7,15 @@ The Contributor Experience Workgroup supports contributors to the Swift project,
 
 ## Charter
 
-The Contributor Experience Workgroup is devoted to
-- improving the mechanics and ergonomics of contributing to the Swift compiler and related open source repositories by
-  - providing guidance and setting expectations for the GitHub pull request and issue workflows
-  - maintaining onboarding documentation
-  - adding and managing GitHub labels
-- providing support systems and facilitating collaboration amongst contributors through
-  - the Swift Mentorship Program
-  - community groups
-  - collaboration tools and spaces to connect with other contributors
+The Contributor Experience Workgroup is devoted to:
+- improving the mechanics and ergonomics of contributing to the Swift compiler and related open source repositories by:
+  - providing guidance and setting expectations for the GitHub pull request and issue workflows.
+  - maintaining onboarding documentation.
+  - adding and managing GitHub labels.
+- providing support systems and facilitating collaboration amongst contributors through:
+  - the Swift Mentorship Program.
+  - community groups.
+  - collaboration tools and spaces to connect with other contributors.
 
 ### Diversity
 

--- a/diversity/index.md
+++ b/diversity/index.md
@@ -47,9 +47,9 @@ The Diversity in Swift workgroup will include posts on the Swift.org blog that r
 
 Everyone is welcome to participate in Diversity in Swift! Below are a few specific ways to contribute:
 
-* Joining community groups that you identify with
-* Proposing new community groups or programs
-* Sharing Swift content on the [Community Showcase](https://forums.swift.org/c/community-showcase)
-* Encouraging participation and highlighting work from developers who are currently underrepresented in the community
+* Joining community groups that you identify with.
+* Proposing new community groups or programs.
+* Sharing Swift content on the [Community Showcase](https://forums.swift.org/c/community-showcase).
+* Encouraging participation and highlighting work from developers who are currently underrepresented in the community.
 
 Anybody can work toward making the Swift community even more approachable. Members of the community can help newcomers overcome barriers by [answering questions on the Swift Forums](/contributing/#answering-questions), improving [open source Swift documentation](https://github.com/apple/swift/blob/main/docs/README.md), searching for or creating [good first issues](/contributing/#good-first-issues), and more.

--- a/documentation-workgroup/index.md
+++ b/documentation-workgroup/index.md
@@ -9,11 +9,11 @@ documentation experience for Swift.
 The Documentation Workgroup will:
 
 * Define and prioritize efforts that address the documentation needs of the
-  Swift community
-* Actively guide development for documentation tooling such as Swift-DocC
+  Swift community.
+* Actively guide development for documentation tooling such as Swift-DocC.
 * Define processes that govern contributions to Swift’s documentation
-  experience
-* Channel feedback to Swift Core Team about the needs of the Swift community
+  experience.
+* Channel feedback to Swift Core Team about the needs of the Swift community.
 
 The current Documentation Workgroup consists of the following people:
 
@@ -67,10 +67,10 @@ The Core Team also selects one member of the workgroup as the chair. The chair
 has no special authority over the workgroup, but they are responsible for
 ensuring its smooth functioning, including by:
 
-* Organizing and leading regular meetings
-* Ensuring that the workgroup communicates effectively with the community
+* Organizing and leading regular meetings.
+* Ensuring that the workgroup communicates effectively with the community.
 * Coordinating meetings between workgroup representatives and the Core Team
-  when issues need to be raised to the Core Team
+  when issues need to be raised to the Core Team.
 
 Workgroup members will try to make a decision independently by consensus
 whenever possible, and will raise issues to the Core Team when there are particular
@@ -90,11 +90,11 @@ experience and the Documentation Workgroup’s initiatives. If you’d like to
 contribute, consider:
 
 * Joining the Documentation Workgroup’s open meetings on WebEx (reach out to
-    `@swift-documentation-workgroup` in forums for details)
+    `@swift-documentation-workgroup` in forums for details).
 * Discussing ideas in the Swift Forums, for example in the [Swift-DocC
   forum](https://forums.swift.org/c/development/swift-docc) for
-  Swift-DocC–related ideas
+  Swift-DocC–related ideas.
 * Opening issues to track enhancements and bugs for the projects governed by the Documentation Workgroup:
-  [Swift-DocC](https://github.com/apple/swift-docc/issues), [The Swift Programming Language book](https://github.com/apple/swift-book/issues)
+  [Swift-DocC](https://github.com/apple/swift-docc/issues), [The Swift Programming Language book](https://github.com/apple/swift-book/issues).
 * Participating in the [Swift Mentorship
-  Program](/mentorship)
+  Program](/mentorship).

--- a/documentation/server/index.md
+++ b/documentation/server/index.md
@@ -20,10 +20,10 @@ Swift on Server provides developers with a modern, safe, and efficient option fo
 
 In addition to the characteristics of Swift that make it an excellent general-purpose programming language, it also has unique characteristics that make it specifically suitable for server applications due to its:
 
-- Performance
-- Quick start-up time
-- Expressiveness and safety
-- Supported ecosystem
+- Performance.
+- Quick start-up time.
+- Expressiveness and safety.
+- Supported ecosystem.
 
 ### Performance
 Swift offers fast performance and a low memory footprint. Instead of tracing garbage collection, it uses [Automatic Reference Counting (ARC)](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting/) and ownership features, which allows precise control over resources. Swift’s use of ARC and its lack of just-in-time (JIT) compilation provides an edge in the cloud services space.
@@ -39,7 +39,7 @@ These characteristics make Swift ideal for use in modern cloud platforms when ma
 ### Quick start-up time
 Swift-based applications quickly start since there are almost no warm-up operations, making Swift an ideal fit for cloud services, which are often rescheduled onto new virtual machines (VMs) or containers to address platform formation changes. Other considerations include:
 
-- Quick boot times make Swift ideal for serverless applications such as [Google Cloud Functions](https://cloud.google.com/functions#) or [AWS Lambda](https://aws.amazon.com/lambda/) with negligible cold start times. Additionally, the quick start-up time and low memory advantages make Swift a good choice for microservices that scale in the cloud. 
+- Quick boot times make Swift ideal for serverless applications such as [Google Cloud Functions](https://cloud.google.com/functions#) or [AWS Lambda](https://aws.amazon.com/lambda/) with negligible cold start times. Additionally, the quick start-up time and low memory advantages make Swift a good choice for microservices that scale in the cloud.
 - Using Swift helps streamline continuous delivery pipelines, incurring less wait time for new versions of the service fleet to go online.
 - Swift allows you to rapidly respond to the need to scale up where services can dynamically adjust their number of instances.
 
@@ -66,20 +66,20 @@ They are designed to help teams and individuals running server-side Swift applic
 
 The following guides focus on how to compile, test, deploy, and debug applications and provide tips in those areas:
 
-- [Setup and code editing](/documentation/server/guides/setup-and-ide-alternatives.html)
-- [Building](/documentation/server/guides/building.html)
-- [Testing](/documentation/server/guides/testing.html)
-- [Debugging Memory leaks](/documentation/server/guides/memory-leaks-and-usage.html)
-- [Performance troubleshooting and analysis](/documentation/server/guides/performance.html)
-- [Optimizing allocations](/documentation/server/guides/allocations.html)
-- [Debugging multithreading issues and memory checks](/documentation/server/guides/llvm-sanitizers.html)
-- [Deployment](/documentation/server/guides/deployment.html)
-- [Packaging](/documentation/server/guides/packaging.html)
+- [Setup and code editing](/documentation/server/guides/setup-and-ide-alternatives.html).
+- [Building](/documentation/server/guides/building.html).
+- [Testing](/documentation/server/guides/testing.html).
+- [Debugging Memory leaks](/documentation/server/guides/memory-leaks-and-usage.html).
+- [Performance troubleshooting and analysis](/documentation/server/guides/performance.html).
+- [Optimizing allocations](/documentation/server/guides/allocations.html).
+- [Debugging multithreading issues and memory checks](/documentation/server/guides/llvm-sanitizers.html).
+- [Deployment](/documentation/server/guides/deployment.html).
+- [Packaging](/documentation/server/guides/packaging.html).
 
 Additionally, specific guides exist for library developers:
 
-* [Log Levels](/documentation/server/guides/libraries/log-levels.html)
-* [Adopting Swift Concurrency](/documentation/server/guides/libraries/concurrency-adoption-guidelines.html)
+* [Log Levels](/documentation/server/guides/libraries/log-levels.html).
+* [Adopting Swift Concurrency](/documentation/server/guides/libraries/concurrency-adoption-guidelines.html).
 
 _These guides are a community effort. Anyone is invited to share their tips and know-how by submitting pull requests to the [Swift.org site](https://github.com/apple/swift-org-website)_.
 

--- a/language-steering-group/index.md
+++ b/language-steering-group/index.md
@@ -8,15 +8,15 @@ The Swift Language Steering Group guides the development of the Swift language a
 # Charter
 
 The Swift Language Steering Group:
-* works with the [Swift Core Team](/community/#community-structure) to define a roadmap for the focus areas of language and library development in the upcoming releases of Swift;
-* works with the Swift Core Team and other workgroups to define, document, and develop the Swift evolution process;
+* works with the [Swift Core Team](/community/#community-structure) to define a roadmap for the focus areas of language and library development in the upcoming releases of Swift.
+* works with the Swift Core Team and other workgroups to define, document, and develop the Swift evolution process.
 * implements the evolution process for the Swift language and library by:
-  * soliciting, writing, and approving feature roadmaps,
-  * guiding evolution discussion,
-  * keeping evolution discussion collegial and inclusive,
-  * deciding whether and when to run a review for an evolution proposal,
-  * running evolution reviews, and
-  * making decisions about proposals; and
+  * soliciting, writing, and approving feature roadmaps.
+  * guiding evolution discussion.
+  * keeping evolution discussion collegial and inclusive.
+  * deciding whether and when to run a review for an evolution proposal.
+  * running evolution reviews.
+  * making decisions about proposals.
 * keeps the community informed about changes to the project roadmap, the status of accepted proposals, and the availability of new features.
 
 ## Membership
@@ -25,10 +25,10 @@ The Language Steering Group is made up of Swift community members with a variety
 
 The Core Team also selects one member of the workgroup as the chair. The chair has no special authority over the workgroup, but they are responsible for ensuring its smooth functioning, including by:
 
-* organizing and leading regular meetings,
-* ensuring that proposals have an assigned review manager sufficiently in advance of when they will be reviewed,
-* ensuring that the workgroup discusses and reaches a conclusion promptly after a proposal has been reviewed,
-* ensuring that the workgroup communicates effectively with the community, and
+* organizing and leading regular meetings.
+* ensuring that proposals have an assigned review manager sufficiently in advance of when they will be reviewed.
+* ensuring that the workgroup discusses and reaches a conclusion promptly after a proposal has been reviewed.
+* ensuring that the workgroup communicates effectively with the community.
 * coordinating meetings between workgroup representatives and the Core Team when issues need to be raised to the Core Team.
 
 The current members of the Language Steering Group are:
@@ -54,10 +54,10 @@ The Language Steering Group communicates with the community primarily using the 
 
 The workgroup is responsible for the following regular communication with the broader Swift community:
 
-* Announcing (and running) evolution proposal reviews for language and library proposals
-* Announcing decisions about evolution proposal reviews for language and library proposals
-* After every release of Swift, describing the language and library evolution proposals newly implemented in that release
-* After every release of Swift, describing the current language and library evolution roadmap for the next few upcoming releases (a 1–2 year timeline)
+* Announcing (and running) evolution proposal reviews for language and library proposals.
+* Announcing decisions about evolution proposal reviews for language and library proposals.
+* After every release of Swift, describing the language and library evolution proposals newly implemented in that release.
+* After every release of Swift, describing the current language and library evolution roadmap for the next few upcoming releases (a 1–2 year timeline).
 
 The workgroup is also partially responsible for the content of language and library documentation:
 
@@ -73,8 +73,8 @@ These limits on the evolution authority of the Language Steering Group are not m
 
 As a major client of the evolution process, the Language Steering Group works closely with the Core Team to define and improve that process, such as by:
 
-* clearly defining how proposals are pitched and reviewed,
-* providing guidelines for participating in the evolution process in various roles, and
+* clearly defining how proposals are pitched and reviewed.
+* providing guidelines for participating in the evolution process in various roles.
 * regularly updating the process and guidelines to make the process work better.
 
 Any change to the evolution process is ultimately up to the discretion of the Core Team.

--- a/sswg/index.md
+++ b/sswg/index.md
@@ -5,9 +5,9 @@ title: Swift Server Workgroup (SSWG)
 
 The Swift Server workgroup is a steering team that promotes the use of Swift for developing and deploying server applications. The Swift Server workgroup will:
 
-* Define and prioritize efforts that address the needs of the Swift server community
-* Define and run an incubation process for these efforts to reduce duplication of effort, increase compatibility and promote best practices
-* Channel feedback for Swift language features needed by the server development community to the Swift Core Team
+* Define and prioritize efforts that address the needs of the Swift server community.
+* Define and run an incubation process for these efforts to reduce duplication of effort, increase compatibility and promote best practices.
+* Channel feedback for Swift language features needed by the server development community to the Swift Core Team.
 
 Analogous to the [Core Team](/community#core-team) for Swift, the workgroup is responsible for providing overall technical direction and establishing the standards by which libraries and tools are proposed, developed and eventually recommended. Membership of the workgroup is contribution-based and is expected to evolve over time.
 
@@ -51,11 +51,11 @@ The Swift Server workgroup uses the [Swift Server forum](https://forums.swift.or
 
 Everyone is welcome to contribute in the following ways:
 
-* Proposing new libraries and tools to be considered
-* Participating in design discussions
-* Asking or answering questions on the forums
-* Reporting or triaging bugs
-* Submitting pull requests to the library projects for implementation or tests
+* Proposing new libraries and tools to be considered.
+* Participating in design discussions.
+* Asking or answering questions on the forums.
+* Reporting or triaging bugs.
+* Submitting pull requests to the library projects for implementation or tests.
 
 These conversations will take place on the [Swift Server forum](https://forums.swift.org/c/server). Over time, the workgroup may form smaller working groups to focus on specific technology areas.
 

--- a/support/security.md
+++ b/support/security.md
@@ -18,9 +18,9 @@ We welcome reports from everyone, including security researchers, developers, an
 
 To report a security or privacy vulnerability, please send an email to [cve@forums.swift.org](mailto:cve@forums.swift.org) that includes:
 
-* The specific project and software version(s) which you believe are affected
-* A description of the behavior you observed as well as the behavior that you expected
-* A numbered list of steps required to reproduce the issue and/or a video demonstration, if the steps may be hard to follow
+* The specific project and software version(s) which you believe are affected.
+* A description of the behavior you observed as well as the behavior that you expected.
+* A numbered list of steps required to reproduce the issue and/or a video demonstration, if the steps may be hard to follow.
 
 Please use [Swift.org's CVE PGP key](/keys/cve-signing-key-1.asc) to encrypt sensitive information that you send by email.
 

--- a/website/index.md
+++ b/website/index.md
@@ -5,13 +5,13 @@ title: Swift.org website
 
 Swift.org website goals include:
 
-* Welcome newcomers with friendly information about Swift
-* Help visitors of all skill levels get started developing with Swift
-* Document the language, libraries, and best practices
-* Announce new features, APIs, and tooling improvements
-* Provide a safe, friendly place to interact with fellow Swift developers
-* Promote activities occurring anywhere within the community
-* Support collaboration and evolution in building the Swift ecosystem
+* Welcome newcomers with friendly information about Swift.
+* Help visitors of all skill levels get started developing with Swift.
+* Document the language, libraries, and best practices.
+* Announce new features, APIs, and tooling improvements.
+* Provide a safe, friendly place to interact with fellow Swift developers.
+* Promote activities occurring anywhere within the community.
+* Support collaboration and evolution in building the Swift ecosystem.
 
 ## Community Participation
 
@@ -23,9 +23,9 @@ Everyone is welcome to contribute to the Swift.org website in the following ways
     * Proposing broad changes to how content is organized in the website (information design).
     * Proposing broad changes to how the website looks (UX/UI design).
     * Proposing broad changes to the technical infrastructure that powers the website.
-* Participating in design discussions
-* Asking or answering questions on the forums
-* Reporting or triaging bugs
+* Participating in design discussions.
+* Asking or answering questions on the forums.
+* Reporting or triaging bugs.
 
 See [`CONTRIBUTING.md`](https://github.com/apple/swift-org-website/blob/main/CONTRIBUTING.md) for additional information about the website's contribution guidelines.
 


### PR DESCRIPTION
### Motivation:

Punctuation in lists is missing or is inconsistent.

### Modifications:

Fixed inconsistencies in the following doc/files:

- _data/documentation.yaml
- code-of-conduct/index.md
- community/_forums.md
- community/index.md
- contributing/_contributing-code.md
- contributor-experience-workgroup/index.md
- diversity/index.md
- documentation-workgroup/index.md
- documentation/server/index.md
- language-steering-group/index.md
- sswg/index.md
- support/security.md
- website/index.md

### Result:

Most of punctation inconsistencies are now fixed (I am saying most because I might have missed something)
