### PR TITLE
Add ability for dashboard script to work with current and proposed schemas

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -168,6 +168,11 @@ function init() {
       languageVersions = evolutionMetadata.implementationVersions
     }
     
+    // Don't display malformed proposals
+    proposals = proposals.filter(function (proposal) {
+      return !proposal.errors
+    })
+    
     // Add upcomingFeatureFlag to proposal if present in mapping.
     // Temporary until upcomingFeatureFlag property is returned in proposals.json. 
     for (var proposal of proposals) {


### PR DESCRIPTION
This PR allows the SE Dashboard script to work with the current JSON schema and the new JSON schema.

This facilitates development and testing during the transition to the updated schema as detailed here; https://forums.swift.org/t/swift-evolution-metadata-proposed-changes/70779

Tested with both the existing JSON file at:
`https://download.swift.org/swift-evolution/proposals.json`

And a test version of the proposed schema at:
`https://download.swift.org/swift-evolution/v1/evolution.json`

From the user's standpoint, there is no observable change in the page.