### PR TITLE
<566> Add years in community showcase archive

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -207,9 +207,21 @@ categories:
         platform_compatibility:
           - Apple
           - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
         license: MIT
         url: https://swiftpackageindex.com/orlandos-nl/MongoKitten
+      - name: SwiftyBeaver
+        description: SwiftyBeaver is a flexible, colorful, lightweight logging library
+          for Swift. It supports console, file, and cloud destinations and is ideal for
+          server-side Swift.
+        owner: SwiftyBeaver
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/SwiftyBeaver/SwiftyBeaver
       - name: fluent
         description: Fluent helps you work with databases, providing a high-level, type-safe
           API for querying and manipulating data in Vapor apps.
@@ -234,19 +246,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
         license: Apache 2.0
         url: https://swiftpackageindex.com/hummingbird-project/hummingbird
-      - name: jwt-kit
-        description: Enables SwiftCrypto-based signing and verification of JSON Web Tokens
-          using various algorithms such as HMAC, RSA, ECDSA, and EdDSA. Supports custom
-          headers, key management, and predefined claims.
-        owner: Vapor
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/vapor/jwt-kit
   - name: Networking
     slug: networking
     brief: Browse a selection of packages that can extend and enhance the Swift core
@@ -305,6 +304,17 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/kean/Pulse
+      - name: RxAlamofire
+        description: RxAlamofire is a wrapper around Alamofire that adds RxSwift functionality,
+          simplifying network requests and allowing responses to be composed in a more
+          streamlined way.
+        owner: RxSwift Community
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS)
+        license: MIT
+        url: https://swiftpackageindex.com/RxSwiftCommunity/RxAlamofire
       - name: Networking
         description: Networking is a Swift package that simplifies connecting to a JSON
           API by combining URLSession, async-await (or Combine), Decodable, and Generics.
@@ -315,18 +325,6 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/freshOS/Networking
-      - name: Socket
-        description: BlueSocket is a Socket framework for Swift. It provides functionality
-          for creating, closing, and listening on sockets.
-        owner: Kitura
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/Kitura/BlueSocket
   - name: Testing
     slug: testing
     brief: "If you want to level up your project\u2019s tests, take a look at a selection
@@ -434,6 +432,18 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
         license: BSD 3-Clause
         url: https://swiftpackageindex.com/CocoaLumberjack/CocoaLumberjack
+      - name: SwiftyBeaver
+        description: SwiftyBeaver is a flexible, colorful, lightweight logging library
+          for Swift. It supports console, file, and cloud destinations and is ideal for
+          server-side Swift.
+        owner: SwiftyBeaver
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/SwiftyBeaver/SwiftyBeaver
       - name: swift-log
         description: SwiftLog is a community-driven logging API package for server-side
           Swift applications. It provides easy logging of messages to a shared destination
@@ -469,23 +479,14 @@ categories:
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/kean/Pulse
-      - name: Wormholy
-        description: Wormholy is a debugging tool for iOS network calls. It records app
-          traffic, reveals request and response content, and helps with debugging and
-          bug fixing. It works with NSURLSession and external libraries like Alamofire
-          and AFNetworking.
-        owner: Paolo Musolino
-        license: MIT
-        url: https://swiftpackageindex.com/pmusolino/Wormholy
-      - name: SwiftyBeaver
-        description: SwiftyBeaver is a flexible, colorful, lightweight logging library
-          for Swift. It supports console, file, and cloud destinations and is ideal for
-          server-side Swift.
-        owner: SwiftyBeaver
+      - name: XCGLogger
+        description: XCGLogger is a debug log module for Swift projects that allows you
+          to log details to the console (and optionally a file) with additional information
+          such as date, function name, and line number.
+        owner: Dave Wood
         swift_compatibility: 5.7+
         platform_compatibility:
           - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
         license: MIT
-        url: https://swiftpackageindex.com/SwiftyBeaver/SwiftyBeaver
+        url: https://swiftpackageindex.com/DaveWoodCom/XCGLogger

