### PR TITLE
Wrap install instructions so they don't soft wrap

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -15,7 +15,8 @@ latest-release:
           curl -O https://download.swift.org/swiftly/linux/swiftly-(uname -m).tar.gz && \
           tar zxf swiftly-(uname -m).tar.gz && \
           ./swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.local/share/swiftly/env.fish
+          set -q SWIFTLY_HOME_DIR && \
+          source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.local/share/swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'

--- a/_data/new-data/install/macos/releases.yml
+++ b/_data/new-data/install/macos/releases.yml
@@ -15,7 +15,8 @@ latest-release:
           curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
           installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
           ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-          set -q SWIFTLY_HOME_DIR && source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.swiftly/env.fish
+          set -q SWIFTLY_HOME_DIR && \
+          source "$SWIFTLY_HOME_DIR/env.fish" || source ~/.swiftly/env.fish
     links:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'


### PR DESCRIPTION
### Motivation:

The last line of the fish install instructions soft wraps right now. This could be confusing -- where does each command start and end? why is only this line soft wrapping.
<img width="919" height="225" alt="before" src="https://github.com/user-attachments/assets/28c751a8-1e06-4d4c-9acc-3c890c38ad9d" />

### Modifications:

This change adds an additional backslash to keep the `source` commands together and separate from the preceding command. I've made the same change to the fish section of both the Linux and macOS install instructions. 

### Result:

Here's how this looks when implemented:
<img width="918" height="208" alt="after" src="https://github.com/user-attachments/assets/205ccdb3-4d79-48b8-b059-a14307053656" />