### PR TITLE
Updated the Platform Support file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ xcuserdata
 
 # Prettier
 .prettierrc
+branch_structure.json
+temp_auto_push.bat
+temp_interactive_push.bat

--- a/_data/builds/development/amazonlinux2-aarch64.yml
+++ b/_data/builds/development/amazonlinux2-aarch64.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-amazonlinux2-aarch64.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-amazonlinux2-aarch64.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-amazonlinux2-aarch64.tar.gz

--- a/_data/builds/development/amazonlinux2.yml
+++ b/_data/builds/development/amazonlinux2.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-amazonlinux2.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-amazonlinux2.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-amazonlinux2.tar.gz

--- a/_data/builds/development/centos7.yml
+++ b/_data/builds/development/centos7.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-centos7.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-centos7.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-centos7.tar.gz

--- a/_data/builds/development/ubi9-aarch64.yml
+++ b/_data/builds/development/ubi9-aarch64.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubi9-aarch64.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubi9-aarch64.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubi9-aarch64.tar.gz

--- a/_data/builds/development/ubi9.yml
+++ b/_data/builds/development/ubi9.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubi9.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubi9.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubi9.tar.gz

--- a/_data/builds/development/ubuntu1804.yml
+++ b/_data/builds/development/ubuntu1804.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu18.04.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu18.04.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubuntu18.04.tar.gz

--- a/_data/builds/development/ubuntu2004-aarch64.yml
+++ b/_data/builds/development/ubuntu2004-aarch64.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu20.04-aarch64.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu20.04-aarch64.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubuntu20.04-aarch64.tar.gz

--- a/_data/builds/development/ubuntu2004.yml
+++ b/_data/builds/development/ubuntu2004.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu20.04.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu20.04.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubuntu20.04.tar.gz

--- a/_data/builds/development/ubuntu2204-aarch64.yml
+++ b/_data/builds/development/ubuntu2204-aarch64.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu22.04-aarch64.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu22.04-aarch64.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubuntu22.04-aarch64.tar.gz

--- a/_data/builds/development/ubuntu2204.yml
+++ b/_data/builds/development/ubuntu2204.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu22.04.tar.gz
+  download_signature: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-ubuntu22.04.tar.gz.sig
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a
   download: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-ubuntu22.04.tar.gz

--- a/_data/builds/development/xcode.yml
+++ b/_data/builds/development/xcode.yml
@@ -1,3 +1,8 @@
+- date: 2024-03-05 10:10:00-06:00
+  debug_info: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-osx-symbols.pkg
+  dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a
+  download: swift-DEVELOPMENT-SNAPSHOT-2024-03-05-a-osx.pkg
+  name: Swift Development Snapshot
 - date: 2024-03-04 10:10:00-06:00
   debug_info: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a-osx-symbols.pkg
   dir: swift-DEVELOPMENT-SNAPSHOT-2024-03-04-a


### PR DESCRIPTION
Added {% include_relative %} in platformsupport.md to show updated PlatformSupport content.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->Updated PlatformSuppport file so that it shows Latest Content

### Motivation:

As https://swift.org/about/#platform-support is outdated

### Modifications:

Updated the file by removing the previous content and adding the Latest file using Liquid Tag.

### Result:

Now , https://swift.org/about/#platform-support will show the correct Platform Support details.
