### PR TITLE
Have the Contributor Experience Workgroup code-own the respective page

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,9 +27,19 @@
 ###
 
 # The following lines are used by GitHub to automatically recommend reviewers.
+#
+# Lines starting with '#' are comments.
+# Each line is a case-sensitive file pattern followed by one or more owners.
+# Order is important — the last matching pattern has the most precedence.
+# More information: https://docs.github.com/en/articles/about-code-owners
+#
+# Please mirror the repository's file hierarchy in case-sensitive lexicographic
+# order.
 
 * @0xTim @alexandersandberg @daveverwer @dempseyatgithub @parispittman @kaishin @shahmishal @timsneath @federicobucchi
 
 /_posts/* @timsneath @tkremenek @shahmishal
+
+/contributor-experience-workgroup/ @swiftlang/contributor-experience
 
 /gsoc*/ @ktoso


### PR DESCRIPTION
### Motivation:

This change is not so much about claiming ownership as getting the workgroup automatically and specially notified about changes to this area and encourage review. I have specified our team as the only owner for now, but I am happy to add more people should it be desired.

cc @swiftlang/contributor-experience
____

We may also want to (co-)own mentorship stuff for the same reason.