### PR TITLE
Display Swift 6.3 snapshots on swift.org/install page

### DIFF
--- a/_data/new-data/install/linux/dev.yml
+++ b/_data/new-data/install/linux/dev.yml
@@ -7,9 +7,9 @@ latest-dev:
       - label: main
         code: |-
           swiftly install main-snapshot
-      - label: release/6.2
+      - label: release/6.3
         code: |-
-          swiftly install 6.2-snapshot
+          swiftly install 6.3-snapshot
     links:
       - href: '/install/linux/swiftly'
         copy: 'Instructions'

--- a/_includes/new-includes/components/wasm-sdk-dev.html
+++ b/_includes/new-includes/components/wasm-sdk-dev.html
@@ -1,5 +1,5 @@
 {% assign wasm_sdk_dev_builds = site.data.builds.development.wasm-sdk | sort: 'date' | reverse %}
-{% assign wasm_sdk_6_2_builds = site.data.builds.swift-6_2-branch.wasm-sdk | sort: 'date' | reverse %}
+{% assign wasm_sdk_6_3_builds = site.data.builds.swift-6_3-branch.wasm-sdk | sort: 'date' | reverse %}
 
 <div class="releases-grid">
     <div class="release-box section">
@@ -26,19 +26,19 @@
     <div class="release-box section">
         <div class="content">
         <div class="code-box content-wrapper">
-            <h2>release/6.2</h2>
+            <h2>release/6.3</h2>
             <p class="body-copy">
-            <small>{{ wasm_sdk_6_2_builds.first.date | date: '%B %-d, %Y' }}</small><br />
-            {% assign base_url = "https://download.swift.org/swift-6.2-branch/wasm-sdk/" | append: wasm_sdk_6_2_builds.first.dir | append: "/" | append: wasm_sdk_6_2_builds.first.download %}
-            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: wasm_sdk_6_2_builds.first.checksum %}
+            <small>{{ wasm_sdk_6_3_builds.first.date | date: '%B %-d, %Y' }}</small><br />
+            {% assign base_url = "https://download.swift.org/swift-6.3-branch/wasm-sdk/" | append: wasm_sdk_6_3_builds.first.dir | append: "/" | append: wasm_sdk_6_3_builds.first.download %}
+            {% assign command = "swift sdk install " | append: base_url | append: " --checksum " | append: wasm_sdk_6_3_builds.first.checksum %}
             <button onclick="copyToClipboard(this, '{{ command | escape }}')">
                 Copy install command
             </button>
             </p>
             <div class="link-wrapper">
             <div class="link-group">
-                <a href="https://download.swift.org/swift-6.2-branch/wasm-sdk/{{ wasm_sdk_6_2_builds.first.dir }}/{{ wasm_sdk_6_2_builds.first.download }}" class="body-copy">Download</a> |
-                <a href="https://download.swift.org/swift-6.2-branch/wasm-sdk/{{ wasm_sdk_6_2_builds.first.dir }}/{{ wasm_sdk_6_2_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
+                <a href="https://download.swift.org/swift-6.3-branch/wasm-sdk/{{ wasm_sdk_6_3_builds.first.dir }}/{{ wasm_sdk_6_3_builds.first.download }}" class="body-copy">Download</a> |
+                <a href="https://download.swift.org/swift-6.3-branch/wasm-sdk/{{ wasm_sdk_6_3_builds.first.dir }}/{{ wasm_sdk_6_3_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
             </div>
             </div>
         </div>

--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -11,11 +11,11 @@ title: Install Swift
     docker_tag="nightly-fedora-39"
     development_builds=site.data.builds.development.fedora39
     aarch64_development_builds=site.data.builds.development.fedora39-aarch64
-    development_2="release/6.2"
-    docker_tag_2="nightly-6.2-fedora39"
-    development_builds_2=site.data.builds.swift-6_2-branch.fedora39
-    aarch64_development_builds_2=site.data.builds.swift-6_2-branch.fedora39-aarch64
-    branch_dir_2="swift-6.2-branch"
+    development_2="release/6.3"
+    docker_tag_2="nightly-6.3-fedora39"
+    development_builds_2=site.data.builds.swift-6_3-branch.fedora39
+    aarch64_development_builds_2=site.data.builds.swift-6_3-branch.fedora39-aarch64
+    branch_dir_2="swift-6.3-branch"
 %}
 
 {% include /new-includes/components/linux-releases.html

--- a/install/macos/_older-6_3-snapshots.md
+++ b/install/macos/_older-6_3-snapshots.md
@@ -1,0 +1,12 @@
+<table id="osx-builds" class="downloads body-copy">
+    <thead>
+        <tr>
+            <th class="download">Download</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for build in xcode_6_3_builds | offset:1 | limit:10 %}
+            {% include_relative _old-snapshot.html build=build name="Xcode" platform_dir="xcode" branch_dir="swift-6.3-branch" %}
+        {% endfor %}
+    </tbody>
+</table>

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -6,7 +6,7 @@ title: Install Swift - macOS
 ---
 
 {% assign xcode_dev_builds = site.data.builds.development.xcode | sort: 'date' | reverse %}
-{% assign xcode_6_2_builds = site.data.builds.swift-6_2-branch.xcode | sort: 'date' | reverse %}
+{% assign xcode_6_3_builds = site.data.builds.swift-6_3-branch.xcode | sort: 'date' | reverse %}
 
 
 <div class="content">
@@ -120,16 +120,16 @@ title: Install Swift - macOS
     <div class="release-box section">
       <div class="content">
         <div class="code-box content-wrapper">
-          <h2>release/6.2</h2>
+          <h2>release/6.3</h2>
           <p class="body-copy">
-            <small>{{ xcode_6_2_builds.first.date | date: '%B %-d, %Y' }}</small><br />
+            <small>{{ xcode_6_3_builds.first.date | date: '%B %-d, %Y' }}</small><br />
             Toolchain package installer (.pkg)
           </p>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/swift-6.2-branch/xcode/{{ xcode_6_2_builds.first.dir }}/{{ xcode_6_2_builds.first.debug_info }}" class="body-copy">Debugging Symbols</a>
+            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.debug_info }}" class="body-copy">Debugging Symbols</a>
           </div>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/swift-6.2-branch/xcode/{{ xcode_6_2_builds.first.dir }}/{{ xcode_6_2_builds.first.download }}" class="body-copy">Download Toolchain</a>
+            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.download }}" class="body-copy">Download Toolchain</a>
           </div>
         </div>
       </div>
@@ -146,8 +146,8 @@ title: Install Swift - macOS
   <div class="release-box section">
     <div class="content">
         <details class="download" style="margin-bottom: 0;">
-        <summary>Previous Snapshots (release/6.2)</summary>
-        {% include_relative _older-6_2-snapshots.md %}
+        <summary>Previous Snapshots (release/6.3)</summary>
+        {% include_relative _older-6_3-snapshots.md %}
         </details>
     </div>
   </div>


### PR DESCRIPTION
We started publishing Swift 6.3 development snapshots for most platforms, so those should take precedence over 6.2 snapshots.