### PR TITLE
Update WinSDK version to 22621

### DIFF
--- a/_data/new-data/install/windows/releases.yml
+++ b/_data/new-data/install/windows/releases.yml
@@ -4,7 +4,7 @@ latest-release:
       Install Swift via the Windows Package Manager (also known as WinGet).
     after-code-text: |
       First, install Windows platform dependencies:
-      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"</code></pre>
+      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"</code></pre>
       <br />
       Next, install Swift and other dependencies:
       <br /><br />


### PR DESCRIPTION
### Motivation:

The version of the Windows SDK that the Swift installation instructions attempts to install is no longer available as part of Visual Studio 2022 Community. The result is that while the installation seems to succeed, when compiling or running users will see errors like the following:
```
lld-link: error: could not open 'kernel32.lib': no such file or directory
lld-link: error: could not open 'ucrt.lib': no such file or directory
```

### Modifications:

Update to the [current shipping version](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2022&preserve-view=true#components-included-by-this-workload-7) of the Windows SDK, which is
`Microsoft.VisualStudio.Component.Windows11SDK.22621`

### Result:

Installs now complete successfully and compile / build tests work. Tested on a clean ARM64 guest instance running Windows 11 25H2.