### PR TITLE
Use Swift orange color for all active nav items

### DIFF
--- a/assets/stylesheets/_screen.scss
+++ b/assets/stylesheets/_screen.scss
@@ -370,7 +370,7 @@ cite {
     .link-container.active {
       a {
         font-weight: 700;
-        color: #f05138; // TODO: Use variable
+        color: var(--color-active-nav-item);
       }
     }
 

--- a/assets/stylesheets/core/_colors.scss
+++ b/assets/stylesheets/core/_colors.scss
@@ -1,4 +1,8 @@
 $base-colors: (
+  swift-orange: (
+    light: #f05138,
+    dark: #f05138,
+  ),
   figure-gray: (
     light: rgb(0, 0, 0),
     dark: rgb(255, 255, 255),

--- a/assets/stylesheets/core/colors/_dark.scss
+++ b/assets/stylesheets/core/colors/_dark.scss
@@ -2,7 +2,7 @@
   --color-nav-background: var(--color-fill-tertiary);
   --color-nav-rule: #{dark-color(fill-gray-tertiary)};
   --color-active-menu-group: #{light-color(fill-tertiary)};
-  --color-active-nav-item: #{light-color(figure-orange)};
+  --color-active-nav-item: #{dark-color(swift-orange)};
   --color-fill: #{dark-color(fill)};
   --color-fill-secondary: #{dark-color(fill-secondary)};
   --color-fill-tertiary: #{dark-color(fill-tertiary)};

--- a/assets/stylesheets/core/colors/_light.scss
+++ b/assets/stylesheets/core/colors/_light.scss
@@ -2,7 +2,7 @@
   --color-nav-background: var(--color-fill-secondary);
   --color-nav-rule: rgb(230, 230, 230);
   --color-active-menu-group: #{dark-color(fill-tertiary)};
-  --color-active-nav-item: #{dark-color(figure-orange)};
+  --color-active-nav-item: #{light-color(swift-orange)};
   --color-fill: #{light-color(fill)};
   --color-fill-secondary: #{light-color(fill-secondary)};
   --color-fill-tertiary: #{light-color(fill-tertiary)};


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Currently, we use an orange color that's slightly off from the "Swift orange" color for the active nav item color. Furthermore, we _do_ actually use the Swift orange color, but only in the mobile menu. We should align these.

I propose to just use the Swift orange color in both light and dark mode as it works well, and is more on-brand than at the moment.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Add a new "swift-orange" color
- Use this color consistently for active nav items

### Result:

<!-- _[After your change, what will change.]_ -->

#### Light mode
|Before|After|
|---|---|
|![CleanShot 2024-04-05 at 09 58 15](https://github.com/apple/swift-org-website/assets/35671299/7a76992c-7290-456e-b205-b80df830a4b1)|![CleanShot 2024-04-05 at 09 59 47](https://github.com/apple/swift-org-website/assets/35671299/e53f7a65-1897-4ec2-ae8c-6536e2c63563)|

#### Dark mode
|Before|After|
|---|---|
|![CleanShot 2024-04-05 at 09 58 27](https://github.com/apple/swift-org-website/assets/35671299/7375755c-cb3b-436b-841b-3b5d229ca395)|![CleanShot 2024-04-05 at 09 59 37](https://github.com/apple/swift-org-website/assets/35671299/a30a3ef2-00db-4024-80eb-154796381ef5)|

#### Mobile — no changes
|Light|Dark|
|---|---|
|![CleanShot 2024-04-05 at 09 58 48](https://github.com/apple/swift-org-website/assets/35671299/a21d988e-3962-41a4-b7d9-5e6a9cd39601)|![CleanShot 2024-04-05 at 09 58 41](https://github.com/apple/swift-org-website/assets/35671299/31818cfb-8039-49a5-9be3-91629b92502d)|

