### PR TITLE
Add Federico Bucchi as SWWG member

### DIFF
--- a/_data/website-workgroup/members.yml
+++ b/_data/website-workgroup/members.yml
@@ -10,6 +10,10 @@
   github: daveverwer
   affiliation: Swift Package Index
 
+- name: Federico Bucchi
+  github: federicobucchi
+  affiliation: Apple
+
 - name: James Dempsey
   github: dempseyatgithub
   affiliation:


### PR DESCRIPTION
### Motivation:

Federico Bucchi was approved as SWWG member: https://forums.swift.org/t/application-to-apply-for-joining-the-swift-website-workgroup/69731

### Modifications:

Added Federico Bucchi info in `members.yml`

### Result:

Federico Bucchi appears in https://www.swift.org/website-workgroup/
