### PR TITLE
Update Swift Programming Language book link

### DIFF
--- a/getting-started/_use-cases.md
+++ b/getting-started/_use-cases.md
@@ -70,4 +70,4 @@ Here are some examples of the many use cases of Swift, in case you want to jump 
 
 ---
 
-Looking for a language reference? [The Swift Programming Language (TSPL)](https://docs.swift.org/swift-book/) book is available in [multiple languages](/documentation/tspl/#translations).
+Looking for a language reference? [The Swift Programming Language (TSPL)](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/) book is available in [multiple languages](/documentation/tspl/#translations).


### PR DESCRIPTION
Updates the outdated link to The Swift Programming Language book on the Swift website.

### Motivation:

The current link (`https://docs.swift.org/swift-book/`) now displays a message saying:  
*"This content has moved; redirecting to the new location."*  
While it still redirects users, updating the link makes sure that they are taken directly to the latest documentation.  

### Modifications:

- Replaced the old link with the new official link:  
  `https://docs.swift.org/swift-book/documentation/the-swift-programming-language/`  

### Result:

Users will be directed straight to the latest version of the Swift book without encountering the redirect notice. 
