### PR TITLE
Fix empty 'Written by' headline on blog post contributions page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,8 +13,10 @@ layout: base
   {{ content }}
 
   <footer>
-    <p>Written by</p>
-    {% include authors.html authors=page.author %}
+    {% if page.author %}
+      <p>Written by</p>
+      {% include authors.html authors=page.author %}
+    {% endif %}
 
     {% if page.previous or page.next %}
     <nav>

--- a/blog-post-contributions/index.md
+++ b/blog-post-contributions/index.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: page
 title: Blog Post Contributions
 ---
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->



### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Fixes an empty "Written by" headline in the footer on https://www.swift.org/blog-post-contributions/

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Only show the 'Written by' headline in the footer if the post has one or more authors
- Change the layout for /blog-post-contributions/ to `page`, as it better suits the content

### Result:

- No empty footer on /blog-post-contributions/
- Other posts with authors have not changed
- In case we use the `post` layout for a page that doesn't have an author in the future, this empty headline will no longer be shown

<!-- _[After your change, what will change.]_ -->
