### PR TITLE
Fix margin icons DocC footer

### DIFF
--- a/assets/stylesheets/docc/footer.css
+++ b/assets/stylesheets/docc/footer.css
@@ -55,6 +55,7 @@ footer[role="contentinfo"] aside i {
   float: right;
   height: var(--icon-size);
   width: var(--icon-size);
+  margin-left: 10px;
 }
 
 footer[role="contentinfo"] aside i.feed {


### PR DESCRIPTION
### Motivation:

Footer social icons (bottom right) in https://www.swift.org/documentation/docc/ are too close

### Modifications:

Applied margin to separate the icons in footer.css for DocC

### Result:

Before

<img width="934" height="429" alt="Screenshot 2025-12-15 at 4 15 53 PM" src="https://github.com/user-attachments/assets/b887694e-6e36-499e-8a5d-c7ffeae347f6" />


After

<img width="910" height="429" alt="Screenshot 2025-12-15 at 4 15 41 PM" src="https://github.com/user-attachments/assets/3608a041-9b96-4813-ae3a-b880584e4d71" />

