### PR TITLE
feat: add Contributor Experience Workgroup and Platforms Steering Group

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -26,12 +26,13 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 * __[Code Owner](#code-owners)__ is the individual responsible for a specific area of the Swift codebase.
 * __[Committer](/contributing/#commit-access)__ is anyone that has commit access to the Swift code base.
 * __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review.
+* __Steering Groups__
+   * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
+   * __[Platforms Steering Group](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
 * __Workgroups__
    * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
    * __[Contributor Experience Workgroup](/contributor-experience-workgroup)__ is a team that supports contributors to the Swift project, including contributions on the Swift Forums.
    * __[Documentation Workgroup](/documentation-workgroup)__ is a team that helps guide the documentation experience for Swift.
-   * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
-   * __[Platforms Steering Group](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
    * __[Swift on Server Workgroup](/sswg)__ is a team that promotes the use of Swift for developing and deploying server applications.
    * __[Website Workgroup](/website-workgroup/)__ is a team that helps guide the evolution on the Swift.org website.
 

--- a/community/index.md
+++ b/community/index.md
@@ -28,12 +28,12 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 * __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review.
 * __Workgroups__
    * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
-   * __[Contributor Experience Workgroup](/contributor-experience-workgroup)__ is a steering team that supports contributors to the Swift project, including contributions on the Swift Forums.
-   * __[Documentation Workgroup](/documentation-workgroup)__ is a steering team that helps guide the documentation experience for Swift.
+   * __[Contributor Experience Workgroup](/contributor-experience-workgroup)__ is a team that supports contributors to the Swift project, including contributions on the Swift Forums.
+   * __[Documentation Workgroup](/documentation-workgroup)__ is a team that helps guide the documentation experience for Swift.
    * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
    * __[Platforms Steering Group](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
-   * __[Swift on Server Workgroup](/sswg)__ is a steering team that promotes the use of Swift for developing and deploying server applications.
-   * __[Website Workgroup](/website-workgroup/)__ is a steering team that helps guide the evolution on the Swift.org website.
+   * __[Swift on Server Workgroup](/sswg)__ is a team that promotes the use of Swift for developing and deploying server applications.
+   * __[Website Workgroup](/website-workgroup/)__ is a team that helps guide the evolution on the Swift.org website.
 
 Most importantly, everyone that uses Swift is a valued member of our extended community.
 

--- a/community/index.md
+++ b/community/index.md
@@ -28,8 +28,10 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 * __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review.
 * __Workgroups__
    * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
+   * __[Contributor Experience Workgroup](/contributor-experience-workgroup)__ is a steering team that supports contributors to the Swift project, including contributions on the Swift Forums.
    * __[Documentation Workgroup](/documentation-workgroup)__ is a steering team that helps guide the documentation experience for Swift.
    * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
+   * __[Platforms Steering Group](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
    * __[Swift on Server Workgroup](/sswg)__ is a steering team that promotes the use of Swift for developing and deploying server applications.
    * __[Website Workgroup](/website-workgroup/)__ is a steering team that helps guide the evolution on the Swift.org website.
 

--- a/community/index.md
+++ b/community/index.md
@@ -27,14 +27,14 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 * __[Committer](/contributing/#commit-access)__ is anyone that has commit access to the Swift code base.
 * __[Contributor](/contributing/#contributing-code)__ is anyone that contributes a patch or helps with code review.
 * __Steering Groups__
-   * __[Language Steering Group](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
-   * __[Platforms Steering Group](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
+   * __[Language](#language-steering-group)__ is a small group of experts that drive the Swift language forward in a coherent direction.
+   * __[Platforms](/platform-steering-group)__ is a small group of experts that enables the Swift language and its tools to be used in new environments.
 * __Workgroups__
-   * __[C++ Interoperability Workgroup](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
-   * __[Contributor Experience Workgroup](/contributor-experience-workgroup)__ is a team that supports contributors to the Swift project, including contributions on the Swift Forums.
-   * __[Documentation Workgroup](/documentation-workgroup)__ is a team that helps guide the documentation experience for Swift.
-   * __[Swift on Server Workgroup](/sswg)__ is a team that promotes the use of Swift for developing and deploying server applications.
-   * __[Website Workgroup](/website-workgroup/)__ is a team that helps guide the evolution on the Swift.org website.
+   * __[C++ Interoperability](/cxx-interop-workgroup)__ is a team that works on adding the support for the bidirectional interoperability between Swift and C++.
+   * __[Contributor Experience](/contributor-experience-workgroup)__ is a team that supports contributors to the Swift project, including contributions on the Swift Forums.
+   * __[Documentation](/documentation-workgroup)__ is a team that helps guide the documentation experience for Swift.
+   * __[Swift on Server](/sswg)__ is a team that promotes the use of Swift for developing and deploying server applications.
+   * __[Website](/website-workgroup/)__ is a team that helps guide the evolution on the Swift.org website.
 
 Most importantly, everyone that uses Swift is a valued member of our extended community.
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:
- #638 
<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

Added entries for `Contributor Experience Workgroup` and `Platforms Steering Group`, with description copied from each individual page while maintaining similar standards in wording as opposed to other group/workgroups.

### Result:

Contributor Experience Workgroup and Platforms Steering Group will be added