### PR TITLE
Double-quote curl commands to enable substitution in Linux installation guide on zsh

### DIFF
--- a/install/linux/swiftly/index.md
+++ b/install/linux/swiftly/index.md
@@ -6,14 +6,14 @@ title: Getting Started with Swiftly on Linux
 Download swiftly for [Linux (Intel)](https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-x86_64.tar.gz), or [Linux (ARM)](https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-aarch64.tar.gz).
 
 ```
-curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz
+curl -O "https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz"
 ```
 
 You can verify the integrity of the archive using the PGP signature. This will download the signature, install the swift.org signatures into your keychain, and verify the signature.
 
 ```
 curl https://www.swift.org/keys/all-keys.asc | gpg --import -
-curl -O https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig
+curl -O "https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig"
 gpg --verify swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz.sig swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz
 ```
 


### PR DESCRIPTION
### Motivation:

The current unquoted curl commands with substitution used for installing swiftly on Linux fail when executed in the Zsh (Z Shell) environment.

Zsh's default behavior is to treat special characters within an unquoted URL (such as periods, slashes, or the parentheses around `$(uname -m)`) as patterns for file matching. When Zsh cannot find a file matching that unusual pattern, it halts execution and returns an error (like `zsh: no matches found`). This prevents users running Zsh from easily following the installation instructions.

### Modifications:

Added double-quotes `"` around the full URL in the curl -O commands used for downloading the swiftly installer.

The updated command now looks like this:
`curl -O "https://download.swift.org/swiftly/linux/swiftly-{{ site.data.builds.swiftly_release.version }}-$(uname -m).tar.gz"`

Double-quotes ensure the shell treats the entire URL as a single, literal string argument for curl, while still allowing the necessary substitution of the architecture via `$(uname -m)`.

### Result:

The Linux installation commands are now fully compatible with both the common Bash shell and the widely used Z shell, making the documentation more robust for a broader Linux user base.