### PR TITLE
<516> Add link to dependencies

### DIFF
--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -2,6 +2,8 @@
 
 [Windows Package Manager](https://docs.microsoft.com/windows/package-manager/) (aka WinGet) comes pre-installed with Windows 11 (21H2 and later). It can also be found in the [Microsoft Store](https://www.microsoft.com/p/app-installer/9nblggh4nns1) or be [installed directly](ms-appinstaller:?source=https://aka.ms/getwinget).
 
+0. Setup all needed [dependencies](/install/windows/#dependencies).
+
 0. Install required Visual Studio components:
 
    Install the latest MSVC toolset and Windows 11 SDK (10.0.22000) through Visual Studio 2022 Community installer. You may change the Visual Studio edition depending on your usage and team size.


### PR DESCRIPTION
### Motivation:

Related to: https://github.com/apple/swift-org-website/issues/516
I think that just adding the link to /install/windows would leave the user again on an unexpected place.  What about having a first step that reminds again on taking care of dependencies?

### Modifications:

Add link to dependencies on step 1 for **Installation via Windows Package Manager**

### Result:

User is now aware of Dependencies without having to scroll up