### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@
 * @0xTim @alexandersandberg @davelester @daveverwer @dempseyatgithub @kaishin @shahmishal @timsneath @federicobucchi
 
 CODEOWNERS @timsneath @tkremenek @shahmishal @davelester
-index.md @timsneath @tkremenek @shahmishal @davelester
+/index.md @timsneath @tkremenek @shahmishal @davelester
 /_data/new-data/landing/* @timsneath @tkremenek @shahmishal @davelester
 /_posts/* @timsneath @tkremenek @shahmishal @davelester
 


### PR DESCRIPTION
Ensure only the main homepage is locked behind specific members and the SWWG can approve and merge PRs for other areas of the site

Currently _any_ index.md page requires approval from Tim, Ted, Mishal or Dave, which makes it hard for the SWWG to evolve other pages and puts a significant bottleneck on getting PRs merged. This PR changes that to (what I believe is) the original intention - to ensure the homepage has approval from the group but other index pages (i.e. any other page) can be edited with an approval from the SWWG
