### PR TITLE
Consolidate constant urls at top of script

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -9,10 +9,10 @@
 // ===---------------------------------------------------------------------===//
 'use strict'
 
-let EVOLUTION_METADATA_URL = 'https://download.swift.org/swift-evolution/proposals.json'
-let GITHUB_BASE_URL = 'https://github.com/'
-let REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
-let UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'
+const EVOLUTION_METADATA_URL = 'https://download.swift.org/swift-evolution/proposals.json'
+const GITHUB_BASE_URL = 'https://github.com/'
+const REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
+const UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'
 
 /** Holds the primary data used on this page: metadata about Swift Evolution proposals. */
 var proposals

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -9,6 +9,11 @@
 // ===---------------------------------------------------------------------===//
 'use strict'
 
+let EVOLUTION_METADATA_URL = 'https://download.swift.org/swift-evolution/proposals.json'
+let GITHUB_BASE_URL = 'https://github.com/'
+let REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
+let UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'
+
 /** Holds the primary data used on this page: metadata about Swift Evolution proposals. */
 var proposals
 
@@ -64,10 +69,6 @@ const upcomingFeatureFlags = new Map([
 var filterSelection = []
 
 var upcomingFeatureFlagFilterEnabled = false
-
-var GITHUB_BASE_URL = 'https://github.com/'
-var REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
-var UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.
@@ -196,7 +197,7 @@ function init() {
   })
 
   document.querySelector('#proposals-count-number').innerHTML = 'Loading…'
-  req.open('get', 'https://download.swift.org/swift-evolution/proposals.json')
+  req.open('get', EVOLUTION_METADATA_URL)
   req.send()
 }
 


### PR DESCRIPTION
Small refactoring PR to consolidate URL constants at the top of the script and make them `const` instead of `var`.

Also add a constant for the URL for the evolution metadata JSON file. This also makes it easier for testing the new JSON file URL during development.