### PR TITLE
Add entry for new article on enabling complete concurrency checking

### DIFF
--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -54,6 +54,10 @@
     description: |
       DocC is a documentation compiler that makes it easy for you to produce documentation for your Swift frameworks and packages.
       The compiler builds your documentation by combining the comments you write in source with extension files, articles, and tutorials that live alongside your package's source code.
+  - title: Enabling Complete Concurrency Checking
+    url: /documentation/concurrency/
+    description: |
+        Prepare for Swift 6 by enabling complete concurrency checking in your SwiftPM packages, Xcode projects, and CI scripts.
 #----------------------------------------------------
 - header: Contributing
   pages:


### PR DESCRIPTION
A new documentation article was added with the release of Swift 5.10.

This PR adds an entry to the `documentation.yaml` file so the article appears on the Documentation page, as well as its existing link from the Swift 5.10 announcement blog post.