### PR TITLE
Add missing directory to blog post

### DIFF
--- a/_posts/2024-03-12-byte-sized-swift-tiny-games-playdate.md
+++ b/_posts/2024-03-12-byte-sized-swift-tiny-games-playdate.md
@@ -146,7 +146,7 @@ I started by locating the Playdate C header files:
 $ ls $HOME/Developer/PlaydateSDK/C_API/
 Examples     buildsupport pd_api       pd_api.h
 
-$ ls $HOME/Developer/PlaydateSDK/C_API/
+$ ls $HOME/Developer/PlaydateSDK/C_API/pd_api
 pd_api_display.h     pd_api_gfx.h         pd_api_lua.h         pd_api_sound.h       pd_api_sys.h
 pd_api_file.h        pd_api_json.h        pd_api_scoreboards.h pd_api_sprite.h
 ```

--- a/_posts/2024-03-12-byte-sized-swift-tiny-games-playdate.md
+++ b/_posts/2024-03-12-byte-sized-swift-tiny-games-playdate.md
@@ -26,7 +26,7 @@ Over the holiday season, I read about building Playdate games in C and became cu
 
 While most Playdate games are written in Lua for ease of development, they can run into performance problems that necessitate the added complexity of using C. Swift's combination of high-level ergonomics with low-level performance, as well as its strong support for interoperating with C, make it seem like a good match for the Playdate. However, the typical Swift application and runtime exceed the device's tight resource constraints.
 
-Regardless, I still wanted to create a game in Swift and I had good idea for the approach.
+Regardless, I still wanted to create a game in Swift and I had a good idea for the approach.
 
 ### The Embedded Language Mode
 


### PR DESCRIPTION
Adds a missing "pd_api" to an "ls" command used in the playdate blog post.
