### PR TITLE
Redirect swift server concurrency guide content to the Swift 6 migration guide

### DIFF
--- a/documentation/concurrency/index.md
+++ b/documentation/concurrency/index.md
@@ -2,9 +2,9 @@
 layout: page
 date: 2024-03-03 12:00:00
 title: Enabling Complete Concurrency Checking
-redirect_to: https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/enabledataracesafety
+redirect_to: /migration/documentation/swift-6-concurrency-migration-guide/enabledataracesafety/
 ---
-<meta http-equiv="refresh" content="0; url=https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/">
-<link rel="canonical" href="https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/" />
+<meta http-equiv="refresh" content="0; url=/migration/documentation/swift-6-concurrency-migration-guide/enabledataracesafety/">
+<link rel="canonical" href="https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/enabledataracesafety/">
 
-This page should redirect automatically to https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide
+This page should redirect automatically to https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/enabledataracesafety/


### PR DESCRIPTION

### Motivation:

The content in this article is identical to the content in the Swift 6 Migration Guide, so to consolidate to a single location to update about migrations and concurrency, I'm redirecting to the data race safety article in the migration guide.

### Modifications:

Keep front-matter and redirect page content to the Migration Guide book/content

### Result:

Any access to the page will automatically redirect to the migration guide.
