### PR TITLE
Include the feed autodiscovery meta tag on every page

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -25,9 +25,7 @@
   <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-180x180.png" />
   <link rel="mask-icon" href="/assets/images/icon-swift.svg" color="#F05339" />
-  {% if page.atom %}
   <link rel="alternate" type="application/atom+xml" title="Swift.org (Atom Feed)" href="/atom.xml" />
-  {% endif %}
 
   {% if page.url %}
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />

--- a/_layouts/new-layouts/base.html
+++ b/_layouts/new-layouts/base.html
@@ -111,14 +111,14 @@
       href="/assets/images/icon-swift.svg"
       color="#F05339"
     />
-    {% if page.atom %}
     <link
       rel="alternate"
       type="application/atom+xml"
       title="Swift.org (Atom Feed)"
       href="/atom.xml"
     />
-    {% endif %} {% if page.url %}
+
+    {% if page.url %}
     <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
     {% endif %}
 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,6 @@
 ---
 layout: new-layouts/base
 title: Swift Programming Language
-atom: true
 ---
 
 <div class="animation-container">


### PR DESCRIPTION
### Motivation:

RSS feed autodiscovery was only enabled on pages that explicitly set `atom: true` in their front matter, and the home page was the only page with that variable set.

Having feed autodiscovery limited to the home page unnecessarily hides the feed from automated services. At the very least, we should enable it on the blog index page and all blog posts. However, I think it's better to include it on every page.

The feed icon is in the footer on every page, so the autodiscovery should be there too.

### Modifications:

- Removed the conditional logic from both layout templates (_layouts/base.html and _layouts/new-layouts/base.html)
- Removed the `atom: true` front matter variable from index.md, as it's no longer used

### Result:

The RSS feed autodiscovery meta tag is now available on all pages of Swift.org.
