### PR TITLE
Add directory for info architecture proposals and first two proposals

### DIFF
--- a/_info-architecture/0001-swift-information-architecture-project.md
+++ b/_info-architecture/0001-swift-information-architecture-project.md
@@ -1,0 +1,220 @@
+# Swift Information Architecture Project
+
+* Proposal: [SIAP-0001](0001-swift-information-architecture-project.md)
+* Author: [James Dempsey](https://github.com/dempseyatgithub)
+
+## Overview
+
+Over the past ten years, the Swift project has grown from a handful of GitHub repositories to a large number of projects, including the [Swift.org](http://Swift.org) website. Over that time there has been no unified information architecture—content and its organization has developed organically. This project aims to define underlying principles for information architecture and then apply those principles to existing and future content across all of the sites of the Swift project.
+
+At a high level the development of the information architecture will have three phases:
+
+1. Develop underlying principles for the architecture
+2. Design architecture for existing pages and content according to the principles
+3. Plan and implement architecture across existing pages and content
+
+All architecture documents will be made available in the Swift forums for community review and feedback.
+
+### Principles
+
+* **Organization-wide Architecture**
+The Swift project provides information in a variety of ways including [Swift.org](http://Swift.org) pages, DocC-generated documentation, GitHub repositories, and more. The information architecture needs to span all of these to provide a cohesive strategy for the entire project.
+* **Best Suited Site**
+Information will be presented where it is best suited for the content and audience. For example, GitHub is well suited to host content about contributing to swiftlang projects, whereas [Swift.org](http://Swift.org) is well suited for content aimed at newcomers and users of the Swift language.
+* **Single Source of Truth**
+The project should strive to have a single source of truth for a topic across all official Swift project sites.
+* **Progressive Disclosure**
+Information should be presented as a high level summary first with the ability to drill down into increasing detail and specificity.
+* **Data-driven**
+Where possible, presented information should be data-driven via json or yml files or other files with structured data.
+* **Funnels / Slippery Slopes**
+Where appropriate, content should present encouragement and next steps focusing on leading visitors towards:
+  * Further Learning
+  * Community Engagement
+  * Contributing
+
+### Sites / Information Sources
+
+In addition to [Swift.org](http://Swift.org), the Swift project has a number of online sources of information and community interaction:
+
+* [Swift.org](http://Swift.org)
+* Swift Forums
+* GitHub repositories
+
+There are also sources of information that are outside the direct control of the Swift project that need to be taken into account:
+
+* [developer.apple.com](http://developer.apple.com)
+* [Swift Package Index](https://swiftpackageindex.com)
+* [Swiftinit Documentation Index](https://swiftinit.org)
+
+Part of the information architecture of the project is a clear definition and rationale of which content belongs on which site. Or more colloquially stated as "a place for everything and everything in its place".
+
+### Audience
+
+There are many ways and levels of granularity that the audience of the sites can be categorized.
+
+At a high-level the audience falls into three categories:
+
+1. Newcomers
+2. Swift Developers
+3. Contributors
+a. Potential Contributors
+
+Each section and page on [Swift.org](http://Swift.org) should have a specific audience in mind. A page or piece of content may be useful to more than one audience, but the content and tone should be geared towards the primary audience.
+
+The 'Potential Contributors' audience is a case where pages or content that are primarily focused on another audience may have this as a secondary or tertiary audience in the form of an encouragement or call to action to contribute.
+
+### Use Cases / Specialties
+
+In addition to audiences as mentioned above, another way to categorize the audience is by use case or specialty. This is an area that could potentially lead to a significant expansion of [Swift.org](http://Swift.org), for example providing specific landing pages focused on use cases such as server-side Swift or embedded Swift.
+
+Current use cases beyond Apple platform app development include:
+
+* Swift on Server
+* Embedded Swift
+* C++ Interoperability
+* Platform-specific / Linux / Windows
+
+### Summary
+
+These are the main principles, sites and audience segments that will inform the information architecture.
+
+## Current Site Examples That Violate Proposed Principles
+
+This section contains some examples demonstrating issues with the current information architecture of the project. They are small case studies of how information on the site has grown organically without an overall strategy and provide motivation for a unified information architecture.
+
+### "Slippery Slope" Example
+
+The diagram below depicts the current state of trying to get from the *Contributing* item on the main page of [swift.org](http://swift.org) to the *Getting Started* directions of contributing to the `swiftlang/swift` project.
+
+At present, the site is a tangle of links and backlinks with only one path that actually brings the visitor to steps to get started contributing.
+
+The path should be much more clear and direct.
+
+```mermaid	
+graph TD;	
+    A[Swift.org] --> B[Source Code];	
+    A --> C[Code: Learn More];	
+    B --> D[Project Listing];	
+    D --> E[swiftlang/swift README];	
+    B --> F[Contributing Code];	
+    F --> G[Getting Started];	
+    F --> H[Forums];	
+    F --> I[Community Overview];	
+    F --> J[Code owners email link];	
+    F --> |Scroll up to|I & B;	
+    E --> K[Getting Started guide];	
+    style K fill:#f9f,stroke:#333,stroke-width:4px;	
+```
+
+### Single Source of Truth Example
+
+The Swift Package Manager currently has at least four different sources of documentation.
+
+This makes it difficult for newcomers and developers to find all the relevant documentation for Swift packages and make it likely that one part of the documentation or another will become out of date.
+
+There is the overview and tutorial on [Swift.org](http://Swift.org):
+[Swift.org - Package Manager](https://www.swift.org/documentation/package-manager/)
+
+The markdown documentation in swiftlang/swift-package-mananger:
+https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/README.md
+
+The DocC generated content hosted on [docs.swift.org](http://docs.swift.org);
+[PackageDescription API — Swift Package Manager](https://docs.swift.org/package-manager/PackageDescription/index.html)
+
+And finally documentation on [developer.apple.com](http://developer.apple.com):
+[Swift packages | Apple Developer Documentation](https://developer.apple.com/documentation/Xcode/swift-packages)
+[PackageDescription | Apple Developer Documentation](https://developer.apple.com/documentation/PackageDescription)
+
+There is likely to be some duplication between the Swift project and [developer.apple.com](http://developer.apple.com). But otherwise, cases like this should move towards a single source of truth.
+
+## Next Steps
+
+The goal of this document is to articulate the underlying principles of the information architecture.
+
+The intent is that the underlying principles provide guidance moving forward as new types of content may need to be added to the information architecture.
+
+The next step is to solicit and incorporate feedback from a wider audience, including the website, contributor experience, and documentation workgroups to get agreement on the principles.
+
+The final step is methodically going through existing content and making and implementing plans for each section.
+
+## Technical Requirements
+
+The project has no specific technical requirements. The design will take the capabilities and limitations of each site / information source into account.
+
+## Project Timeline
+
+The timeline of the project reflects its comprehensive scope beginning with principles, progressing to design and culminating in detailed changes to implement the architecture.
+
+### Phase 1: Develop Core Principles
+
+* Develop a set of core principles to guide the information architecture design.
+* Review and refine principles based on stakeholder and community feedback.
+* Form working groups of stakeholders to focus on applying principles to different areas.
+* **Deliverable**: A principles document to guide further design efforts.
+
+### Phase 2: High Level Architecture
+
+* Develop the high level information architecture.
+* Conduct a review of existing information architecture.
+* Focus on how information will be provided across different project sites.
+* Review and refine based on stakeholder and community feedback.
+* **Deliverable**: A high level architecture document to guide detailed design efforts.
+
+### Phase 3: Audience / Area Level Architecture
+
+* Working groups develop architecture for each audience / area.
+* Review and refine based on stakeholder and community feedback.
+* **Deliverable**: An architecture document for each audience/area.
+
+### Phase 4: Detailed Plans and Implementation
+
+* Create detailed plans and file issues for required changes to implement plan.
+* Begin implementation of changes.
+* **Deliverables** Detailed issues filed to implement architecture.
+
+### Phase 5: Remaining Implementation
+
+* Continue implementation of issues.
+* Identify and work to address any implementation blockers.
+* **Deliverable** Completed implementation of unified information architecture.
+
+## Roles and Responsibilities
+
+### Project Team
+
+* Dave Verwer (Swift Website and Documentation workgroups)
+* David Rönnqvist (Documentation workgroup)
+* Dianna Ma (Documentation and Server workgroups)
+* James Dempsey (DRI)
+* Joe Heck (Contributor Experience and Documentation workgroups)
+* Paris Pittman(Core Team)
+
+### Stakeholders
+
+* Swift Website Workgroup
+* Contributor Experience Workgroup
+* Documentation Workgroup
+* Swift Core Team
+* Apple
+* Swift community
+
+## Community Participation
+
+Participation in the Swift Information Architecture project is open to all members of the Swift community.
+
+There are a variety of ways to get involved:
+
+### Join project and working group meetings and discussions
+
+The core effort of the project will be working through the information architecture for different areas of focus. This will happen through small working groups collaborating on the design for each area through meetings and discussions. Please send a message to [@swift-website-workgroup](https://forums.swift.org/new-message?groupname=swift-website-workgroup) on the Swift forums to join this effort.
+
+### Review and provide feedback on design plans and proposals
+
+Once an initial design is created, it will be posted in the Swift Website category on the Swift forums for review and feedback. Turning on the ‘Watching First Post’ notification of the Swift Website category in the Swift forums will notify you when any new Swift Website thread appears, including review threads for this project.
+
+### Working on issues to implement the design
+
+As information architecture designs are finalized, GitHub issues will be created for the concrete changes required to implement the design. These issues will be found on the [Github project page](https://github.com/orgs/swiftlang/projects/12) for this project. Contributing pull requests that resolve these issues will help move the architecture from plan to reality.
+
+Throughout the process, the current status of the project will be available on [GitHub](https://github.com/orgs/swiftlang/projects/12).

--- a/_info-architecture/0002-high-level-information-architecture.md
+++ b/_info-architecture/0002-high-level-information-architecture.md
@@ -1,0 +1,334 @@
+# Swift High-Level Information Architecture
+
+* Proposal: [SIAP-0002](0002-high-level-information-architecture.md)
+* Author: [James Dempsey](https://github.com/dempseyatgithub)
+
+## Overview
+
+The Swift project consists of a very large surface area of information across a number of software projects, audiences, and specializations.
+
+The goals of this document are:
+
+* Outline the characteristics of the different information channels across the Swiftlang project.
+* Define high-level focus areas of audience / topic that are largely independent of one another, allowing the architecture to be divided into more manageable chunks.
+* For each focus area, define general principles for where information will be hosted across sites.
+
+The intent is for this document to define a general approach for each focus area with details to be worked through and proposed by more focused working groups.
+
+Note also that the focus areas are not strictly divided along audience or channel boundaries. Each focus area is as granular as practical.
+
+## Terms
+
+For purposes of discussion, this document and the Swift Information Architecture Project will use the following terms:
+
+* *Channel*: A website, service, or other mechanisms where the the Swift community can receive information.
+* *Audience*: One of the high-level audience categories defined in the [project overview document](0001-swift-information-architecture-project.md).Those high-level audiences are defined as:
+  1. Newcomers
+  2. Swift Developers
+  3. Contributors
+a. Potential Contributors
+* *Specialization*: A Swift use case such as Embedded Swift, Server, C++ Interoperability, etc. with information and typically a community of developers specific to that use case.
+* *Focus Area*: A well-defined piece of the Swift information architecture that can be worked on largely independently of other focus areas.
+
+## Sources Of Truth
+
+One of the [design principles](0001-swift-information-architecture-project.md) in the initial project document is that the project should strive to have a single source of truth for each piece of information across all official Swift project channels.
+
+This section refines that design principle and adds a new principle.
+
+At present, two channels serve as sources of truth:
+
+* GitHub repositories
+This is the primary source of truth for Swiftlang content. Even channels such as [Swift.org](http://Swift.org) are ultimately derived from content in a GitHub repository.
+* Swift Forums
+A small but important percentage of content is available only on the Swift Forums. This content includes Swift Evolution proposal pitches, review threads, and the rationale for proposal decisions.
+
+### Additional Desgin Principle: Minimize Update Friction
+
+The source of truth for content should be in a repository scoped to those best suited to update, review, and approve the content.
+
+An example of where that principle is currently *not* in practice:
+
+> The source of truth for content such as C++ Interoperability documentation is currently in the swift-org-website repository and so requires approval from members of the website workgroup to merge changes.
+>
+>
+>
+> Members of the website workgroup do not necessarily have the technical expertise in that area to be the appropriate people to review the changes.
+
+Adhering to this principle can be addressed in various ways including separate repositories or CODEOWNERS files within a repository.
+
+## Channels
+
+Information is presented to the Swift community across a variety of channels. Part of the information architecture of the project is a clear definition and rationale of which content is presented in which channel.
+
+### [Swift.org](http://Swift.org)
+
+[Swift.org](http://Swift.org) can be thought of as the ‘front door’ or ‘front of house’ of the Swift project. It serves two main purposes:
+
+* Provide an excellent ‘front door’ to newcomers to the Swift language and ecosystem. Some of the pages/content is focused entirely on newcomers:
+  * Getting Started
+  * Tutorials
+* Provide excellent day to day information for existing Swift developers:
+  * Documentation
+  * Downloads including development builds
+  * News / Blog
+
+#### Audiences
+
+Newcomer and Developer audiences
+
+#### Interaction
+
+This channel is for presenting information and does not provide facilities for discussion or interaction. In general the content on [Swift.org](http://Swift.org) can be considered ‘read only’.
+
+#### User Experience
+
+One of the core strengths of this channel is complete control over its appearance and user experience.
+
+### GitHub
+
+GitHub serves as the ‘back of house’ of the Swift project.
+
+Work on Swiftlang projects happens in GitHub repositories. These repositories contain the source to everything from the Swift compiler and standard library to The Swift Programming Language book, to the contents of [Swift.org](http://Swift.org).
+
+The purpose of this channel is to provide information about contributing, both for the swiftlang organization overall and individual repositories.
+
+#### Audiences
+
+Contributor audience
+
+#### Interaction
+
+Interaction largely takes the form of creating and commenting on Issues and Pull Requests. It also includes other GitHub features various swiftlang repositories may choose to use, such as projects.
+
+GitHub Discussions are not used for Swiftlang projects, discussions are conducted in the Swift Forums.
+
+#### User Experience
+
+This channel is the standard GitHub user experience. This provides a familiar interface for users of GitHub. Control over the user experience is limited to the settings available in GitHub.
+
+There is also the potential to present some content using GitHub Pages which would provide more control over the user experience of the pages. It would be important to establish guidelines regarding using GitHub as a way to present webpages as opposed to [Swift.org](http://Swift.org).
+
+### Swift Forums
+
+#### Audiences
+
+All audiences. The various categories in the Swift Forums have different audiences, from newcomers asking questions about getting started with Swift to contributors discussion evolution pitches and proposals.
+
+#### Interaction
+
+The Swift Forums provide the most general and free-form interaction in the Swift community. This includes public and private categories as well as sending private direct messages to individuals and groups.
+
+#### User Experience
+
+The forums have the standard user experience of Discourse forums software. Control of the user interface is limited to settings and options of the Discourse software.
+
+### Social Media
+
+#### Audiences
+
+Although all audience can get information form this channel, the primary audience is Swift Developers.
+
+#### Interaction
+
+Typical social media interactions are available such as replying to the post, liking, reposting, etc. The official Swift account does not typically reply back.
+
+#### User Experience
+
+The user experience is defined by each social media service and any third party clients.
+
+### APIs
+
+Not all information in the Swiftlang project is presented in the form of webpages. The Swift project already vends a number of APIs for use by clients.
+
+One example is the `evolution.json` file used to drive the Swift Evolution Dashboard. This API is also used by other clients in the Swift community including desktop and mobile apps.
+
+This channel includes RSS feeds, which overlaps with the Blog / News area of focus.
+
+This channel typically vends a transformed representation of a source of truth.
+
+#### Audiences
+
+Contributor and Developer audience
+
+#### Interaction
+
+At present APIs are read-only used as a data source. There are currently no read-write APIs.
+
+#### User Experience
+
+There is no inherent user experience but the client experience as to the structure and content of what the API vends is completely in the control of the Swift project.
+
+### External Channels
+
+There are also channels outside the direct control of the Swift project that need to be considered. For example:
+
+[developer.apple.com](https://developer.apple.com)
+[Swift Package Index](https://swiftpackageindex.com/)
+[Swiftinit Documentation Index](https://swiftinit.org/)
+
+In some cases the most appropriate channel for information will be an external channel.
+
+## Focus Areas
+
+Focus areas exist for the purpose of dividing the information architecture project into smaller, manageable chunks, allowing smaller working groups to work through the details of that area.
+
+Although some focus areas are larger in scope than others, when taken all together, they should address all of the audiences and channels defined above.
+
+The set of focus areas listed below uses the [Swift.org](http://Swift.org) site as of April 2025 as a starting point.
+
+### Contributor Audience
+
+The Contributor Experience Workgroup will define the information architecture for contributors to the Swift project. This includes repository-specific information as well as swiftlang organization-wide information.
+
+Audience: Contributors
+
+Members of the Contributor Experience Workgroup are members of this project and will coordinate between this project and the workgroup.
+
+Because the vast majority of activity for contributors happens on GitHub, GitHub will be the channel for the vast majority of contributor information.
+
+#### Contributor Overview
+
+Although the vast majority of contributor information will use GitHub, an aspirational page that encourages the broad variety of contributions to the project may be better suited for [Swift.org](http://Swift.org).
+
+Audience: Potential Contributors
+
+#### Governance
+
+Governance information describes the Swiftlang organization, how it is structured, governed, and run. This includes overviews of all workgroups and steering groups, as well as charters and membership for each group.
+
+Similarly, it may make sense for things such as the project code of conduct to be presented both on GitHub and on [Swift.org](http://Swift.org).
+
+Audience: Mixed
+The audience for this information is mixed. Newcomers may want to get an overview of how the project is managed before deciding to select Swift as a language. Existing Swift Developers may be curious about how decisions get made about the language they use on a daily basis. Contributors may also be curious about how the project is structured.
+
+This information is relatively static and may be a good candidate to be presented on [Swift.org](http://Swift.org) (although likely with less top-level menu entries than the current site). Which channel to present this information bears discussion and so is a separate focus area.
+
+#### Workgroup Operations
+
+As opposed to governance information which is fairly static, workgroup operations includes things such as meeting notes, requests for comment on proposals which are not part of the evolution process, and any other communication from and with workgroups and steering groups.
+
+### Newcomer and Swift Developer Audiences
+
+The primary channel for both the Newcomer and Swift Developer audiences is [Swift.org](http://Swift.org).
+
+Some pages on [Swift.org](http://Swift.org) serve a definite audience and so are different focus areas.
+
+Some parts of [Swift.org](http://Swift.org), such as navigation, need to be designed to take the entirety of the site into account.
+
+With [Swift.org](http://Swift.org) in particular there are areas that do not fit neatly into isolated focus areas. Areas of expected overlap are noted.
+
+Another note is that the core pages of [Swift.org](http://Swift.org) are generated as a static site using Jekyll, while other content, such as documentation, is generated separately.
+
+The focus areas on this section are separated into the current core pages / sections of the [Swift.org](http://Swift.org) site.
+
+Note also that the information architecture project is being run in parallel with the [Swift.org Redesign Project](https://forums.swift.org/t/announcing-the-swift-org-redesign-project/75865). The two projects will work in tandem.
+
+#### Home Page
+
+Audience: Newcomers / Swift Developers
+
+At present the home page does not provide any dynamic information which can make the Swift project appear to be lifeless. Although the home page should be a welcoming 'front door' for developers coming to Swift, it could potentially have something to also make it useful to day to day Swift developers.
+
+#### Getting Started
+
+Audience: Newcomers
+
+Newcomers are the audience for this page. Note that things such as tutorials for newcomers and how they are authored and delivered may have some overlap with Documentation.
+
+Also, providing a path for newcomers interested in particular specializations (e.g. Embedded Swift, Server-side Swift, etc.) may require coordination with how these specialized communities are supported on [Swift.org](http://Swift.org) overall.
+
+#### Blog / News
+
+Audience: Swift Developers
+
+The audience for blog posts are existing Swift Developers. Newcomers may also read blog posts, and give a newcomer a sense of what is going on in the Swift ecosystem, but the posts are written for those already in the ecosystem.
+
+A related item that overlaps with the Home Page focus area is the notion of some way of presenting project news on [Swift.org](http://Swift.org). At present the only mechanism for announcing or highlighting something on [Swift.org](http://Swift.org) is through blog posts. Having a way to present information that is more lightweight may be very beneficial.
+
+This area of focus also includes the social media channel as one way of getting news about Swift. It also includes RSS feeds as another means of getting news.
+
+#### Packages
+
+Audience: Newcomers / Swift Developers
+
+I believe this section has two purposes, first to show newcomers that Swift has a vibrant package ecosystem and second to make existing Swift developers aware of the packages available.
+
+#### Tools
+
+Audience: Newcomers / Swift Developers
+
+This page is primarily for newcomers. Existing Swift developers have probably already discovered their editor of choice. It may be useful for existing Swift developers looking to expand to other platforms.
+
+#### Community
+
+Audience: Newcomers / Swift Developers / Potential Contributors
+
+All audiences may be interested in learning more about the Swift community.
+
+Currently the top-level menu has many items. In conjunction with the Governance and Contributor Overview focus areas, this focus area would discuss how (or if) community information should appear on [Swift.org](http://Swift.org).
+
+#### Install / Downloads
+
+Audience: Newcomers and Swift Developers
+
+There are two audiences for installation and downloads. Newcomers need an easy way to install and get started with Swift. Day to day developers need easy ways to download different Swift versions including daily development builds.
+
+This section of [Swift.org](http://Swift.org) needs to support both use cases well.
+
+The introduction of swiftly may change the requiremets of installation and downloads on [Swift.org](http://Swift.org).
+
+#### Documentation
+
+Documentation is currently split between being statically generated as part of the core [Swift.org](http://Swift.org) site, and being generated via DocC and appearing in the [docs.swift.org](http://docs.swift.org) subdomain.
+
+Audience: Swift Developers
+Although contributors and newcomers will also look at documentation, documentation should be geared towards day to day use by Swift developers.
+
+Because documentation pages are generated in a different way and has its own set of requirements, it is a separate focus area.
+
+Topics that may also fall out of the Documentation focus area include documentation for Swift specializations such as C++ Interoperability, Server Side Swift, etc. Also, how best to incorporate sample code as part of documentation.
+
+#### [Swift.org](http://Swift.org) Site-wide Areas
+
+The primary site-wide area is navigation and overall site structure. This includes top-level navigation items and how the site is organized.
+
+For example Google Summer of Code pages are top-level pages and a new top-level page is added every year. Possibly should be grouped a level down.
+
+In addition, there are topics that bear discussion:
+
+* Search
+* Localization
+* SEO
+
+At present these are all included in this single focus areas but could be broken out as needed.
+
+#### Specializations
+
+Specializations are use cases of Swift where specialized information is required. These include areas such as Embedded Swift, Swift on Server, etc. In addition, there is typically a community of developers who specialize in these areas.
+
+The purpose of this focus area is to work through how these communities should be supported on [Swift.org](http://Swift.org) - both newcomers coming to Swift with an interest in a specialization and day to day developers who work in these areas.
+
+Note that this focus area overlaps with a number of other focus areas (Getting Started page, Documentation) and may propose other solutions such as a landing page for a specialization.
+
+### APIs / Dashboards
+
+[Swift.org](http://Swift.org) vends various APIs, including the JSON file that drives the Swift Evolution Dashboard.
+
+This focus area will catalog all of the existing APIs, developer criteria for what purpose APIs should serve and when adding an API would be appropriate.
+
+## Next Steps
+
+Breaking down the information space into more manageable focus areas allows each focus area to be worked on independently with a minimal amount of overlap.
+
+Each focus area will create a proposal which will include:
+
+* The current state of the focus area
+* The proposed information design of the focus area including the rationale
+* A plan / tasks required to move from current state to the desired design
+
+Once the members of the Swift Information Architecture project have reviewed the proposal it will be made public for Swift community review and feedback.
+
+## Conclusion
+
+The Swift project consists of a vast amount of information. By identifying audiences and channels, as well as breaking the information space into smaller focus areas, a detailed information architecture can be created for each focus area without losing sight of the overall architecture.


### PR DESCRIPTION
As discussed in the last website workgroup meeting, Swift info architecture project proposals and documents will be included in the swift-org-website repository.

The proposals are *not* rendered as webpages on swift.org.

Jekyll automatically ignores directories and files beginning with `#`. Since files beginning with an underscore are typically part of the configuration / operation of Jekyll itself, the directory name is `#info-architecture` to emphasize this is not part of the Jekyll infrastructure or published on the website.

This PR includes the first two proposals that have been announced and reviewed by the community. Future proposals will be added when they are ready for community review and feedback.