### PR TITLE
Increase intro text size on landing page

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_index.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_index.scss
@@ -319,6 +319,11 @@ $icons: (
       text-align: left;
     }
   }
+
+  .pillar-intro {
+    font-size: 21px;
+    line-height: 1.5;
+  }
 }
 
 .pillar {

--- a/index.md
+++ b/index.md
@@ -52,11 +52,11 @@ atom: true
 
 <section id="pillar-1" class="section pillar">
     <div class="pillar-wrapper content-wrapper">
-        <p class="pillar-intro body-copy">
+        <p class="pillar-intro">
             Swift is the only language that scales from embedded devices and kernels to apps and cloud infrastructure. It’s simple, and expressive, with incredible performance and safety. And it has unmatched interoperability with C and C++.
         </p>
         <br />
-        <p class="pillar-intro body-copy">
+        <p class="pillar-intro">
             It's the combination of approachability, speed, safety, and all of<br/> Swift’s strengths that make it so unique.
         </p>
     </div>


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The intro text is a bit small.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Increased the intro text to the same size as the other section's subtitle size.

### Result:

<!-- _[After your change, what will change.]_ -->

|Before|After|
|---|---|
|![CleanShot 2025-06-03 at 21 16 41](https://github.com/user-attachments/assets/36aa2b03-4e5c-4e32-8b88-50bda3ddcbdb)|![CleanShot 2025-06-03 at 21 20 00](https://github.com/user-attachments/assets/5e2e1d1d-2ed6-47cc-8f64-bc3c85c447c7)|
