### PR TITLE
Added a databases category to the Packages page

### DIFF
--- a/_data/packages/packages.yml
+++ b/_data/packages/packages.yml
@@ -488,9 +488,84 @@ categories:
           to log details to the console (and optionally a file) with additional information
           such as date, function name, and line number.
         owner: Dave Wood
+  - name: Database access
+    slug: database
+    brief: We all need to store data somewhere! Find everything from local SQLite databases
+      to connections to server-based databases from your Swift on server apps.
+    description:
+      When looking for something as an alternative to [Core Data](https://developer.apple.com/documentation/coredata)
+      or [SwiftData](https://developer.apple.com/xcode/swiftdata/), look no further
+      than this list of popular database packages.
+    more:
+      title: More database packages
+      url: https://swiftpackageindex.com/keywords/database
+    packages:
+      - name: GRDB
+        description: GRDB is a SQLite toolkit for application development. It provides
+          SQL generation, database observation, robust concurrency, migrations, and raw
+          SQL access.
+        owner: "Gwendal Rou\xE9"
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (macOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/groue/GRDB.swift
+      - name: MongoKitten
+        description: MongoKitten is a fast, pure Swift MongoDB driver built for Server
+          Side Swift. It supports both MongoDB in server and embedded environments and
+          can be used with Vapor or Hummingbird.
+        owner: Orlandos Technologies - OpenSource
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS) and Linux
+        license: MIT
+        url: https://swiftpackageindex.com/orlandos-nl/MongoKitten
+      - name: Realm
+        description: Realm is a mobile database for iOS, macOS, tvOS, and watchOS. It
+          offers an object-oriented data model, real-time syncing, and encryption. It
+          integrates with SwiftUI and supports various installation methods.
+        owner: Realm
         swift_compatibility: 5.7+
         platform_compatibility:
           - Apple
         platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/realm/realm-swift
+      - name: fluent
+        description: Fluent helps you work with databases, providing a high-level, type-safe
+          API for querying and manipulating data in Vapor apps.
+        owner: Vapor
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+          - Linux
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS) and
+          Linux
+        license: MIT
+        url: https://swiftpackageindex.com/vapor/fluent
+      - name: USearch
+        description: USearch enhances vector and upcoming text similarity search with
+          faster, smaller, and broadly compatible implementations. It offers extensibility,
+          fewer dependencies, and supports multiple programming languages.
+        owner: Unum
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, visionOS, watchOS, tvOS)
+        license: Apache 2.0
+        url: https://swiftpackageindex.com/unum-cloud/usearch
+      - name: RxRealm
+        description: RxRealm provides reactive extensions for RealmSwift, allowing you
+          to observe and manipulate objects and collections of objects, bind to table
+          and collection views, and write transactions.
+        owner: RxSwift Community
+        swift_compatibility: 5.7+
+        platform_compatibility:
+          - Apple
+        platform_compatibility_tooltip: Apple (iOS, macOS, watchOS, tvOS)
         license: MIT
         url: https://swiftpackageindex.com/DaveWoodCom/XCGLogger


### PR DESCRIPTION
As suggested in [this Swift forums thread](https://forums.swift.org/t/packages-page-on-swift-org-relevance-of-a-persistence-or-databases-category/70868) this PR adds a “Database access” package list to the Packages page.

There is more discussion in [the original thread](https://forums.swift.org/t/packages-page-on-swift-org-relevance-of-a-persistence-or-databases-category/70868).

![Screenshot 2024-04-01 at 12 48 21@2x](https://github.com/apple/swift-org-website/assets/5180/4099636b-e72f-43fe-8458-35cfe65cf732)
