### PR TITLE
Update evolution script for proposal changes

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -158,7 +158,7 @@ function init() {
   var req = new window.XMLHttpRequest()
 
   req.addEventListener('load', function() {
-    let evolutionMetadata = JSON.parse(req.responseText, flattenStatus)
+    let evolutionMetadata = JSON.parse(req.responseText, adjustStatusValue)
     
     // Temporary conditional to allow script to work with old and new schemas
     if (Array.isArray(evolutionMetadata)) { // current schema
@@ -210,13 +210,11 @@ function init() {
 }
 
 /** 
- * Reviver function passed to JSON.parse() to convert new status field structure to old structure.
+ * Reviver function passed to JSON.parse() to convert new status field value to old value.
  */
-function flattenStatus(key, value) {
-  if (key == "status" && value !== "" && !value.state) {
-    let [subkey, subvalue] = Object.entries(value)[0]
-    subvalue.state = "." + subkey
-    return subvalue
+function adjustStatusValue(key, value) {
+  if (key == "state" && value !== "" && !value.startsWith(".")) {
+    return "." + value
   }
   return value
 }


### PR DESCRIPTION
An update to allow the SE Dashboard script to continue to work with the current JSON schema and the new JSON schema.

The feedback on the proposed schema reduced the required change to the status field. Now, only a dot needs to be prepended to the new status state value.

This facilitates development and testing during the transition to the updated schema as detailed here; https://forums.swift.org/t/swift-evolution-metadata-proposed-changes/70779

Tested with both the existing JSON file at:
https://download.swift.org/swift-evolution/proposals.json

And a test version of the proposed schema at:
https://download.swift.org/swift-evolution/v1/evolution.json

From the user's standpoint, there is no observable change in the page.