### PR TITLE
Fix debian12 dependency install instructions

### DIFF
--- a/_includes/linux/debian12.html
+++ b/_includes/linux/debian12.html
@@ -1,5 +1,5 @@
 {% highlight bash %}
-$ yum install \
+$ apt install \
       binutils-gold \
       gcc \
       git \
@@ -12,5 +12,5 @@ $ yum install \
       libxml2-dev \
       pkg-config \
       tzdata \
-      uuid-dev 
+      uuid-dev
 {% endhighlight %}


### PR DESCRIPTION
Debian uses apt, not yum.