### PR TITLE
Add zip as a dependency on Linux distributions

### DIFF
--- a/_includes/linux/amazonlinux2.html
+++ b/_includes/linux/amazonlinux2.html
@@ -4,6 +4,7 @@ $ yum install \
       gcc \
       git \
       glibc-static \
+      zip \
       gzip \
       libbsd \
       libcurl \

--- a/_includes/linux/fedora39.html
+++ b/_includes/linux/fedora39.html
@@ -10,5 +10,6 @@ $ yum install \
       libxml2-devel \
       python3-devel \
       sqlite-devel \
+      zip \
       unzip
 {% endhighlight %}

--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -15,6 +15,7 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
+          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}

--- a/_includes/linux/ubuntu2310.html
+++ b/_includes/linux/ubuntu2310.html
@@ -15,6 +15,7 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
+          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}

--- a/_includes/linux/ubuntu2404.html
+++ b/_includes/linux/ubuntu2404.html
@@ -15,6 +15,7 @@ $ apt-get install \
           libz3-dev \
           pkg-config \
           tzdata \
+          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
On Linux, Swift Testing uses the zip package/tool to compress directories when they are recorded as test attachments.

This should be merged at the same time as:
https://github.com/swiftlang/swift-docker/pull/508