### PR TITLE
Add ui-monospace for code display in Safari

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -22,7 +22,7 @@ body {
 
   pre,
   code {
-    font-family: "SF Mono", Menlo, Consolas, Monaco, "Courier New", monospace,
+    font-family: "SF Mono", ui-monospace, Menlo, Consolas, Monaco, "Courier New", monospace,
       serif;
   }
 }


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Safari won't display SF Font families if you installed the official distribution and try to use it with `font-family: "SF Mono"`. So in my Safari the code font fallbacks to Menlo. 

This PR fixes it and it should also work even if the Safari users didn't install SF Mono.

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

Added `ui-monospace` to styles.
```css 
  pre,
  code {
    font-family: "SF Mono", ui-monospace, Menlo, Consolas, Monaco, "Courier New", monospace,
      serif;
  }
```
<!-- _[Describe the modifications you've done.]_ -->

### Result:

The left is original, the right one is updated.

<img width="1132" alt="Screenshot 2024-03-05 at 14 34 40" src="https://github.com/apple/swift-org-website/assets/45376537/05b76986-4d4c-4c4a-8c77-552683a01d37">

<!-- _[After your change, what will change.]_ -->
