### PR TITLE
Improve page layout with <footer> element

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,10 +9,13 @@ layout: default
       </header>
     {% endif %}
   {% endunless %}
+
   {{ content }}
+
   {% if page.author %}
-    <hr>
-    <p>Contributed by</p>
-    {% include authors.html authors=page.author %}
+    <footer>
+      <p>Contributed by</p>
+      {% include authors.html authors=page.author %}
+    </footer>
   {% endif %}
 </article>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

We're using the `<footer>` element on `article` layout pages for the author bylines. This is styled with some margin and a divider between the content and the authors.

We should use this on `page` layout pages too, to keep the styling consistent.

Using a `<footer>` element here will also improve the semantics of the HTML for the `page` layout.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Replaced the `<hr>` in the `page` layout with a `<footer>`

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2024-04-10 at 20 58 12](https://github.com/apple/swift-org-website/assets/35671299/12e3feae-2376-4ea8-baf5-540c29917a63)|![CleanShot 2024-04-10 at 20 57 51](https://github.com/apple/swift-org-website/assets/35671299/fcc40bd8-3820-4091-b62c-d890c5ff99cc)|

Which now looks the same as the blog posts' footer:

<img src="https://github.com/apple/swift-org-website/assets/35671299/22b87c47-72ec-45a0-976d-cd3a32a94ab8" width=400 />