### PR TITLE
remove member affiliation

### DIFF
--- a/_data/contributer-experience-workgroup/members.yml
+++ b/_data/contributer-experience-workgroup/members.yml
@@ -8,7 +8,7 @@
 
 - name: Devanshi Modha	
   github: devanshimodha
-  affiliation: Diversity in Swift champion
+  affiliation: 
 
 - name: Egor Zhdan
   github: egorzhdan


### PR DESCRIPTION
Remove affiliation as it ensures alignment with the [updated workgroups](https://www.swift.org/community/)