### PR TITLE
Tweak the title to remove the official-sounding package name

### DIFF
--- a/_posts/2024-03-20-benchmarks.md
+++ b/_posts/2024-03-20-benchmarks.md
@@ -2,7 +2,7 @@
 layout: post
 published: true
 date: 2024-03-20 10:00:00
-title: "Introducing Swift's Benchmark Package: Complementing Unit Tests with Performance Checks"
+title: "Introducing the Benchmark Package: Complementing Unit Tests with Performance Checks"
 author: [hassila]
 ---
 


### PR DESCRIPTION
### Motivation:

Minor correction to the Benchmark blog post title to avoid making it sound like Swift project core package.

### Modifications:

Changes the title of the most recent blog post.
