### PR TITLE
Use odd numbered weeks for Testing Workgroup meetings

### DIFF
--- a/testing-workgroup/index.md
+++ b/testing-workgroup/index.md
@@ -94,7 +94,7 @@ particular challenges with reaching consensus on significant decisions.
 ## Meetings
 
 The Testing Workgroup meets biweekly on Monday at 1:00PM PT (USA Pacific).
-Meetings take place in [even numbered weeks](http://www.whatweekisit.org/),
+Meetings take place in [odd numbered weeks](http://www.whatweekisit.org/),
 unless otherwise communicated in advance.
 
 Many workgroup meetings are meant for open discussion and any Swift community


### PR DESCRIPTION
The last meeting was Aug 11 2025, which is Week 33. Update the declared schedule to match the current meeting cadence.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

The actual meeting schedule for the workgroup has fallen out of sync with what's declared on the website.

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

Update the schedule on the website to match the current cadence.

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
