### PR TITLE
Add Swift 6 language mode migration banner to landing page

### DIFF
--- a/assets/stylesheets/core/colors/_dark.scss
+++ b/assets/stylesheets/core/colors/_dark.scss
@@ -23,6 +23,9 @@
   --color-figure-red: #{dark-color(figure-red)};
   --color-tutorials-teal: #{dark-color(tutorials-teal)};
 
+  --color-banner-foreground: rgb(240, 81, 56);
+  --color-banner-background: rgb(240, 81, 56, 0.1);
+  --color-banner-detail: rgb(240, 81, 56, 0.5);
   --color-article-body-background: rgb(17, 17, 17);
   --color-button-background-active: #{dark-color(fill-blue)};
   --color-dropdown-background: var(--color-dropdown-dark-background);

--- a/assets/stylesheets/core/colors/_light.scss
+++ b/assets/stylesheets/core/colors/_light.scss
@@ -24,6 +24,9 @@
   --color-figure-red: #{light-color(figure-red)};
   --color-tutorials-teal: #{light-color(tutorials-teal)};
 
+  --color-banner-foreground: rgb(222, 75, 52);
+  --color-banner-background: rgb(222, 75, 52, 0.1);
+  --color-banner-detail: rgb(222, 75, 52, 0.5);
   --color-article-background: var(--color-fill-tertiary);
   --color-article-body-background: var(--color-fill);
   --color-aside-deprecated: var(--color-figure-gray);

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -61,6 +61,31 @@
   }
 }
 
+.banner {
+  padding: 0.75rem 1.25rem;
+  margin: 2rem 0;
+  color: #ffffff;
+  background: #f05138;
+  font-weight: 500;
+  text-align: center;
+  border-radius: var(--border-radius);
+
+  p {
+    margin: 0;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 255, 255, 0.5);
+    text-underline-offset: 2px;
+
+    &:hover {
+      text-decoration-color: #ffffff;
+    }
+  }
+}
+
 .link-grid {
   ul {
     display: grid;

--- a/assets/stylesheets/pages/_landing.scss
+++ b/assets/stylesheets/pages/_landing.scss
@@ -64,8 +64,8 @@
 .banner {
   padding: 0.75rem 1.25rem;
   margin: 2rem 0;
-  color: #ffffff;
-  background: #f05138;
+  color: var(--color-banner-foreground);
+  background: var(--color-banner-background);
   font-weight: 500;
   text-align: center;
   border-radius: var(--border-radius);
@@ -77,11 +77,11 @@
   a {
     color: inherit;
     text-decoration: underline;
-    text-decoration-color: rgba(255, 255, 255, 0.5);
+    text-decoration-color: var(--color-banner-detail);
     text-underline-offset: 2px;
 
     &:hover {
-      text-decoration-color: #ffffff;
+      text-decoration-color: var(--color-banner-foreground);
     }
   }
 }

--- a/index.md
+++ b/index.md
@@ -16,6 +16,10 @@ atom: true
 {% endfor %}
 </div>
 
+<div class="banner">
+  <p>Get ready for the Swift 6 language mode with the <a href="https://www.swift.org/migration/documentation/migrationguide/">official migration guide</a></p>
+</div>
+
 <div class="link-grid">
   <ul>
     <li>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

Add a banner to direct users to the Swift 6 language mode migration guide.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Add banner to landing page + add necessary CSS
  - Note: I'm using an absolute URL here as the migration guide is not hosted in this repository and will otherwise show up as a "not found" page when running locally

### Result:

<!-- _[After your change, what will change.]_ -->

Live preview: https://alexandersandberg-swift-org-banner.netlify.app

![CleanShot 2024-06-12 at 18 37 19](https://github.com/apple/swift-org-website/assets/35671299/f36cd285-e4df-4a75-8596-0150b2baef07)