### PR TITLE
March 2024 SWWG Membership updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,7 +36,7 @@
 
 # The following lines are used by GitHub to automatically recommend reviewers.
 
-* @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @mschinis @shahmishal @TimTr @tomerd @cthielen
+* @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @shahmishal @cthielen @federicobucchi
 
 /_posts/* @cthielen @TimTr @tkremenek @tomerd
 

--- a/_data/website-workgroup/emeriti.yml
+++ b/_data/website-workgroup/emeriti.yml
@@ -9,3 +9,11 @@
 - name: Michael Schinis
   github: mschinis
   affiliation:
+
+- name: Tim Triemstra
+  github: TimTr
+  affiliation: Apple
+
+- name: Tom Doron
+  github: tomerd
+  affiliation: Apple

--- a/_data/website-workgroup/members.yml
+++ b/_data/website-workgroup/members.yml
@@ -10,6 +10,10 @@
   github: daveverwer
   affiliation: Swift Package Index
 
+- name: Federico Bucchi
+  github: federicobucchi
+  affiliation: Apple
+  
 - name: James Dempsey
   github: dempseyatgithub
   affiliation:
@@ -20,7 +24,7 @@
 
 - name: Paris Pittman
   github: parispittman
-  affiliation: Apple
+  affiliation: Apple, Core Team rep
 
 - name: Reda Lemeden
   github: kaishin
@@ -29,11 +33,3 @@
 - name: Tim Condon
   github: 0xTim
   affiliation: Vapor
-
-- name: Tim Triemstra
-  github: TimTr
-  affiliation: Apple
-
-- name: Tom Doron
-  github: tomerd
-  affiliation: Apple, Core team rep


### PR DESCRIPTION
Make website workgroup membership updates to be merged along with forum post announcement.

- Add Federico Bucchi as a member
- Move Tim Triemstra and Tom Doron to the emeritus list
- Designate Paris Pittman as the Core Team rep