### PR TITLE
Fix Swift 6.3 snapshot Android SDK URLs

### DIFF
--- a/_includes/new-includes/components/android-sdk-dev.html
+++ b/_includes/new-includes/components/android-sdk-dev.html
@@ -36,8 +36,8 @@
             </p>
             <div class="link-wrapper">
             <div class="link-group">
-                <a href="https://download.swift.org/development/android-sdk/{{ android_sdk_6_3_dev_builds.first.dir }}/{{ android_sdk_6_3_dev_builds.first.download }}" class="body-copy">Download</a> |
-                <a href="https://download.swift.org/development/android-sdk/{{ android_sdk_6_3_dev_builds.first.dir }}/{{ android_sdk_6_3_dev_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
+                <a href="https://download.swift.org/swift-6.3-branch/android-sdk/{{ android_sdk_6_3_dev_builds.first.dir }}/{{ android_sdk_6_3_dev_builds.first.download }}" class="body-copy">Download</a> |
+                <a href="https://download.swift.org/swift-6.3-branch/android-sdk/{{ android_sdk_6_3_dev_builds.first.dir }}/{{ android_sdk_6_3_dev_builds.first.download_signature }}" class="body-copy">Signature (PGP)</a>
             </div>
             </div>
         </div>


### PR DESCRIPTION
It looks like #1257 missed this change, simple fix, @alexandersandberg.