### PR TITLE
Server docs building

### DIFF
--- a/documentation/server/guides/building.md
+++ b/documentation/server/guides/building.md
@@ -89,8 +89,8 @@ This is particularly useful in monorepo setups or packages with multiple deploym
 
 ## Use package traits
 
-Beyond additional compiler flags, Swift 6.2 introduces another way to control what gets built.
-Starting with Swift 6.2, packages can define traits, which enable or disable optional features at build time.
+Beyond additional compiler flags, Swift 6.1 introduces another way to control what gets built.
+Starting with Swift 6.1, packages can define traits, which enable or disable optional features at build time.
 
 Package Traits allows a package to define additional, optional code that you can enable for your service or library.
 You can toggle experimental APIs, performance monitoring, or deployment settings without creating separate branches. 


### PR DESCRIPTION
# Do Not Merge

Updates the guide to building packages for Swift Server

### Motivation:

Updates the guide to building packages for Swift Server, resolves swiftlang/docs#19 

### Modifications:

Revise to align to the outline in swiftlang/docs#19 and add some additional guidance on inspecting binary executables using `file` with examples to show how the different build options can be compared.

### Result:

Perhaps the easiest way to view this content would be to check out this PR and running the branch locally, so you get a good HTML preview of the proposed article updates:

```
gh pr checkout 1277
make build
make website
open http://localhost:4000/documentation/server/guides/building/
make clean
```