--- a/_data/packages/showcase-history.yml
+++ b/_data/packages/showcase-history.yml
@@ -1,398 +1,404 @@
-months:
-  - name: March 2024
-    slug: march-2024
-    packages:
-      - name: Adwaita
-        description: Adwaita for Swift enables the creation of user interfaces for GNOME,
-          offering an API similar to SwiftUI, focusing on simplicity and extensive widget
-          support.
-        owner: Aparoksha
-        swift_compatibility: 5.8+
-        platform_compatibility:
-          - Linux
-        platform_compatibility_tooltip: Linux
-        license: MIT
-        url: https://swiftpackageindex.com/AparokshaUI/adwaita-swift
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/30){:target='_blank'}.
-      - name: Time
-        description: Time simplifies working with calendars in Swift, providing type-safe
-          APIs for retrieving and formatting time values. It also allows converting between
-          time zones and calculating differences between dates.
-        owner: Dave DeLong
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/davedelong/time
-        note:
-          Nominated via two posts in the Swift forums ([1](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'},
-          [2](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/35){:target='_blank'}).
-      - name: Fork
-        description: Fork allows for parallelizing multiple async functions. It takes
-          a single input and splits it into two separate async functions that return different
-          outputs that can be merged back into a single output.
-        owner: Zach
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/0xLeif/Fork
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}.
-      - name: Nuke
-        description: Loads and displays images from various sources with advanced processing
-          capabilities and a robust caching system. Optimized for performance, customizable,
-          and extensively tested for reliability.
-        owner: Alex Grebenyuk
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/kean/Nuke
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/27){:target='_blank'}.
-      - name: Prefire
-        description: Prefire automates generation of SwiftUI Preview Playbook views and
-          Snapshot tests, enhancing UI component, screen, and flow visualization and testing.
-        owner: BarredEwe
-        swift_compatibility: 5.8+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS)
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/BarredEwe/Prefire
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/33){:target='_blank'}.
-      - name: Model3DView
-        description: Enables effortless rendering and manipulation of 3D models within
-          SwiftUI applications, supporting features like glTF, interactive camera controls,
-          and environment-based lighting.
-        owner: Freek
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
-        license: MIT
-        url: https://swiftpackageindex.com/frzi/swiftui-model3dview
-        note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
-  - name: February 2024
-    slug: february-2024
-    packages:
-      - name: VersionedCodable
-        description: VersionedCodable allows you to version your Codable types and handle
-          incremental migrations. It provides easy encoding and decoding with support
-          for JSON and property list formats. Suitable for handling complex types in storage.
-        owner: Jonathan Rothwell
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/jrothwell/VersionedCodable
-        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
-      - name: CalendarKit
-        description: CalendarKit is a Swift calendar UI library for iOS and Mac Catalyst.
-          It looks similar to the Apple Calendar app out-of-the-box, while allowing customization
-          when needed.
-        owner: Richard Topchii
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/richardtop/CalendarKit
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6){:target='_blank'}.
-      - name: SQLite.swift
-        description: SQLite.swift is a type-safe, pure-Swift layer over SQLite3. It provides
-          a compile-time confident SQL syntax and intent, with features like type-safe
-          SQL expression builder, query layer, data access, and more.
-        owner: Stephen Celis
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/stephencelis/SQLite.swift
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19){:target='_blank'}.
-      - name: swift-markdown-ui
-        description: MarkdownUI is a powerful library for displaying and customizing Markdown
-          text in SwiftUI. It is compatible with GitHub Flavored Markdown and can display
-          images, headings, lists, blockquotes, code blocks, tables, and more.
-        owner: Guille Gonzalez
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/gonzalezreal/swift-markdown-ui
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
-      - name: Vortex
-        description: Vortex is a powerful particle system library for SwiftUI, enabling
-          the creation of various effects like fire, rain, and snow. It supports iOS,
-          macOS, tvOS, watchOS, and visionOS.
-        owner: Paul Hudson
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/twostraws/Vortex
-        note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
-      - name: SwiftSummarize
-        description: The easiest way to create a summary from a String. Internally it's
-          a simple wrapper around CoreServices SKSummary.
-        owner: Stef Kors
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (macOS, visionOS)
-        license: MIT
-        url: https://swiftpackageindex.com/StefKors/SwiftSummarize
-        note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
-  - name: January 2024
-    slug: january-2024
-    packages:
-      - name: soto
-        description: Soto for AWS is a Swift language SDK for Amazon Web Services (AWS).
-          It provides access to all AWS services via a direct mapping of the REST APIs
-          Amazon publishes for each of its services.
-        owner: Soto for AWS
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/soto-project/soto
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/13){:target='_blank'}.
-      - name: Pow
-        description: Pow provides delightful SwiftUI animations and effects for your app.
-          It includes transitions and change effects which can trigger every time a value
-          is updated.
-        owner: Emerge Tools
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
-        license: MIT
-        url: https://swiftpackageindex.com/EmergeTools/Pow
-        note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
-      - name: OpenAPIKit
-        description: OpenAPIKit allows encoding and decoding of OpenAPI 3.0.x and 3.1.x
-          documents and their components in Swift.
-        owner: Mathew Polzin
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/mattpolzin/OpenAPIKit
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}.
-      - name: Benchmark
-        description: Benchmark helps measure and track performance metrics for apps and
-          frameworks. It supports automated regression checks, manual comparisons, and
-          benchmark result exports in multiple formats.
-        owner: Ordo One
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
-        license: Apache 2.0
-        url: https://swiftpackageindex.com/ordo-one/package-benchmark
-        note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/11){:target='_blank'}.
-      - name: Typhoon
-        description: "Typhoon provides retry policies for handling errors in asynchronous
-          operations. It offers three retry strategy options: constant, exponential, and
-          exponential with jitter."
-        owner: Space Code
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/space-code/typhoon
-        note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
-      - name: SwiftUICoreImage
-        description: Provides a convenient way to chain multiple Core Image filters to
-          CIImage instances and render them into SwiftUI or any other context. It can
-          also be used without SwiftUI.
-        owner: Dan Wood
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
-        license: MIT
-        url: https://swiftpackageindex.com/danwood/SwiftUICoreImage
-        note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
-  - name: December 2023
-    slug: december-2023
-    packages:
-      - name: swift-composable-architecture
-        description: The Composable Architecture is a library for building applications
-          with state management, composition, side effects, and testing in mind. It can
-          be used with SwiftUI, UIKit, and more.
-        owner: Point-Free
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture
-        note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/3){:target='_blank'}.
-      - name: Time
-        description: Time simplifies working with calendars in Swift, providing type-safe
-          APIs for retrieving and formatting time values. It also allows converting between
-          time zones and calculating differences between dates.
-        owner: Dave DeLong
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/davedelong/time
-        note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}.
-      - name: BluetoothLinux
-        description: BluetoothLinux makes working with Bluetooth from Swift easier without
-          needing to wrap underlying libraries from other languages.
-        owner: PureSwift
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/PureSwift/BluetoothLinux
-        note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}.
-      - name: MemberwiseInit
-        description: MemberwiseInit is a Swift Macro that enhances automatic memberwise
-          initializers, reducing boilerplate code. It supports customizable parameter
-          labels and inferring types from property initialization expressions.
-        owner: "Galen O\u2019Hanlon"
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
-          Linux
-        license: MIT
-        url: https://swiftpackageindex.com/gohanlon/swift-memberwise-init-macro
-        note: Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
-      - name: SwiftyGPIO
-        description: SwiftyGPIO is a Swift library for interacting with external sensors
-          and devices on Linux/ARM boards. It supports GPIOs, SPI, I2C, PWM, UART, and
-          1-Wire interfaces. It is specifically designed for Raspberry Pis and other ARM
-          boards running Linux.
-        owner: uraimo
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/uraimo/SwiftyGPIO
-        note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}.
-      - name: Variablur
-        description: Variablur creates variable blur effects in a SwiftUI view using a
-          mask. It supports gradient or progressive blurs, vignettes, and more.
-        owner: Dale Price
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/daprice/Variablur
-        note: Linked in [Issue 637 of iOS Dev Weekly](https://iosdevweekly.com/issues/637#txS8ASr){:target='_blank'}.
-  - name: November 2023
-    slug: november-2023
-    packages:
-      - name: SwiftTUI
-        description: SwiftTUI is a library that brings SwiftUI-like functionality to the
-          terminal, allowing developers to build text-based user interfaces. It supports
-          many features from SwiftUI, such as property wrappers, view builders, and modifiers.
-        owner: Rens Breur
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/rensbreur/SwiftTUI
-        note: Discussed on [Episode 163 of the Empower Apps Podcast](https://brightdigit.com/episodes/163-swiftly-tooling-with-pol-piella-abadia/){:target='_blank'}.
-      - name: SwiftGodot
-        description: SwiftGodot provides Swift language bindings for the Godot game engine.
-          Developers can use it to build extensions or embed Godot directly into Swift
-          applications.
-        owner: Miguel de Icaza
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (macOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/migueldeicaza/SwiftGodot
-        note:
-          Discussed on [Season 5 Episode 28 of Compile Swift](https://www.compileswift.com/podcast/s05e28/){:target='_blank'}
-          podcast.
-      - name: Automerge
-        description: Automerge-swift is a low-level library that implements the Automerge
-          library of data structures for building collaborative applications in Swift.
-        owner: Automerge
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-          - Linux
-        platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
-        license: MIT
-        url: https://swiftpackageindex.com/automerge/automerge-swift
-        note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
-      - name: Grape
-        description: Grape is a Swift library for force simulation and graph visualization.
-          It provides classes for creating simulations and forces and supports both 2D
-          and 3D graphs.
-        owner: Zhen Li
-        swift_compatibility: 5.9+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
-        license: MIT
-        url: https://swiftpackageindex.com/li3zhen1/Grape
-        note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
-      - name: Firefly
-        description: Firefly is a syntax highlighter for iOS and macOS. It uses regular
-          expressions to detect tokens and color them based on the current theme and supports
-          line numbers, customizable themes, and multiple languages.
-        owner: Taylor Lineman
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (macOS)
-        license: MIT
-        url: https://swiftpackageindex.com/ActuallyTaylor/Firefly
-        note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
-      - name: Daily
-        description: "An SDK for developing video applications on iOS with Daily\u2019s
-          real-time audio, video, and vision platform."
-        owner: Daily
-        swift_compatibility: 5.7+
-        platform_compatibility:
-          - Apple
-        platform_compatibility_tooltip: Apple (iOS)
-        license: BSD 2-Clause
-        url: https://swiftpackageindex.com/daily-co/daily-client-ios
-        note: Discussed on [Episode 162 of the Empower Apps Podcast](https://brightdigit.com/episodes/162-building-a-video-sdk-with-marc-schwieterman/){:target='_blank'}.
+years:
+  - year: 2024
+    months:
+      - month: March
+        slug: march
+        packages:
+          - name: Adwaita
+            description: Adwaita for Swift enables the creation of user interfaces for GNOME,
+              offering an API similar to SwiftUI, focusing on simplicity and extensive widget
+              support.
+            owner: Aparoksha
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Linux
+            platform_compatibility_tooltip: Linux
+            license: MIT
+            url: https://swiftpackageindex.com/AparokshaUI/adwaita-swift
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/30){:target='_blank'}.
+          - name: Time
+            description: Time simplifies working with calendars in Swift, providing type-safe
+              APIs for retrieving and formatting time values. It also allows converting
+              between time zones and calculating differences between dates.
+            owner: Dave DeLong
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/davedelong/time
+            note:
+              Nominated via two posts in the Swift forums ([1](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'},
+              [2](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/35){:target='_blank'}).
+          - name: Fork
+            description: Fork allows for parallelizing multiple async functions. It takes
+              a single input and splits it into two separate async functions that return
+              different outputs that can be merged back into a single output.
+            owner: Zach
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/0xLeif/Fork
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}.
+          - name: Nuke
+            description: Loads and displays images from various sources with advanced processing
+              capabilities and a robust caching system. Optimized for performance, customizable,
+              and extensively tested for reliability.
+            owner: Alex Grebenyuk
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/kean/Nuke
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/27){:target='_blank'}.
+          - name: Prefire
+            description: Prefire automates generation of SwiftUI Preview Playbook views
+              and Snapshot tests, enhancing UI component, screen, and flow visualization
+              and testing.
+            owner: BarredEwe
+            swift_compatibility: 5.8+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS)
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/BarredEwe/Prefire
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/33){:target='_blank'}.
+          - name: Model3DView
+            description: Enables effortless rendering and manipulation of 3D models within
+              SwiftUI applications, supporting features like glTF, interactive camera controls,
+              and environment-based lighting.
+            owner: Freek
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/frzi/swiftui-model3dview
+            note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
+      - month: February
+        slug: february
+        packages:
+          - name: VersionedCodable
+            description: VersionedCodable allows you to version your Codable types and handle
+              incremental migrations. It provides easy encoding and decoding with support
+              for JSON and property list formats. Suitable for handling complex types in
+              storage.
+            owner: Jonathan Rothwell
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/jrothwell/VersionedCodable
+            note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
+          - name: CalendarKit
+            description: CalendarKit is a Swift calendar UI library for iOS and Mac Catalyst.
+              It looks similar to the Apple Calendar app out-of-the-box, while allowing
+              customization when needed.
+            owner: Richard Topchii
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/richardtop/CalendarKit
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6){:target='_blank'}.
+          - name: SQLite.swift
+            description: SQLite.swift is a type-safe, pure-Swift layer over SQLite3. It
+              provides a compile-time confident SQL syntax and intent, with features like
+              type-safe SQL expression builder, query layer, data access, and more.
+            owner: Stephen Celis
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/stephencelis/SQLite.swift
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19){:target='_blank'}.
+          - name: swift-markdown-ui
+            description: MarkdownUI is a powerful library for displaying and customizing
+              Markdown text in SwiftUI. It is compatible with GitHub Flavored Markdown and
+              can display images, headings, lists, blockquotes, code blocks, tables, and
+              more.
+            owner: Guille Gonzalez
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/gonzalezreal/swift-markdown-ui
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}.
+          - name: Vortex
+            description: Vortex is a powerful particle system library for SwiftUI, enabling
+              the creation of various effects like fire, rain, and snow. It supports iOS,
+              macOS, tvOS, watchOS, and visionOS.
+            owner: Paul Hudson
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/twostraws/Vortex
+            note: Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}.
+          - name: SwiftSummarize
+            description: The easiest way to create a summary from a String. Internally it's
+              a simple wrapper around CoreServices SKSummary.
+            owner: Stef Kors
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/StefKors/SwiftSummarize
+            note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
+      - month: January
+        slug: january
+        packages:
+          - name: soto
+            description: Soto for AWS is a Swift language SDK for Amazon Web Services (AWS).
+              It provides access to all AWS services via a direct mapping of the REST APIs
+              Amazon publishes for each of its services.
+            owner: Soto for AWS
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS, tvOS)
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/soto-project/soto
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/13){:target='_blank'}.
+          - name: Pow
+            description: Pow provides delightful SwiftUI animations and effects for your
+              app. It includes transitions and change effects which can trigger every time
+              a value is updated.
+            owner: Emerge Tools
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/EmergeTools/Pow
+            note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
+          - name: OpenAPIKit
+            description: OpenAPIKit allows encoding and decoding of OpenAPI 3.0.x and 3.1.x
+              documents and their components in Swift.
+            owner: Mathew Polzin
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/mattpolzin/OpenAPIKit
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}.
+          - name: Benchmark
+            description: Benchmark helps measure and track performance metrics for apps
+              and frameworks. It supports automated regression checks, manual comparisons,
+              and benchmark result exports in multiple formats.
+            owner: Ordo One
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
+            license: Apache 2.0
+            url: https://swiftpackageindex.com/ordo-one/package-benchmark
+            note: Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/11){:target='_blank'}.
+          - name: Typhoon
+            description: "Typhoon provides retry policies for handling errors in asynchronous
+              operations. It offers three retry strategy options: constant, exponential,
+              and exponential with jitter."
+            owner: Space Code
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/space-code/typhoon
+            note: Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
+          - name: SwiftUICoreImage
+            description: Provides a convenient way to chain multiple Core Image filters
+              to CIImage instances and render them into SwiftUI or any other context. It
+              can also be used without SwiftUI.
+            owner: Dan Wood
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS)
+            license: MIT
+            url: https://swiftpackageindex.com/danwood/SwiftUICoreImage
+            note: Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}.
+  - year: 2023
+    months:
+      - month: December
+        slug: december
+        packages:
+          - name: swift-composable-architecture
+            description: The Composable Architecture is a library for building applications
+              with state management, composition, side effects, and testing in mind. It
+              can be used with SwiftUI, UIKit, and more.
+            owner: Point-Free
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/pointfreeco/swift-composable-architecture
+            note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/3){:target='_blank'}.
+          - name: Time
+            description: Time simplifies working with calendars in Swift, providing type-safe
+              APIs for retrieving and formatting time values. It also allows converting
+              between time zones and calculating differences between dates.
+            owner: Dave DeLong
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/davedelong/time
+            note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}.
+          - name: BluetoothLinux
+            description: BluetoothLinux makes working with Bluetooth from Swift easier without
+              needing to wrap underlying libraries from other languages.
+            owner: PureSwift
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/PureSwift/BluetoothLinux
+            note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}.
+          - name: MemberwiseInit
+            description: MemberwiseInit is a Swift Macro that enhances automatic memberwise
+              initializers, reducing boilerplate code. It supports customizable parameter
+              labels and inferring types from property initialization expressions.
+            owner: "Galen O\u2019Hanlon"
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+              and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/gohanlon/swift-memberwise-init-macro
+            note: Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}.
+          - name: SwiftyGPIO
+            description: SwiftyGPIO is a Swift library for interacting with external sensors
+              and devices on Linux/ARM boards. It supports GPIOs, SPI, I2C, PWM, UART, and
+              1-Wire interfaces. It is specifically designed for Raspberry Pis and other
+              ARM boards running Linux.
+            owner: uraimo
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/uraimo/SwiftyGPIO
+            note: Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}.
+          - name: Variablur
+            description: Variablur creates variable blur effects in a SwiftUI view using
+              a mask. It supports gradient or progressive blurs, vignettes, and more.
+            owner: Dale Price
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/daprice/Variablur
+            note: Linked in [Issue 637 of iOS Dev Weekly](https://iosdevweekly.com/issues/637#txS8ASr){:target='_blank'}.
+      - month: November
+        slug: november
+        packages:
+          - name: SwiftTUI
+            description: SwiftTUI is a library that brings SwiftUI-like functionality to
+              the terminal, allowing developers to build text-based user interfaces. It
+              supports many features from SwiftUI, such as property wrappers, view builders,
+              and modifiers.
+            owner: Rens Breur
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS, visionOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/rensbreur/SwiftTUI
+            note: Discussed on [Episode 163 of the Empower Apps Podcast](https://brightdigit.com/episodes/163-swiftly-tooling-with-pol-piella-abadia/){:target='_blank'}.
+          - name: SwiftGodot
+            description: SwiftGodot provides Swift language bindings for the Godot game
+              engine. Developers can use it to build extensions or embed Godot directly
+              into Swift applications.
+            owner: Miguel de Icaza
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/migueldeicaza/SwiftGodot
+            note:
+              Discussed on [Season 5 Episode 28 of Compile Swift](https://www.compileswift.com/podcast/s05e28/){:target='_blank'}
+              podcast.
+          - name: Automerge
+            description: Automerge-swift is a low-level library that implements the Automerge
+              library of data structures for building collaborative applications in Swift.
+            owner: Automerge
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+              - Linux
+            platform_compatibility_tooltip: Apple (iOS, macOS) and Linux
+            license: MIT
+            url: https://swiftpackageindex.com/automerge/automerge-swift
+            note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
+          - name: Grape
+            description: Grape is a Swift library for force simulation and graph visualization.
+              It provides classes for creating simulations and forces and supports both
+              2D and 3D graphs.
+            owner: Zhen Li
+            swift_compatibility: 5.9+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+            license: MIT
+            url: https://swiftpackageindex.com/li3zhen1/Grape
+            note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
+          - name: Firefly
+            description: Firefly is a syntax highlighter for iOS and macOS. It uses regular
+              expressions to detect tokens and color them based on the current theme and
+              supports line numbers, customizable themes, and multiple languages.
+            owner: Taylor Lineman
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (macOS)
+            license: MIT
+            url: https://swiftpackageindex.com/ActuallyTaylor/Firefly
+            note: Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}.
+          - name: Daily
+            description: "An SDK for developing video applications on iOS with Daily\u2019s
+              real-time audio, video, and vision platform."
+            owner: Daily
+            swift_compatibility: 5.7+
+            platform_compatibility:
+              - Apple
+            platform_compatibility_tooltip: Apple (iOS)
+            license: BSD 2-Clause
+            url: https://swiftpackageindex.com/daily-co/daily-client-ios
+            note: Discussed on [Episode 162 of the Empower Apps Podcast](https://brightdigit.com/episodes/162-building-a-video-sdk-with-marc-schwieterman/){:target='_blank'}.

--- a/_plugins/packages.rb
+++ b/_plugins/packages.rb
@@ -17,14 +17,16 @@ module Jekyll
   class CommunityShowcaseHistoryGenerator < Generator
     def generate(site)
       # Generate one page per month for previous Community Showcase lists in the Packages page
-      site.data.dig('packages', 'showcase-history', 'months').each do |month|
-        history_page = PageWithoutAFile.new(site, site.source, "packages", "showcase-#{month['slug']}.md")
-        history_page.data = {
-          'layout' => 'page-wide',
-          'title' => "Community Showcase: #{month['name']}"
-        }
-        history_page.content = "{% include_relative _history.html month_slug=\"#{month['slug']}\" %}"
-        site.pages << history_page
+      site.data.dig('packages', 'showcase-history', 'years').each do |year|
+        year['months'].each do |month|
+          history_page = PageWithoutAFile.new(site, site.source, "packages", "showcase-#{month['slug']}-#{year['name']}.md")
+          history_page.data = {
+            'layout' => 'page-wide',
+            'title' => "Community Showcase: #{month['name']} #{year['name']}"
+          }
+          history_page.content = "{% include_relative _history.html month_slug=\"#{month['slug']}\" %}"
+          site.pages << history_page
+        end
       end
     end
   end

--- a/_plugins/packages.rb
+++ b/_plugins/packages.rb
@@ -19,12 +19,12 @@ module Jekyll
       # Generate one page per month for previous Community Showcase lists in the Packages page
       site.data.dig('packages', 'showcase-history', 'years').each do |year|
         year['months'].each do |month|
-          history_page = PageWithoutAFile.new(site, site.source, "packages", "showcase-#{month['slug']}-#{year['name']}.md")
+          history_page = PageWithoutAFile.new(site, site.source, "packages", "showcase-#{month['slug']}-#{year['year']}.md")
           history_page.data = {
             'layout' => 'page-wide',
-            'title' => "Community Showcase: #{month['name']} #{year['name']}"
+            'title' => "Community Showcase: #{month['month']} #{year['year']}"
           }
-          history_page.content = "{% include_relative _history.html month_slug=\"#{month['slug']}\" %}"
+          history_page.content = "{% include_relative _history.html year=\"#{year['year']}\" month_slug=\"#{month['slug']}\" %}"
           site.pages << history_page
         end
       end

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -57,5 +57,29 @@ layout: source
         }
       });
     });
