### PR TITLE
Adjust official meeting time for Testing Workgroup

### DIFF
--- a/testing-workgroup/index.md
+++ b/testing-workgroup/index.md
@@ -93,7 +93,7 @@ particular challenges with reaching consensus on significant decisions.
 
 ## Meetings
 
-The Testing Workgroup meets biweekly on Monday at 1:00PM PT (USA Pacific).
+The Testing Workgroup meets biweekly on Monday at 1:05PM PT (USA Pacific).
 Meetings take place in [odd numbered weeks](http://www.whatweekisit.org/),
 unless otherwise communicated in advance.
 


### PR DESCRIPTION
Tiny modification: We've changed the official start time of meetings of the Testing Workgroup to be 5 minutes past the hour, so this updates the time from 1:00pm to 1:**05**pm PT.