### PR TITLE
[cxx-interop] Add documentation about changes to SWIFT_SHARED_REFERENCE feature in Swift 6.2

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1304,10 +1304,10 @@ These annotations tell the Swift compiler whether the type is returned as `+1` (
 
 ```c++
 // Returns +1 ownership.
-SharedObject* makeOwnedObject() SWIFT_RETURNS_RETAINED;
+SharedObject* _Nonnull makeOwnedObject() SWIFT_RETURNS_RETAINED;
 
 // Returns +0 ownership.
-SharedObject* getUnOwnedObject() SWIFT_RETURNS_UNRETAINED;
+SharedObject* _Nonnull getUnOwnedObject() SWIFT_RETURNS_UNRETAINED;
 ```
 
 These annotations are necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:


### PR DESCRIPTION
Updating the C++ interop documentation by clarifying ownership and initialization semantics for `SWIFT_SHARED_REFERENCE` types. This change is documenting:

- Guarantees and assumptions when `SWIFT_SHARED_REFERENCE` types are passed as parameters from Swift to C++ functions or methods.
- How `SWIFT_RETURNS_RETAINED` and `SWIFT_RETURNS_UNRETAINED` can be used to specity ownership of returned values in C++ APIs returning `SWIFT_SHARED_REFERENCE` types.
- Propagation of foreign reference annotations to inherited C++ types.
- Swift initializer support for C++ constructors and static factory methods of `SWIFT_SHARED_REFERENCE` types annotated with `SWIFT_NAME`.

