### PR TITLE
Add Android minimum level to deployment platforms table

### DIFF
--- a/platform-support/_platform-support.md
+++ b/platform-support/_platform-support.md
@@ -33,6 +33,7 @@ This table shows the minimum OS version for which a Swift application can be dep
 | **iOS**                            |11.0                        |
 | **watchOS**                        |4.0                         |
 | **tvOS**                           |11.0                        |
+| **Android**                        |9 (API 28)                  |
 | **Ubuntu**                         |20.04                       |
 | **Debian**                         |12                          |
 | **Fedora**                         |39                          |


### PR DESCRIPTION
### Motivation:

This PR documents the current minimum Android API level for Swift deployment.

### Modifications:

Add Android to the supported deployments table.

### Result:

The developer will know what the minimum support Android level it.