### PR TITLE
Replace "Committer" with "Code Merger" and fix broken anchors

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -24,7 +24,7 @@ Advancing the Swift programming language with a coherent, clear view of its evol
 * __[Project Lead](#project-lead)__ appoints technical leaders from the community.  Apple Inc. is the project lead, and interacts with the community through its representative.
 * __[Core Team](#core-team)__ is the small group responsible for strategic direction and oversight of the Swift project.
 * __[Code Owner](/contributing/#code-owners)__ is the individual responsible for a specific area of the Swift codebase.
-* __[Committer](/contributing/#commit-access)__ is anyone that has commit access to the Swift code base.
+* __[Code Merger](/contributing/#code-merger)__ is anyone that has commit access to the Swift code base.
 * __[Member](/contributing/#member)__ is anyone who is a member of the swiftlang organization on GitHub.
 * __[Contributor](/contributing/#contributor)__ is anyone who has contributed to Swift by writing code, answering questions on the forums, reporting or triaging bugs, participating in the Swift evolution process, or other ways.
 * __Steering Groups__

--- a/contributing/_contributing-code.md
+++ b/contributing/_contributing-code.md
@@ -176,7 +176,7 @@ People depend on Swift to create their production software.  This means that a b
 2. Bug fixes and new features must include a test case to pinpoint any future regressions, or include a justification for why a test case would be impractical.
 3. Code must pass the appropriate test suites---for example, the `swift/test` and `swift/validation-test` test suites in the Swift compiler.
 
-Additionally, the committer is responsible for addressing any problems found in the future that the change may cause. This responsibility means that you may need to update your change in order to:
+Additionally, the code merger is responsible for addressing any problems found in the future that the change may cause. This responsibility means that you may need to update your change in order to:
 
 * Ensure the code compiles cleanly on all primary platforms.
 * Fix any correctness regressions found in other test suites.

--- a/contributing/_good-first-issues.md
+++ b/contributing/_good-first-issues.md
@@ -12,7 +12,7 @@ excessive refactoring, research, or debugging — rather, they should encourage
 newcomers to dip their toes in some part of Swift, learn more about it, and
 make a real contribution.
 
-Anyone with [commit access](#commit-access) and insight into a particular area
+Anyone with [commit access](#code-merger) and insight into a particular area
 is welcome and encouraged to pin down or think up good first issues.
 
 {% comment %}


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Some docs still use the `Committer`, leading to broken anchors.

### Modifications:

Replace `Committer` with `Code Merger` and fix broken anchors.

### Result:

Docs now consistently use `Code Merger` and all anchors work correctly.
