### PR TITLE
Fix strings in autocomplete snippet

### DIFF
--- a/documentation/articles/zero-to-swift-nvim.md
+++ b/documentation/articles/zero-to-swift-nvim.md
@@ -297,9 +297,9 @@ return {
             "hrsh7th/cmp-buffer",
         },
     },
-    { "hrsh7th/cmp-nvim-lsp, lazy = true },
+    { "hrsh7th/cmp-nvim-lsp", lazy = true },
     { "hrsh7th/cmp-path", lazy = true },
-    { "hrsh7th/cmp-buffer, lazy = true },
+    { "hrsh7th/cmp-buffer", lazy = true },
 }
 ```
 


### PR DESCRIPTION
There were some missing closing quotes on some strings in the autocomplete configuration code snippet in the article for setting up Neovim for Swift development.