### PR TITLE
Migrate SE Dashboard script to new metadata schema file

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -392,12 +392,11 @@ function renderReviewManagers(reviewManagers) {
 
 /** Create nodes for arrays of authors and review managers. */
 function personNodesForPersonArray(personArray) {
-  let personNodes = personArray.map(function (person) {
+  const personNodes = personArray.map(function (person) {
     if (person.link.length > 0) {
       return html('a', { href: person.link, target: '_blank' }, person.name)
-    } else {
-      return document.createTextNode(person.name)
     }
+    return document.createTextNode(person.name)
   })
   
   return _joinNodes(personNodes, ', ')

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -20,25 +20,6 @@ let proposals
 /** Array of language versions in which proposals have been implemented. */
 let languageVersions
 
-/** 
- * Mapping of proposal ids to upcoming feature flags. 
- * Temporary until upcomingFeatureFlag property is returned in proposals.json. 
- */
-const upcomingFeatureFlags = new Map([
-  ['SE-0274', { "flag": 'ConciseMagicFile' }],
-  ['SE-0286', { "flag": 'ForwardTrailingClosures' }],
-  ['SE-0335', { "flag": 'ExistentialAny' }],
-  ['SE-0354', { "flag": 'BareSlashRegexLiterals' }],
-  ['SE-0383', { "flag": 'DeprecateApplicationMain' }],
-  ['SE-0384', { "flag": 'ImportObjcForwardDeclarations' }],
-  ['SE-0401', { "flag": 'DisableOutwardActorInference' }],
-  ['SE-0409', { "flag": 'InternalImportsByDefault' }],
-  ['SE-0411', { "flag": 'IsolatedDefaultValues' }],
-  ['SE-0413', { "flag": 'FullTypedThrows' }],
-  ['SE-0418', { "flag": 'InferSendableFromCaptures' }],
-  ['SE-0423', { "flag": 'DynamicActorIsolation' }],
-])
-
 /** Storage for the user's current selection of filters when filtering is toggled off. */
 let filterSelection = []
 
@@ -140,14 +121,6 @@ function init() {
     proposals = proposals.filter(function (proposal) {
       return !proposal.errors
     })
-    
-    // Add upcomingFeatureFlag to proposal if present in mapping.
-    // Temporary until upcomingFeatureFlag property is returned in proposals.json. 
-    for (var proposal of proposals) {
-      if (upcomingFeatureFlags.has(proposal.id)) {
-        proposal.upcomingFeatureFlag = upcomingFeatureFlags.get(proposal.id)
-      }
-    }
 
     // Descending numeric sort based the numeric nnnn in a proposal ID's SE-nnnn
     proposals.sort(function compareProposalIDs (p1, p2) {

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -15,36 +15,10 @@ const REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/ma
 const UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'
 
 /** Holds the primary data used on this page: metadata about Swift Evolution proposals. */
-var proposals
+let proposals
 
-/**
- * To be updated when proposals are confirmed to have been implemented
- * in a new language version.
- */
-var languageVersions = [
-  '2.2',
-  '3.0',
-  '3.0.1',
-  '3.1',
-  '4.0',
-  '4.1',
-  '4.2',
-  '5.0',
-  '5.1',
-  '5.2',
-  '5.3',
-  '5.4',
-  '5.5',
-  '5.5.2',
-  '5.6',
-  '5.7',
-  '5.8',
-  '5.9',
-  '5.9.2',
-  '5.10',
-  '6.0',
-  'Next'
-]
+/** Array of language versions in which proposals have been implemented. */
+let languageVersions
 
 /** 
  * Mapping of proposal ids to upcoming feature flags. 
@@ -66,9 +40,9 @@ const upcomingFeatureFlags = new Map([
 ])
 
 /** Storage for the user's current selection of filters when filtering is toggled off. */
-var filterSelection = []
+let filterSelection = []
 
-var upcomingFeatureFlagFilterEnabled = false
+let upcomingFeatureFlagFilterEnabled = false
 
 /**
  * `name`: Mapping of the states in the proposals JSON to human-readable names.
@@ -159,14 +133,8 @@ function init() {
 
   req.addEventListener('load', function() {
     let evolutionMetadata = JSON.parse(req.responseText, adjustStatusValue)
-    
-    // Temporary conditional to allow script to work with old and new schemas
-    if (Array.isArray(evolutionMetadata)) { // current schema
-      proposals = evolutionMetadata
-    } else { // new schema
-      proposals = evolutionMetadata.proposals
-      languageVersions = evolutionMetadata.implementationVersions
-    }
+    proposals = evolutionMetadata.proposals
+    languageVersions = evolutionMetadata.implementationVersions
     
     // Don't display malformed proposals
     proposals = proposals.filter(function (proposal) {

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -338,7 +338,7 @@ function renderProposals() {
       var detailNodes = []
       detailNodes.push(renderAuthors(proposal.authors))
 
-      if (proposal.reviewManager.name) detailNodes.push(renderReviewManager(proposal.reviewManager))
+      if (proposal.reviewManagers.length > 0) detailNodes.push(renderReviewManagers(proposal.reviewManagers))
       if (proposal.trackingBugs) detailNodes.push(renderTrackingBugs(proposal.trackingBugs))
       if (state === '.implemented') detailNodes.push(renderVersion(proposal.status.version))
       if (state === '.previewing') detailNodes.push(renderPreview())
@@ -370,34 +370,37 @@ function renderProposals() {
 
 /** Authors have a `name` and optional `link`. */
 function renderAuthors(authors) {
-  var authorNodes = authors.map(function (author) {
-    if (author.link.length > 0) {
-      return html('a', { href: author.link, target: '_blank' }, author.name)
-    } else {
-      return document.createTextNode(author.name)
-    }
-  })
-
-  authorNodes = _joinNodes(authorNodes, ', ')
-
   return html('div', { className: 'authors proposal-detail' }, [
     html('div', { className: 'proposal-detail-label' },
       authors.length > 1 ? 'Authors: ' : 'Author: '
     ),
-    html('div', { className: 'proposal-detail-value' }, authorNodes)
+    html('div', { className: 'proposal-detail-value' },
+      personNodesForPersonArray(authors))
   ])
 }
 
 /** Review managers have a `name` and optional `link`. */
-function renderReviewManager(reviewManager) {
-  return html('div', { className: 'review-manager proposal-detail' }, [
-    html('div', { className: 'proposal-detail-label' }, 'Review Manager: '),
-    html('div', { className: 'proposal-detail-value' }, [
-      reviewManager.link
-        ? html('a', { href: reviewManager.link, target: '_blank' }, reviewManager.name)
-        : reviewManager.name
-    ])
+function renderReviewManagers(reviewManagers) {
+  return html('div', { className: 'review-managers proposal-detail' }, [
+    html('div', { className: 'proposal-detail-label' },
+      reviewManagers.length > 1 ? 'Review Managers: ' : 'Review Manager: '
+    ),
+    html('div', { className: 'proposal-detail-value' }, 
+      personNodesForPersonArray(reviewManagers))
   ])
+}
+
+/** Create nodes for arrays of authors and review managers. */
+function personNodesForPersonArray(personArray) {
+  let personNodes = personArray.map(function (person) {
+    if (person.link.length > 0) {
+      return html('a', { href: person.link, target: '_blank' }, person.name)
+    } else {
+      return document.createTextNode(person.name)
+    }
+  })
+  
+  return _joinNodes(personNodes, ', ')
 }
 
 /** Tracking bugs linked in a proposal are updated via GitHub Issues. */
@@ -742,7 +745,7 @@ function _searchProposals(filterText) {
   var searchableProperties = [
       ['id'],
       ['title'],
-      ['reviewManager', 'name'],
+      ['reviewManagers', 'name'],
       ['status', 'state'],
       ['status', 'version'],
       ['authors', 'name'],

--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -9,7 +9,7 @@
 // ===---------------------------------------------------------------------===//
 'use strict'
 
-const EVOLUTION_METADATA_URL = 'https://download.swift.org/swift-evolution/proposals.json'
+const EVOLUTION_METADATA_URL = 'https://download.swift.org/swift-evolution/v1/evolution.json'
 const GITHUB_BASE_URL = 'https://github.com/'
 const REPO_PROPOSALS_BASE_URL = GITHUB_BASE_URL + 'apple/swift-evolution/blob/main/proposals'
 const UFF_INFO_URL = '/blog/using-upcoming-feature-flags/'


### PR DESCRIPTION
This PR migrates the SE Dashboard script to the new metadata schema file.

Details of the schema changes are available in the proposal:
https://forums.swift.org/t/swift-evolution-metadata-proposed-changes/70779

Note this PR consists of multiple commits. It may be easier to review by looking at each commit on its own.

This PR:
- Uses the new metadata file located at `https://download.swift.org/swift-evolution/v1/evolution.json'
- Removes legacy file conditional code and the hard-coded language version array
   - Uses the new `implementationVersions` field for language versions
- Updates top-level variables to use `let`
- Removes hard-coded upcoming feature flags and uses the ones now provided in the metadata
- Migrates to the new `reviewManagers` field to handle cases with multiple review managers
(e.g: SE-0368, SE-0240)
   - Refactors logic from `renderAuthors()` to create list of people
   - Replaces uses of `reviewManager` with `reviewManagers` where appropriate
   
   Have tested, including comparing review manager listing with the listings on the deployed dashboard.