### PR TITLE
Fix error message syntax in static Linux Swift SDK guide

### DIFF
--- a/documentation/articles/static-linux-getting-started.md
+++ b/documentation/articles/static-linux-getting-started.md
@@ -254,7 +254,7 @@ Hello, world!
 
 ### What about package dependencies?
 
-Swift packages that make use of Foundation or Swift NIO should just
+Swift packages that make use of Foundation or SwiftNIO should just
 work.  If you try to use a package that uses the C library, however,
 you may have a little work to do.  Such packages often contain files
 with code like the following:


### PR DESCRIPTION
Per [user's report](https://forums.swift.org/t/cross-compiling-for-linux/83523/9) `error(Unknown platform)` is invalid syntax. The error message string should be quoted.