### PR TITLE
Assign Tim Sneath to the blog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,8 +28,8 @@
 
 # The following lines are used by GitHub to automatically recommend reviewers.
 
-* @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @shahmishal @cthielen @federicobucchi
+* @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @shahmishal @timsneath @federicobucchi
 
-/_posts/* @cthielen @tkremenek @shahmishal
+/_posts/* @timsneath @tkremenek @shahmishal
 
 /gsoc*/ @ktoso


### PR DESCRIPTION
Update CODEOWNERS to assign Tim Sneath to blog review, replacing me.

### Motivation:

Tim Sneath is taking over blog review duties.

### Modifications:

Update CODEOWNERS to reflect role change.

### Result:

Tim Sneath will have the ability to review blog PRs.