### PR TITLE
Fix: Code Box Tab Scroll

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_get-started.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_get-started.scss
@@ -438,6 +438,18 @@
 
   &.code-box-with-tabs {
     overflow: hidden;
+
+    h2 {
+      font-size: 22px;
+      line-height: 1.2;
+      margin-bottom: 5px;
+
+      @media only screen and (max-width: 768px) {
+        font-size: 32px;
+        line-height: 1.33;
+      }
+    }
+
     pre {
       display: none;
 
@@ -470,6 +482,11 @@
         margin-bottom: -1px;
       }
     }
+
+    @media only screen and (max-width: 768px) {
+      overflow: scroll;
+      padding-bottom: 1px;
+    }
   }
 
   .link-wrapper {
@@ -490,19 +507,6 @@
 
   .link-single {
     display: flex;
-  }
-
-  &.code-box-with-tabs {
-    h2 {
-      font-size: 22px;
-      line-height: 1.2;
-      margin-bottom: 5px;
-
-      @media only screen and (max-width: 768px) {
-        font-size: 32px;
-        line-height: 1.33;
-      }
-    }
   }
 
   h2 {


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

- The Code Box component tabs are not scrolling on mobile and need to be fixed.

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

- Added component styles.
- Consolidated duplicate selectors

<!-- _[Describe the modifications you've done.]_ -->

### Result:

- Tabs now scroll on mobile..

<!-- _[After your change, what will change.]_ -->