+
+    const archiveYears = document.querySelectorAll('.archive .years .year');
+
+    if (archiveYears.length > 0) {
+      archiveYears.forEach(function(year) {
+        year.addEventListener('click', function(e) {
+          const activeYear = document.querySelector('.archive .year.active');
+          const activeMonth = document.querySelector('.archive .months.active');
+          const months = document.querySelector(`.archive .months[data-year='${year.textContent}']`);
+
+          if (activeYear) {
+            activeYear.classList.remove('active');
+          }
+
+          e.currentTarget.classList.add('active')
+
+          if (activeMonth) {
+            activeMonth.classList.remove('active');
+          }
+
+          months.classList.add('active');
+        });
+      });
+    }
   });
 })();

--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -63,15 +63,15 @@ layout: source
     if (archiveYears.length > 0) {
       archiveYears.forEach(function(year) {
         year.addEventListener('click', function(e) {
-          const activeYear = document.querySelector('.archive .year.active');
+          const activeYear = document.querySelector('.archive .year[aria-pressed="true"]');
           const activeMonth = document.querySelector('.archive .months.active');
           const months = document.querySelector(`.archive .months[data-year='${year.textContent}']`);
 
           if (activeYear) {
-            activeYear.classList.remove('active');
+            activeYear.setAttribute('aria-pressed', 'false');
           }
 
-          e.currentTarget.classList.add('active')
+          e.currentTarget.setAttribute('aria-pressed', 'true');
 
           if (activeMonth) {
             activeMonth.classList.remove('active');

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -1158,3 +1158,36 @@ article {
     padding: 4px 0 4px 10px;
   }
 }
+
+.archive {
+  .years {
+    display: flex;
+    padding: 0;
+
+    .year {
+      cursor: pointer;
+      margin-right: 1rem;
+      background-color: transparent;
+      border-radius: var(--border-radius);
+      border: 1px solid var(--color-text);
+      color: var(--color-text);
+      display: block;
+      padding: .5rem;
+      text-align: center;
+
+      &:hover, &.active {
+        background-color: var(--color-text);
+        color: var(--color-fill);
+        text-decoration: none;
+      }
+    }
+  }
+
+  .months {
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+}

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -1175,7 +1175,7 @@ article {
       padding: .5rem;
       text-align: center;
 
-      &:hover, &.active {
+      &:hover, &[aria-pressed="true"] {
         background-color: var(--color-text);
         color: var(--color-fill);
         text-decoration: none;

--- a/packages/_history.html
+++ b/packages/_history.html
@@ -1,4 +1,5 @@
-{%- assign month = site.data.packages.showcase-history.months | where: "slug", include.month_slug | first %}
+{%- assign year = site.data.packages.showcase-history.years | where: "year", include.year | first %}
+{%- assign month = year.months | where: "slug", include.month_slug | first %}
 
 <section class="package-list">
   <nav>
@@ -10,7 +11,7 @@
     <a href="https://forums.swift.org/t/68168">this thread on the Swift forums</a> and voted on by the
     <a href="https://swift.org/website-workgroup/">Swift Website Workgroup</a>.
   </p>
-  <p><strong>This list is an archive of the Community Showcase from {{ month.name }}</strong>.</p>
+  <p><strong>This list is an archive of the Community Showcase from {{ month.month }} {{ year.year }}</strong>.</p>
 
   <ul>
     {%- for package in month.packages %} {% include_relative _package.html package=package %} {%- endfor %}

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -29,15 +29,15 @@
 <div class="archive">
   <ul class="years">
     {%- for year in site.data.packages.showcase-history.years %}
-      <button aria-pressed="{% if forloop.index == 1 %}true{% else %}false{% endif %}" class="year">{{ year.name }}</button>
+      <button aria-pressed="{% if forloop.index == 1 %}true{% else %}false{% endif %}" class="year">{{ year.year }}</button>
     {% endfor %}
   </ul>
   {%- for year in site.data.packages.showcase-history.years %}
-    <ul class="months {% if forloop.index == 1 %}active{% endif %}" data-year="{{ year.name }}">
+    <ul class="months {% if forloop.index == 1 %}active{% endif %}" data-year="{{ year.year }}">
       {%- for month in year.months %}
-        {%- assign url = "packages/showcase-" | append: month.slug | append: "-" | append: year.name | append: ".md" %}
+        {%- assign url = "packages/showcase-" | append: month.slug | append: "-" | append: year.year | append: ".md" %}
         <li class="month">
-          <a href="{% link {{ url }} %}">{{ month.name }}</a>
+          <a href="{% link {{ url }} %}">{{ month.month }}</a>
         </li>
       {% endfor %}
     </ul>

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -29,11 +29,11 @@
 <div class="archive">
   <ul class="years">
     {%- for year in site.data.packages.showcase-history.years %}
-      <button class="year">{{ year.name }}</button>
+      <button aria-pressed="{% if forloop.index == 1 %}true{% else %}false{% endif %}" class="year">{{ year.name }}</button>
     {% endfor %}
   </ul>
   {%- for year in site.data.packages.showcase-history.years %}
-    <ul class="months" data-year="{{ year.name }}">
+    <ul class="months {% if forloop.index == 1 %}active{% endif %}" data-year="{{ year.name }}">
       {%- for month in year.months %}
         {%- assign url = "packages/showcase-" | append: month.slug | append: "-" | append: year.name | append: ".md" %}
         <li class="month">

--- a/packages/_package-list.html
+++ b/packages/_package-list.html
@@ -26,12 +26,21 @@
   The Community Showcase <a href="{% post_url 2023-10-31-packages-page %}">launched in November 2023</a> and features a
   new set of packages every month. Browse the archive below to see the history of featured Community Showcase packages:
 </p>
-<ul>
-  {%- for month in site.data.packages.showcase-history.months %}
-  {%- assign url = "packages/showcase-" | append: month.slug | append: ".md" %}
-  <li>
-    <a href="{% link {{ url }} %}"> {{ month.name }} </a>
-  </li>
+<div class="archive">
+  <ul class="years">
+    {%- for year in site.data.packages.showcase-history.years %}
+      <button class="year">{{ year.name }}</button>
+    {% endfor %}
+  </ul>
+  {%- for year in site.data.packages.showcase-history.years %}
+    <ul class="months" data-year="{{ year.name }}">
+      {%- for month in year.months %}
+        {%- assign url = "packages/showcase-" | append: month.slug | append: "-" | append: year.name | append: ".md" %}
+        <li class="month">
+          <a href="{% link {{ url }} %}">{{ month.name }}</a>
+        </li>
+      {% endfor %}
+    </ul>
   {% endfor %}
-</ul>
+</div>
 {% endif %}


### PR DESCRIPTION
### Motivation:

https://github.com/apple/swift-org-website/issues/566

### Modifications:

- Added years in `showcase-history.yml` and include months in each year.
- Loop years instead of months in the view (`_package-list.html`), then loop the months inside each year)
- Add `JS` to make year tabs interactive and show the correct list of months (after you click on an year).
- Add style to handle the new archive view in `_screen.scss`

### Result:

<img width="1097" alt="Screenshot 2024-03-24 at 8 22 36 PM" src="https://github.com/apple/swift-org-website/assets/59409/579aa439-2925-476f-b61c-31aa6feaa250">

<img width="1103" alt="Screenshot 2024-03-24 at 8 22 44 PM" src="https://github.com/apple/swift-org-website/assets/59409/c9693f7e-7e37-4765-b6f8-9d3aba2dfebc">

<img width="560" alt="Screenshot 2024-03-24 at 8 22 56 PM" src="https://github.com/apple/swift-org-website/assets/59409/73f4242f-a088-45df-87ab-d56ff2baef74">
