### PR TITLE
Preselect Linux version on /install if only one version available

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -2,11 +2,11 @@
 
 <div class="interactive-tabs os">
   <div class="tabs">
-    <a href="/install/linux/amazonlinux#versions" aria-pressed="{{ include.amazonlinux }}">Amazon Linux</a>
-    <a href="/install/linux/centos#versions" aria-pressed="{{ include.centos }}">CentOS</a>
-    <a href="/install/linux/debian#versions" aria-pressed="{{ include.debian }}">Debian</a>
-    <a href="/install/linux/fedora#versions" aria-pressed="{{ include.fedora }}">Fedora</a>
-    <a href="/install/linux/ubi#versions" aria-pressed="{{ include.ubi }}">Red Hat</a>
+    <a href="/install/linux/amazonlinux/2#versions" aria-pressed="{{ include.amazonlinux }}">Amazon Linux</a>
+    <a href="/install/linux/centos/7#versions" aria-pressed="{{ include.centos }}">CentOS</a>
+    <a href="/install/linux/debian/12#versions" aria-pressed="{{ include.debian }}">Debian</a>
+    <a href="/install/linux/fedora/39#versions" aria-pressed="{{ include.fedora }}">Fedora</a>
+    <a href="/install/linux/ubi/9#versions" aria-pressed="{{ include.ubi }}">Red Hat</a>
     <a href="/install/linux/ubuntu#versions" aria-pressed="{{ include.ubuntu }}">Ubuntu</a>
   </div>
 </div>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Suggestion from #676 by @daveverwer.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Add Linux version to the Linux platform tab if only one version is available to select from

Note: The best implementation of this would be to store the platforms/versions in a data file and dynamically (at build-time) decide whether we should directly link to the version or not based on the data.

I did start working on this but decided to go for this simpler, manual implementation for now as I think in general the install page data can be reworked to not only store the platforms/versions in a data file but also _generate the pages_ based on this data.

@shahmishal @federicobucchi let me know what you think about this—whether this quick implementation is still worth it or if we should consider the data file solution right away.

### Result:

<!-- _[After your change, what will change.]_ -->

On /install, clicking a Linux platform with only one version will directly link to that version instead of requiring an extra click.