### PR TITLE
Release Swift 5.10.1 with new platforms Debian 12, Fedora 39, Ubuntu …

### DIFF
--- a/_data/builds/swift_releases.yml
+++ b/_data/builds/swift_releases.yml
@@ -1716,3 +1716,72 @@
       docker: 5.10-windowsservercore-ltsc2022
       archs:
         - x86_64
+- name: "5.10.1"
+  tag: swift-5.10.1-RELEASE
+  xcode: Xcode 15.3
+  xcode_release: false
+  date: 2024-06-05
+  platforms:
+    - name: Ubuntu 18.04
+      platform: Linux
+      archs:
+        - x86_64
+    - name: Ubuntu 20.04
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Ubuntu 22.04
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Ubuntu 23.10
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Ubuntu 24.04
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Debian 12
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Fedora 39
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: CentOS 7
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+    - name: Amazon Linux 2
+      platform: Linux
+      docker: Coming soon
+      archs:
+        - x86_64
+        - aarch64
+    - name: Red Hat Universal Base Image 9
+      platform: Linux
+      docker: Coming soon
+      dir: ubi9
+      archs:
+        - x86_64
+        - aarch64
+    - name: Windows 10
+      platform: Windows
+      docker: Coming soon
+      archs:
+        - x86_64

--- a/_data/install/debian.yml
+++ b/_data/install/debian.yml
@@ -1,0 +1,2 @@
+- name: Debian 12
+  url: /install/linux/debian/12

--- a/_data/install/fedora.yml
+++ b/_data/install/fedora.yml
@@ -1,0 +1,2 @@
+- name: Fedora 39
+  url: /install/linux/fedora/39

--- a/_data/install/ubuntu.yml
+++ b/_data/install/ubuntu.yml
@@ -2,3 +2,7 @@
   url: /install/linux/ubuntu/20_04
 - name: Ubuntu 22.04
   url: /install/linux/ubuntu/22_04
+- name: Ubuntu 23.10
+  url: /install/linux/ubuntu/23_10
+- name: Ubuntu 24.04
+  url: /install/linux/ubuntu/24_04

--- a/_includes/install/_build_release.md
+++ b/_includes/install/_build_release.md
@@ -11,7 +11,7 @@
     <p class="description">
       The offical Docker images for Swift.
     </p>
-    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">{{ site.data.builds.swift_releases.last.name }}-{{include.docker_tag}}</a>
+    <a href="https://hub.docker.com/_/swift" class="cta-secondary external">Coming soon</a>
     <a href="/install/linux/docker" class="cta-secondary">Instructions</a>
   </li>
   <li class="resource">

--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -2,12 +2,12 @@ To install a specific toolchain, select platform below:
 
 <div class="interactive-tabs os">
   <div class="tabs">
-    <a href="/install/linux/ubuntu" aria-pressed="{{ include.ubuntu }}">Ubuntu</a>
     <a href="/install/linux/amazonlinux" aria-pressed="{{ include.amazonlinux }}">Amazon Linux</a>
     <a href="/install/linux/centos" aria-pressed="{{ include.centos }}">CentOS</a>
+    <a href="/install/linux/debain" aria-pressed="{{ include.debain }}">Debian</a>
+    <a href="/install/linux/fedora" aria-pressed="{{ include.fedora }}">Fedora</a>
     <a href="/install/linux/ubi" aria-pressed="{{ include.ubi }}">Red Hat</a>
-    <!-- <a href="/install/linux/fedora" aria-pressed="{{ include.fedora }}">Fedora</a>
-    <a href="/install/linux/debain" aria-pressed="{{ include.debain }}">Debian</a> -->
+    <a href="/install/linux/ubuntu" aria-pressed="{{ include.ubuntu }}">Ubuntu</a>
   </div>
 </div>
 

--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -4,7 +4,7 @@ To install a specific toolchain, select platform below:
   <div class="tabs">
     <a href="/install/linux/amazonlinux" aria-pressed="{{ include.amazonlinux }}">Amazon Linux</a>
     <a href="/install/linux/centos" aria-pressed="{{ include.centos }}">CentOS</a>
-    <a href="/install/linux/debain" aria-pressed="{{ include.debain }}">Debian</a>
+    <a href="/install/linux/debian" aria-pressed="{{ include.debian }}">Debian</a>
     <a href="/install/linux/fedora" aria-pressed="{{ include.fedora }}">Fedora</a>
     <a href="/install/linux/ubi" aria-pressed="{{ include.ubi }}">Red Hat</a>
     <a href="/install/linux/ubuntu" aria-pressed="{{ include.ubuntu }}">Ubuntu</a>

