### PR TITLE
Remove line breaks from long WinGet command

### DIFF
--- a/_data/new-data/install/windows/releases.yml
+++ b/_data/new-data/install/windows/releases.yml
@@ -5,10 +5,7 @@ latest-release:
     headline: WinGet
     after-code-text: |
       First, install Windows platform dependencies:
-      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force
-      --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add
-      Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add
-      Microsoft.VisualStudio.Component.VC.Tools.ARM64"</code></pre>
+      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"</code></pre>
       <br />
       Next, install Swift and other dependencies:
       <br /><br />

--- a/assets/stylesheets/new-stylesheets/pages/_get-started.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_get-started.scss
@@ -434,6 +434,10 @@
   pre {
     max-height: 400px;
     border: var(--get-started-code-box-pre-border);
+
+    code {
+      white-space: pre-wrap;
+    }
   }
 
   &.code-box-with-tabs {


### PR DESCRIPTION
The WinGet command for installing Windows platform dependencies contained line breaks. When copied, the line breaks would break the command up in to multiple lines. The first line is a valid command and so runs sucessfully but the subsequent lines are truncated and will produce an error if run.

Update the command to remove line breaks, and update the css for `.code-box pre code` to add back in line breaks in css that are not preserved when the command is copied.

The swiftly install command breaks the command up with backslashes `\` but on Windows we would have to either use `^` for cmd.exe or backtick for powershell. This ambiguity means its safer just to put the whole command on one line.