### PR TITLE
Add editor configuration instructions for Swift WebAssembly development

### DIFF
--- a/documentation/articles/wasm-getting-started.md
+++ b/documentation/articles/wasm-getting-started.md
@@ -100,7 +100,7 @@ Build of product 'Hello' complete! (1.31s)
 Hello from WASI!
 ```
 
-# Embedded Swift Support
+## Embedded Swift Support
 
 [Embedded Swift](https://github.com/swiftlang/swift-evolution/blob/main/visions/embedded-swift.md) is an experimental [subset of the language](https://docs.swift.org/embedded/documentation/embedded/languagesubset)
 allowing the toolchain to produce Wasm binaries that are multiple orders of magnitude smaller. One of the Swift SDKs in the artifact bundle you've installed


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

I'd like to move Swift on Wasm development docs from book.swiftwasm.org to swift.org as much as possible so that developers don't need to switch documentation sites.

For the first step, I'd like to move editor setup guide for cross-compiling Swift SDK: https://book.swiftwasm.org/getting-started/vscode.html

### Modifications:

Added Editor Configuration section to the Getting Started Wasm document.

### Result:

Developers will be able to find a way to configure their editors for Swift on Wasm development
