### PR TITLE
Fixed Swift and Swiftly install command for Linux

### DIFF
--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -6,8 +6,8 @@
     The Swiftly installer manages Swift and its dependencies. It supports switching between different versions and downloading updates.
   </p>
   <h4>Run this in a terminal:</h4>
-  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz &amp;&amp; \
-tar zxf swiftly-$(uname -m).tar.gz &amp;&amp; \
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curlo! -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
+tar zxf "swiftly-$(uname -m).tar.gz" &amp;&amp; \
 ./swiftly init --quiet-shell-followup &amp;&amp; \
 . ~/.local/share/swiftly/env.sh &amp;&amp; \
 hash -r

--- a/_includes/install/_linux_platforms_tabs.md
+++ b/_includes/install/_linux_platforms_tabs.md
@@ -6,7 +6,7 @@
     The Swiftly installer manages Swift and its dependencies. It supports switching between different versions and downloading updates.
   </p>
   <h4>Run this in a terminal:</h4>
-  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curlo! -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><button>Copy</button><pre class="highlight"><code>curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" &amp;&amp; \
 tar zxf "swiftly-$(uname -m).tar.gz" &amp;&amp; \
 ./swiftly init --quiet-shell-followup &amp;&amp; \
 . ~/.local/share/swiftly/env.sh &amp;&amp; \

--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -6,21 +6,21 @@ title: Getting Started with Swiftly on Linux
 Download swiftly for [Linux (Intel)](https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-x86_64.tar.gz), or [Linux (ARM)](https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-aarch64.tar.gz).
 
 ```
-curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz
+curl -O "https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz"
 ```
 
 You can verify the integrity of the archive using the PGP signature. This will download the signature, install the swift.org signatures into your keychain, and verify the signature.
 
 ```
 curl https://www.swift.org/keys/all-keys.asc | gpg --import -
-curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig
-gpg --verify swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz
+curl -O "https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig"
+gpg --verify "swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig" "swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz"
 ```
 
 Extract the archive.
 
 ```
-tar -zxf swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz
+tar -zxf "swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz"
 ```
 
 Run the following command in your terminal, to configure swiftly for your account, and automatically download the latest swift toolchain.


### PR DESCRIPTION
Fixed Swift and Swiftly install commands for Linux.

### Motivation:

When using the Zsh shell with Oh My Zsh, magic functions incorrectly escape $(uname -m) as $\(uname -m) when pasting installation commands from documentation. This is a known [issue](https://github.com/ohmyzsh/ohmyzsh/issues/6654) in the Oh My Zsh project.
We need take this issue into account and provide commands that are able to install swift tooling in every environment.

### Modifications:

Wrapped affected commands in parentheses to prevent incorrect escaping.

### Result:

All installation commands now work as expected.
