### PR TITLE
Minor corrections to vscode getting started guide

### DIFF
--- a/documentation/articles/getting-started-with-vscode-swift.md
+++ b/documentation/articles/getting-started-with-vscode-swift.md
@@ -81,8 +81,9 @@ which can include:
 ![Package swift actions](/assets/images/getting-started-with-vscode-swift/language-features/package_actions.png)
 
 <div class="warning" markdown="1">
-Before language features can be used you must perform a `swift build` command on your
-project either on the command line or using a task in VS Code. This populates the index in SourceKit-LSP.
+Prior to Swift 6.1 you must perform a `swift build` command on your project either
+on the command line or using a task in VS Code Before language features can be used.
+This populates the index in SourceKit-LSP.
 </div>
 
 ## Swift Tasks
@@ -142,10 +143,9 @@ target in your Swift package. You may configure these yourself by adding a
 {
   "configurations": [
     {
-      "type": "lldb",
+      "type": "swift",
       "name": "Debug swift-executable",
       "request": "launch",
-      "sourceLanguages": ["swift"],
       "args": ["--hello", "world"],
       "cwd": "${workspaceFolder}",
       "program": "${workspaceFolder}/.build/debug/swift-executable",


### PR DESCRIPTION
Update documentation for getting started with the Swift extension for VS Code:

- SourceKit-LSP has background indexing enabled by default starting in Swift 6.1 which means that users no longer need to run a build before language features are available.
- The debug configuration has changed slightly since previous extension versions. The type should now be `"swift"` instead of `"lldb"`.
