### PR TITLE
Revises description of digest blog posts in October digest

### DIFF
--- a/_posts/2025-10-31-whats-new-in-swift-october-2025.md
+++ b/_posts/2025-10-31-whats-new-in-swift-october-2025.md
@@ -7,7 +7,7 @@ author: [heckj, davelester]
 category: "Digest"
 ---
 
-*Editor Note: This is the first of a new series, What’s new in Swift, a monthly digest featuring what's new in the Swift project and ecosystem, with insights and perspectives from across the Swift world. This October edition covers highlights from the Server Side Swift conference, major package releases, and the latest Swift Evolution proposals.*
+*Editor Note: This is the first of a new series, What’s new in Swift, a regular digest featuring what's new in the Swift project and ecosystem, with insights and perspectives from across the Swift world. This October edition covers highlights from the Server Side Swift conference, major package releases, and the latest Swift Evolution proposals.*
 
 *Thanks to Joe Heck for sharing his conference experience and insights as our inaugural guest contributor.*
 


### PR DESCRIPTION
About six weeks ago we published [What's new in Swift: October 2025 Edition](https://www.swift.org/blog/whats-new-in-swift-october-2025/), a digest blog post featuring what’s new in the Swift project and ecosystem, with insights and perspectives from across the Swift community.

The original post included the description of a "monthly digest" which was overly ambitious and definitive for a new series -- regularity is important, but we'll likely want to evolve the cadence as we also evolve the post format itself.

To avoid future confusion, this PR simply updates the past mention from "monthly digest" to "regular digest" -- something we can do in future digest posts as well.