### PR TITLE
Update migration banner URL to /migration

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ atom: true
 </div>
 
 <div class="banner">
-  <p>Get ready for the Swift 6 language mode with the <a href="https://www.swift.org/migration/documentation/migrationguide/">official migration guide</a></p>
+  <p>Get ready for the Swift 6 language mode with the <a href="https://www.swift.org/migration/">official migration guide</a></p>
 </div>
 
 <div class="link-grid">


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The banner currently links to https://www.swift.org/migration/documentation/migrationguide/, but the migration guide will soon live at https://www.swift.org/migration/ instead, and we can link to it directly.

https://www.swift.org/migration/ currently does redirect to the migration guide but with a redirection message—which is why we didn't want to use that URL immediately.

This PR is just a draft PR in preparation for when the redirect situation is fixed. Once that's done, this can be merged.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Updated migration banner URL to https://www.swift.org/migration/

### Result:

<!-- _[After your change, what will change.]_ -->

Nice and short URL!
