### PR TITLE
Mark prompts as non-selectable.

### DIFF
--- a/assets/stylesheets/_syntax.scss
+++ b/assets/stylesheets/_syntax.scss
@@ -129,6 +129,17 @@ pre.highlight {
     /* Literal.String.Symbol */
     color: var(--color-syntax-heading);
   }
+
+  /* Make prompts non-selectable, to make it easy to copy and paste */
+  .gp {
+    -webkit-user-select: none;
+    user-select: none;
+
+    & + .w {
+      -webkit-user-select: none;
+      user-select: none;
+    }
+  }
 }
 
 .language-console {


### PR DESCRIPTION
This means that we can have nicely formatted sequences of shell commands with output without it being unclear, while also making it easy to copy just the command without getting the prompt as well.

Here's what it looks like in action:

![](https://github.com/apple/swift-org-website/assets/2750072/b8d67d54-ec92-4fff-9cfa-53539a9cd0c8)


