### PR TITLE
Remove https://swiftbook.es from TSPL page

### DIFF
--- a/documentation/tspl/index.md
+++ b/documentation/tspl/index.md
@@ -34,7 +34,6 @@ Get involved with an existing translation project, or start a new one.
 - [Read Chinese translation](https://swiftgg.gitbook.io/swift){:target="_blank"}
 - [Read Japanese translation](https://www.swiftlangjp.com){:target="_blank"}
 - [Read Korean translation](https://bbiguduk.gitbook.io/swift){:target="_blank"}
-- [Read Spanish translation](https://swiftbook.es){:target="_blank"}
 - [Read Ukrainian translation](https://book.swift.org.ua){:target="_blank"}
 </div>
 


### PR DESCRIPTION
https://swiftbook.es website is no longer available, we can re-add it once its back online.