### PR TITLE
Add Platform Steering Group to community navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -96,6 +96,21 @@
           name: evolution-process
         - title: Community participation
           name: community-participation
+    - title: Platform Steering Group
+      url: /platform-steering-group/
+      sections:
+        - title: Charter
+          name: charter
+        - title: Membership
+          name: membership
+        - title: Evolution
+          name: evolution
+        - title: Communication
+          name: communication
+        - title: Platform Evolution process
+          name: platform-evolution-process
+        - title: Community participation
+          name: community-participation
     - title: C++ Interoperability
       url: /cxx-interop-workgroup/
       sections:


### PR DESCRIPTION
The charter and info about the new Platform Steering Group was added to the site with PR #624.

However, the content landed without adding a link to the new group in the Workgroups section in the Community menu.

This PR adds an entry in the navigation.yml file for the new steering group.