### PR TITLE
Fix #1091: Text Wrap Bug

### DIFF
--- a/assets/stylesheets/new-stylesheets/_helpers.scss
+++ b/assets/stylesheets/new-stylesheets/_helpers.scss
@@ -200,3 +200,15 @@
   text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
   text-underline-offset: 2px;
 }
+
+.hide-small {
+  @media only screen and (max-width: 767px) {
+    display: none;
+  }
+}
+
+.hide-medium {
+  @media only screen and (max-width: 1024px) {
+    display: none;
+  }
+}

--- a/assets/stylesheets/new-stylesheets/includes/callout/_base.scss
+++ b/assets/stylesheets/new-stylesheets/includes/callout/_base.scss
@@ -71,9 +71,3 @@
 .callout-text {
   text-align: left;
 }
-
-.hide-small {
-  @media only screen and (max-width: 767px) {
-    display: none;
-  }
-}

--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ atom: true
         </p>
         <br />
         <p class="pillar-intro">
-            It's the combination of approachability, speed, safety, and all of<br class="hide-small"/> Swift’s strengths that make it so unique.
+            It's the combination of approachability, speed, safety, and all of<br class="hide-medium"/> Swift’s strengths that make it so unique.
         </p>
     </div>
     {% for callout in pillar1_callouts %}


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation: 

Handled text wrapping bug described in #1091 

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

- Add the hide medium CSS utility class. 
- Update the br element to use the new class. 
- Move the utility classes from the component partial to the helper partial, as the classes aren't specific to the call-out component.

<!-- _[Describe the modifications you've done.]_ -->

### Result:

Line br is now hidden, and text wraps correctly. 

<!-- _[After your change, what will change.]_ -->
