### PR TITLE
Changed wording from Swift to Apache 2.0 license

### DIFF
--- a/_includes/getting-started/_installing.md
+++ b/_includes/getting-started/_installing.md
@@ -6,4 +6,4 @@ To kickstart your journey, [install Swift](/install) to begin using it on **macO
 
 Swift comes bundled with the [Swift Package Manager (SwiftPM)]({% link documentation/package-manager/index.md %}) that manages the distribution of Swift code. It allows easy importing of other Swift packages into your applications and libraries, making it a valuable tool for any Swift developer.
 
-Swift is covered by the [Swift License](swift.org/LICENSE.txt).
+Swift is covered by the [Apache License, Version 2.0](/LICENSE.txt).


### PR DESCRIPTION
### Motivation:

Updated language.

### Modifications:

Changed wording from **Swift** to **Apache 2.0** license.

### Result:

Provide accuracy.
