### PR TITLE
Update authors in GSoC 2025 showcase post

### DIFF
--- a/_posts/2025-11-12-gsoc-2025-showcase-code-completion.md
+++ b/_posts/2025-11-12-gsoc-2025-showcase-code-completion.md
@@ -3,7 +3,7 @@ layout: new-layouts/post
 published: true
 date: 2025-11-12 17:05:00
 title: "Swift GSoC 2025 highlight: Improved code completion for Swift"
-author: [ahmedelrefaey, hamish, ktoso]
+author: [ahmedelrefaey, ktoso]
 category: "Developer Tools"
 ---
 


### PR DESCRIPTION
Removed 'hamish' from the list of authors; we're only including the "blog post" writers