### PR TITLE
<502> Remove jump when switching page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -11,11 +11,11 @@
         {% for nav in site.data.navigation %}
           <li class="nav-item{% if nav.isCta %} cta{% endif %}">
             {% if nav.isCta and nav.url %}
-              <a href="{{ nav.url }}">{{ nav.header }}</a>
+              <a href="{{ nav.url }}" data-text="{{ nav.header }}"">{{ nav.header }}</a>
             {% else %}
               <span class="{% if page.url == nav.url %}active{% endif %}">
                 {% if nav.url %}
-                  <a href="{{ nav.url }}">{{ nav.header }}</a>
+                  <a href="{{ nav.url }}" data-text="{{ nav.header }}">{{ nav.header }}</a>
                 {% else %}
                   {{ nav.header }}
                 {% endif %}

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -219,11 +219,24 @@ cite {
 
   li {
     display: inline-block;
-    margin-left: 0.5em;
+    margin-left: .3em;
 
     .active a {
       font-weight: 700;
       color: var(--color-active-nav-item);
+    }
+
+    a {
+      display: inline-block;
+    }
+
+    a::before {
+      display: block;
+      content: attr(data-text);
+      font-weight: bold;
+      height: 0;
+      overflow: hidden;
+      visibility: hidden;
     }
 
     &.nav-section {
@@ -245,6 +258,7 @@ cite {
 
       a {
         display: block;
+        text-align: center;
 
         span {
           letter-spacing: 0;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -220,6 +220,7 @@ cite {
   li {
     display: inline-block;
     margin-left: .3em;
+    text-align: center;
 
     .active a {
       font-weight: 700;

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -309,6 +309,7 @@ cite {
     display: block;
     padding: 0;
     margin: 0;
+    text-align: left;
 
     a {
       display: block;
@@ -338,10 +339,12 @@ cite {
 
 .nav-item span i {
   display: inline-block;
-  margin-left: -0.6em;
+  margin-left: -0.75em;
   font-style: normal;
   font-weight: 100;
   opacity: 0.2;
+  line-height: 1em;
+  padding-top: .2em;
 }
 
 .nav-item:hover > span {


### PR DESCRIPTION
### Motivation:

https://github.com/apple/swift-org-website/issues/502

> The menu items shouldn't jump after changing pages

### Modifications:

Added style in: `assets/stylesheets/_screen.scss`

### Result:

The menu items are not shifting after the page change
