### PR TITLE
style(blog): Remove backdrop filter from incorrect element.

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_blog.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_blog.scss
@@ -59,7 +59,6 @@
     box-sizing: border-box;
     border-radius: 22px;
     text-align: left;
-    backdrop-filter: blur(10px);
 
     @media only screen and (max-width: 1024px) {
       padding: 20px;


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

The backdrop blur filter was mistakenly applied to the wrong element, resulting in the background noise appearing cut off. 

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Removed CSS rule. 

### Result:

The backdrop filter was removed. 

<!-- _[After your change, what will change.]_ -->
