### PR TITLE
Remove double title blog post

### DIFF
--- a/_posts/2025-10-03-swift-profile-recorder.md
+++ b/_posts/2025-10-03-swift-profile-recorder.md
@@ -7,8 +7,6 @@ author: [weissi, mitchellallison]
 category: "Developer Tools"
 ---
 
-# Introducing Swift Profile Recorder: Identifying Performance Bottlenecks in Production
-
 
 [Swift Profile Recorder](https://github.com/apple/swift-profile-recorder), an in-process sampling profiler for Swift services, is now available as an open source project.
 


### PR DESCRIPTION
### Motivation:

Title shows 2 times in this blog post: https://www.swift.org/blog/swift-profile-recorder/

### Modifications:

Removed markdown title

### Result:

Title is only one
