### PR TITLE
Fix all drop-down items highlighted as active

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -51,8 +51,8 @@
   <nav class="mobile-navigation" role="navigation">
     <ul class="mobile-navigation-links">
       {% for nav in site.data.navigation %}
-        <li class="nav-item {% if page.url == nav.url %}active{% endif %}{% if nav.isCta %} cta{% endif %}">
-          <div class="link-container">
+        <li class="nav-item{% if nav.isCta %} cta{% endif %}">
+          <div class="link-container{% if page.url == nav.url %} active{% endif %}">
             {% if nav.url %}
               <a href="{{ nav.url }}">{{ nav.header }}</a>
               {% else %}

--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -348,7 +348,8 @@ cite {
     border-top: 1px solid var(--color-nav-rule);
     display: block;
 
-    &.active {
+    &.active,
+    .link-container.active {
       a {
         font-weight: 700;
         color: #F05138; // TODO: Use variable


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

I noticed that all drop-down items are highlighted as active if the top-level item is active. This PR fixes that.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Moved `.active` class to the `.link-container` div

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2024-03-26 at 18 59 33](https://github.com/apple/swift-org-website/assets/35671299/03826e1b-0432-4787-b935-6d427da392d6)|![CleanShot 2024-03-26 at 18 59 56](https://github.com/apple/swift-org-website/assets/35671299/9ab1b9cd-a6c6-44a5-90e2-7484e8f462fb)|
