### PR TITLE
Fix html anchors

### DIFF
--- a/_includes/new-includes/components/linux-releases.html
+++ b/_includes/new-includes/components/linux-releases.html
@@ -86,7 +86,7 @@
     </div>
   </div>
   {% endif %}
-  <h2 id="development-snapshots" class="header-with-anchor">Development Snapshots</h2>
+  <h2 id="development-snapshots" class="html-header-with-anchor">Development Snapshots</h2>
   <div>
     <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>
   </div>

--- a/assets/javascripts/new-javascripts/application.js
+++ b/assets/javascripts/new-javascripts/application.js
@@ -113,7 +113,7 @@ if (codeBoxes.length) {
   })
 }
 
-document.querySelectorAll('h2.header-with-anchor').forEach(header => {
+document.querySelectorAll('h2.html-header-with-anchor').forEach(header => {
   if (!header.id) return;
 
   const link = document.createElement('a');

--- a/assets/stylesheets/new-stylesheets/_core.scss
+++ b/assets/stylesheets/new-stylesheets/_core.scss
@@ -69,7 +69,8 @@ blockquote {
   }
 }
 
-.header-with-anchor {
+.header-with-anchor,
+.html-header-with-anchor {
   scroll-margin-top: 80px;
 
   a {
@@ -82,7 +83,8 @@ blockquote {
   }
 }
 
-h2.header-with-anchor {
+h2.header-with-anchor,
+.html-header-with-anchor {
   &:hover {
     a {
       display: inline-block;

--- a/install/linux/index.md
+++ b/install/linux/index.md
@@ -6,7 +6,7 @@ title: Install Swift - Linux
 ---
 
 <div class="content">
-  <h3 id="swiftly" class="header-with-anchor">1. Install Swift via Swiftly</h3>
+  <h3 id="swiftly" class="html-header-with-anchor">1. Install Swift via Swiftly</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.linux.releases.latest-release.swiftly %}
@@ -17,7 +17,7 @@ title: Install Swift - Linux
       {% include new-includes/components/code-box.html content = site.data.new-data.install.linux.releases.latest-release.container %}
     </div>
   </div>
-  <h3 id="editor" class="header-with-anchor">2. Select an Editor</h3>
+  <h3 id="editor" class="html-header-with-anchor">2. Select an Editor</h3>
   <div class="releases-grid">
     <div class="release-box section">
       <div class="content">
@@ -30,13 +30,13 @@ title: Install Swift - Linux
       </div>
     </div>
   </div>
-  <h3 id="build-a-command-line-tool" class="header-with-anchor">3. Build a Command-line Tool</h3>
+  <h3 id="build-a-command-line-tool" class="html-header-with-anchor">3. Build a Command-line Tool</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.build-a-package%}
     </div>
   </div>
-  <h2 id="swift-sdk-bundles" class="header-with-anchor">Swift SDK Bundles</h2>
+  <h2 id="swift-sdk-bundles" class="html-header-with-anchor">Swift SDK Bundles</h2>
   <div>
     <p class="content-copy">Additional components for cross-compilation</p>
   </div>
@@ -54,7 +54,7 @@ title: Install Swift - Linux
   </div>
 <br><br>
 <hr>
-  <h2 id="development-snapshots" class="header-with-anchor">Development Snapshots</h2>
+  <h2 id="development-snapshots" class="html-header-with-anchor">Development Snapshots</h2>
   <div>
     <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>
   </div>
@@ -63,7 +63,7 @@ title: Install Swift - Linux
       {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.linux.dev.latest-dev.swiftly %}
     </div>
   </div>
-  <h2 id="swift-sdk-bundles" class="header-with-anchor">Swift SDK Bundles</h2>
+  <h2 id="swift-sdk-bundles" class="html-header-with-anchor">Swift SDK Bundles</h2>
   <div>
     <p class="content-copy">Additional components for cross-compilation</p>
   </div>

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -10,13 +10,13 @@ title: Install Swift - macOS
 
 
 <div class="content">
-  <h3 id="swiftly" class="header-with-anchor">1. Install Swift via Swiftly</h3>
+  <h3 id="swiftly" class="html-header-with-anchor">1. Install Swift via Swiftly</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html with-tabs = true content = site.data.new-data.install.macos.releases.latest-release.swiftly%}
     </div>
   </div>
-  <h3 id="editor" class="header-with-anchor">2. Select an Editor</h3>
+  <h3 id="editor" class="html-header-with-anchor">2. Select an Editor</h3>
   <div class="releases-grid">
   <div class="release-box section">
     <div class="content">
@@ -34,13 +34,13 @@ title: Install Swift - macOS
       {% include new-includes/components/code-box.html content = site.data.new-data.install.macos.releases.latest-release.other_editors%}
     </div>
   </div>
-  <h3 id="build-a-command-line-tool" class="header-with-anchor">3. Build a Command-line Tool</h3>
+  <h3 id="build-a-command-line-tool" class="html-header-with-anchor">3. Build a Command-line Tool</h3>
 <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.build-a-package%}
     </div>
   </div>
-  <h2 id="swift-sdk-bundles" class="header-with-anchor">Swift SDK Bundles</h2>
+  <h2 id="swift-sdk-bundles" class="html-header-with-anchor">Swift SDK Bundles</h2>
   <div>
     <p class="content-copy">Additional components for cross-compilation</p>
   </div>
@@ -56,7 +56,7 @@ title: Install Swift - macOS
       </div>
     </div>
   </div>
-  <h3 id="alternative-install-options" class="header-with-anchor">Alternative toolchain install options</h3>
+  <h3 id="alternative-install-options" class="html-header-with-anchor">Alternative toolchain install options</h3>
     <div class="release-box section">
       <div class="content">
         <div class="code-box content-wrapper">
@@ -83,7 +83,7 @@ title: Install Swift - macOS
   </div>
   <br><br>
   <hr>
-  <h2 id="development-snapshots" class="header-with-anchor">Development Snapshots</h2>
+  <h2 id="development-snapshots" class="html-header-with-anchor">Development Snapshots</h2>
   <div>
     <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>
     <p class="content-copy">The easiest way to install development snapshots is with the Swiftly tool. Read more on the <a href="/install/macos/swiftly">instructions page</a>.</p>
@@ -151,7 +151,7 @@ title: Install Swift - macOS
         </details>
     </div>
   </div>
-  <h2 id="swift-sdk-buindles-dev" class="header-with-anchor">Swift SDK Bundles</h2>
+  <h2 id="swift-sdk-buindles-dev" class="html-header-with-anchor">Swift SDK Bundles</h2>
   <div>
     <p class="content-copy">Additional components for cross-compilation</p>
   </div>

--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -13,13 +13,13 @@ title: Install Swift - Windows
 {% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Windows 10' | first %}
 
 <div class="content">
-  <h3 id="winget" class="header-with-anchor">1. Install Swift via WinGet</h3>
+  <h3 id="winget" class="html-header-with-anchor">1. Install Swift via WinGet</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.winget %}
     </div>
   </div>
-  <h3 id="editor" class="header-with-anchor">2. Select an Editor</h3>
+  <h3 id="editor" class="html-header-with-anchor">2. Select an Editor</h3>
   <div class="releases-grid">
     <div class="release-box section">
       <div class="content">
@@ -32,13 +32,13 @@ title: Install Swift - Windows
       </div>
     </div>
   </div>
-  <h3 id="build-a-command-line-tool" class="header-with-anchor">3. Build a Command-line Tool</h3>
+  <h3 id="build-a-command-line-tool" class="html-header-with-anchor">3. Build a Command-line Tool</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.build-a-package%}
     </div>
   </div>
-  <h2 id="alternative-install-options" class="header-with-anchor">Alternative install options</h2>
+  <h2 id="alternative-install-options" class="html-header-with-anchor">Alternative install options</h2>
   <div class="releases-grid">
     <div class="release-box section">
       <div class="content">
@@ -76,7 +76,7 @@ title: Install Swift - Windows
       </div>
     </div>
   </div>
-  <h2 id="previous-releases" class="header-with-anchor">Previous Releases</h2>
+  <h2 id="previous-releases" class="html-header-with-anchor">Previous Releases</h2>
   <div>
     <p class="content-copy">Previous releases of Swift are available for installation on Windows using the manual installer, <a href="/install/windows/archived">as documented here</a>.</p>
   </div>
@@ -88,7 +88,7 @@ title: Install Swift - Windows
         </details>
     </div>
   </div>
-  <h2 id="development-snapshots" class="header-with-anchor">Development Snapshots</h2>
+  <h2 id="development-snapshots" class="html-header-with-anchor">Development Snapshots</h2>
   <div>
     <p class="content-copy">Swift snapshots are prebuilt binaries that are automatically created from the branch. These snapshots are not official releases. They have gone through automated unit testing, but they have not gone through the full testing that is performed for official releases.</p>
   </div>


### PR DESCRIPTION
### Motivation:

In Blog posts titles have 2 anchors (2 icons)

### Modifications:

Applied more specific class to avoid conflict with existing one

### Result:

Now Blog posts headings have only 1 anchor each and the other pages are working correctly (for example Install page)
