### PR TITLE
Update /get-started/ to redirect to root

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /
+redirect_to: /getting-started/
 ---


### PR DESCRIPTION
https://www.swift.org/get-started/ is currently redirecting to https://www.swift.org/get-started/machine-learning-and-ai/ (presumably in anticipation of https://github.com/swiftlang/swift-org-website/issues/1097), but that page doesn't exist so it results in a 404.

This change simply redirects https://www.swift.org/get-started/ to https://www.swift.org/ for lack of anywhere better, but I suppose it could alternatively go to https://www.swift.org/documentation/.
