### PR TITLE
Fix wrong marketing strings

### DIFF
--- a/_data/new-data/landing/callouts.yml
+++ b/_data/new-data/landing/callouts.yml
@@ -71,7 +71,7 @@
 
 - title: Adaptable
   subtitle: From microcontrollers to servers.
-  text: "The only language that can span from embedded and kernel, to server and apps. Swift excels no matter where it’s used: from constrained environments like firmware where every byte counts, to cloud services handling billions of requests a day."
+  text: "A powerful language that can span from embedded and kernel, to server and apps. Swift excels no matter where it’s used: from constrained environments like firmware where every byte counts, to cloud services handling billions of requests a day."
   code: |-
     // Configure UART by direct register manipulation 
     // using Swift MMIO. Enables RX and TX, and sets

--- a/index.md
+++ b/index.md
@@ -53,7 +53,7 @@ atom: true
 <section id="pillar-1" class="section pillar">
     <div class="pillar-wrapper content-wrapper">
         <p class="pillar-intro">
-            Swift is the only language that scales from embedded devices and kernels to apps and cloud infrastructure. It’s simple, and expressive, with incredible performance and safety. And it has unmatched interoperability with C and C++.
+            Swift a wonderful language that scales from embedded devices and kernels to apps and cloud infrastructure. It’s simple, and expressive, with incredible performance and safety. And it has unmatched interoperability with C and C++.
         </p>
         <br />
         <p class="pillar-intro">


### PR DESCRIPTION
Fix misleading marketing message. 

### Motivation:

All the motivation is explained in https://github.com/swiftlang/swift-org-website/issues/1044 The website contains false information about Swift being the only language capable of doing kernels, apps, and cloud. 

### Modifications:

Fixed the misleading strings.

### Result:

The website will no longer contain claims about Swift that are proven to be false.