--- a/install/linux/debian/12/index.md
+++ b/install/linux/debian/12/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md debian="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.debain  name="Debian 12" pressed="Debian 12" %}
+
+{% include install/_build_release.md platform="Debian 12" docker_tag="debian12" aarch64="true" %}

--- a/install/linux/debian/12/index.md
+++ b/install/linux/debian/12/index.md
@@ -7,6 +7,6 @@ title: Install Swift
 
 {% include install/_linux_platforms_tabs.md debian="true" %}
 
-{% include install/_os_versions_tabs.md os_versions=site.data.install.debain  name="Debian 12" pressed="Debian 12" %}
+{% include install/_os_versions_tabs.md os_versions=site.data.install.debian  name="Debian 12" pressed="Debian 12" %}
 
 {% include install/_build_release.md platform="Debian 12" docker_tag="debian12" aarch64="true" %}

--- a/install/linux/debian/12/index.md
+++ b/install/linux/debian/12/index.md
@@ -7,6 +7,6 @@ title: Install Swift
 
 {% include install/_linux_platforms_tabs.md debian="true" %}
 
-{% include install/_os_versions_tabs.md os_versions=site.data.install.debian  name="Debian 12" pressed="Debian 12" %}
+{% include install/_os_versions_tabs.md os_versions=site.data.install.debian  name="Debian" pressed="Debian 12" %}
 
 {% include install/_build_release.md platform="Debian 12" docker_tag="debian12" aarch64="true" %}

--- a/install/linux/debian/index.md
+++ b/install/linux/debian/index.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md debain="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.debain  name="Debain" %}

--- a/install/linux/debian/index.md
+++ b/install/linux/debian/index.md
@@ -5,6 +5,6 @@ title: Install Swift
 
 {% include install/_os_tabs.md linux="true" %}
 
-{% include install/_linux_platforms_tabs.md debain="true" %}
+{% include install/_linux_platforms_tabs.md debian="true" %}
 
-{% include install/_os_versions_tabs.md os_versions=site.data.install.debain  name="Debain" %}
+{% include install/_os_versions_tabs.md os_versions=site.data.install.debian  name="Debian" %}

--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -7,6 +7,6 @@ title: Install Swift
 
 {% include install/_linux_platforms_tabs.md fedora="true" %}
 
-{% include install/_os_versions_tabs.md os_versions=site.data.install.fedora  name="Fedora 39" pressed="Fedora 39" %}
+{% include install/_os_versions_tabs.md os_versions=site.data.install.fedora  name="Fedora" pressed="Fedora 39" %}
 
 {% include install/_build_release.md platform="Fedora 39" docker_tag="fedora39" aarch64="true" %}

--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md fedora="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.fedora  name="Fedora 39" pressed="Fedora 39" %}
+
+{% include install/_build_release.md platform="Fedora 39" docker_tag="fedora39" aarch64="true" %}

--- a/install/linux/fedora/index.md
+++ b/install/linux/fedora/index.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md fedora="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.fedora  name="Fedora" %}

--- a/install/linux/ubuntu/23_10/index.md
+++ b/install/linux/ubuntu/23_10/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md ubuntu="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.ubuntu  name="Ubuntu" pressed="Ubuntu 23.10" %}
+
+{% include install/_build_release.md platform="Ubuntu 23.10" docker_tag="mantic" aarch64="true"%}

--- a/install/linux/ubuntu/24_04/index.md
+++ b/install/linux/ubuntu/24_04/index.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Install Swift
+---
+
+{% include install/_os_tabs.md linux="true" %}
+
+{% include install/_linux_platforms_tabs.md ubuntu="true" %}
+
+{% include install/_os_versions_tabs.md os_versions=site.data.install.ubuntu  name="Ubuntu" pressed="Ubuntu 24.04" %}
+
+{% include install/_build_release.md platform="Ubuntu 24.04" docker_tag="noble" aarch64="true"%}


### PR DESCRIPTION
…23.10, and Ubuntu 24.04

* Docker images will be available soon.

<img width="772" alt="Screenshot 2024-06-05 at 10 26 56 PM" src="https://github.com/apple/swift-org-website/assets/2727770/3d01553a-ff40-4a15-98a7-96dc05fd672f">
