### PR TITLE
Apply wider template to Install page

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/amazonlinux/2/index.md
+++ b/install/linux/amazonlinux/2/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 
@@ -13,12 +13,12 @@ title: Install Swift
 
 {% include install/_build_snapshot.md platform="Amazon Linux 2"
 aarch64="true"
-branch_dir="development" 
-development="main" 
-docker_tag="nightly-amazonlinux2" 
-development_builds=site.data.builds.development.amazonlinux2 
+branch_dir="development"
+development="main"
+docker_tag="nightly-amazonlinux2"
+development_builds=site.data.builds.development.amazonlinux2
 aarch64_development_builds=site.data.builds.development.amazonlinux2-aarch64
-development_2="release/6.0" 
-docker_tag_2="nightly-6.0-amazonlinux2" 
-development_builds_2=site.data.builds.swift-6_0-branch.amazonlinux2 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.amazonlinux2-aarch64 
+development_2="release/6.0"
+docker_tag_2="nightly-6.0-amazonlinux2"
+development_builds_2=site.data.builds.swift-6_0-branch.amazonlinux2 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.amazonlinux2-aarch64
 branch_dir_2="swift-6.0-branch"%}

--- a/install/linux/amazonlinux/index.md
+++ b/install/linux/amazonlinux/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/centos/7/index.md
+++ b/install/linux/centos/7/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 
@@ -11,12 +11,12 @@ title: Install Swift
 
 {% include install/_build_release.md platform="CentOS 7" docker_tag="centos7" rpm="true" %}
 
-{% include install/_build_snapshot.md platform="CentOS 7" 
-branch_dir="development" 
-development="main" 
-docker_tag="nightly-centos7" 
-development_builds=site.data.builds.development.centos7 
-development_2="release/6.0" 
-docker_tag_2="nightly-6.0-centos7" 
-development_builds_2=site.data.builds.swift-6_0-branch.centos7 
+{% include install/_build_snapshot.md platform="CentOS 7"
+branch_dir="development"
+development="main"
+docker_tag="nightly-centos7"
+development_builds=site.data.builds.development.centos7
+development_2="release/6.0"
+docker_tag_2="nightly-6.0-centos7"
+development_builds_2=site.data.builds.swift-6_0-branch.centos7
 branch_dir_2="swift-6.0-branch"%}

--- a/install/linux/centos/index.md
+++ b/install/linux/centos/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/debian/12/index.md
+++ b/install/linux/debian/12/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/debian/index.md
+++ b/install/linux/debian/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/fedora/index.md
+++ b/install/linux/fedora/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/ubi/9/index.md
+++ b/install/linux/ubi/9/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 
@@ -13,12 +13,12 @@ title: Install Swift
 
 {% include install/_build_snapshot.md platform="ubi 9"
 aarch64="true"
-branch_dir="development" 
-development="main" 
-docker_tag="nightly-rhel-ubi9" 
-development_builds=site.data.builds.development.ubi9 
+branch_dir="development"
+development="main"
+docker_tag="nightly-rhel-ubi9"
+development_builds=site.data.builds.development.ubi9
 aarch64_development_builds=site.data.builds.development.ubi9-aarch64
-development_2="release/6.0" 
-docker_tag_2="nightly-6.0-rhel-ubi9" 
-development_builds_2=site.data.builds.swift-6_0-branch.ubi9 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubi9-aarch64 
+development_2="release/6.0"
+docker_tag_2="nightly-6.0-rhel-ubi9"
+development_builds_2=site.data.builds.swift-6_0-branch.ubi9 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubi9-aarch64
 branch_dir_2="swift-6.0-branch"%}

--- a/install/linux/ubi/index.md
+++ b/install/linux/ubi/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/ubuntu/20_04/index.md
+++ b/install/linux/ubuntu/20_04/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 
@@ -13,12 +13,12 @@ title: Install Swift
 
 {% include install/_build_snapshot.md platform="Ubuntu 20.04"
 aarch64="true"
-branch_dir="development" 
-development="main" 
-docker_tag="nightly-focal" 
-development_builds=site.data.builds.development.ubuntu2004 
+branch_dir="development"
+development="main"
+docker_tag="nightly-focal"
+development_builds=site.data.builds.development.ubuntu2004
 aarch64_development_builds=site.data.builds.development.ubuntu2004-aarch64
-development_2="release/6.0" 
-docker_tag_2="nightly-6.0-focal" 
-development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2004 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2004-aarch64 
+development_2="release/6.0"
+docker_tag_2="nightly-6.0-focal"
+development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2004 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2004-aarch64
 branch_dir_2="swift-6.0-branch"%}

--- a/install/linux/ubuntu/22_04/index.md
+++ b/install/linux/ubuntu/22_04/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 
@@ -13,12 +13,12 @@ title: Install Swift
 
 {% include install/_build_snapshot.md platform="Ubuntu 22.04"
 aarch64="true"
-branch_dir="development" 
-development="main" 
-docker_tag="nightly-jammy" 
-development_builds=site.data.builds.development.ubuntu2204 
+branch_dir="development"
+development="main"
+docker_tag="nightly-jammy"
+development_builds=site.data.builds.development.ubuntu2204
 aarch64_development_builds=site.data.builds.development.ubuntu2204-aarch64
-development_2="release/6.0" 
-docker_tag_2="nightly-6.0-jammy" 
-development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2204 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2204-aarch64 
+development_2="release/6.0"
+docker_tag_2="nightly-6.0-jammy"
+development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2204 aarch64_development_builds_2=site.data.builds.swift-6_0-branch.ubuntu2204-aarch64
 branch_dir_2="swift-6.0-branch"%}

--- a/install/linux/ubuntu/23_10/index.md
+++ b/install/linux/ubuntu/23_10/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/ubuntu/24_04/index.md
+++ b/install/linux/ubuntu/24_04/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/linux/ubuntu/index.md
+++ b/install/linux/ubuntu/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Install Swift
 ---
 

--- a/install/windows/traditional/index.md
+++ b/install/windows/traditional/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: page-wide
 title: Traditional Installation
 ---
 


### PR DESCRIPTION
### Motivation:

This page like the Homepage, Getting Started, Packages and Tools can be made wider

### Modifications:

Applied `page-wide` class to all Install pages

### Result:

<img width="954" alt="Screenshot 2024-06-07 at 9 28 20 PM" src="https://github.com/apple/swift-org-website/assets/59409/30787ecd-f305-4b87-a114-d8f595a31741">
