### PR TITLE
Remove code annotation from header in blog post 2026-01-22-improving-usability-of-c-libraries-in-swift.md

### DIFF
--- a/_posts/2026-01-22-improving-usability-of-c-libraries-in-swift.md
+++ b/_posts/2026-01-22-improving-usability-of-c-libraries-in-swift.md
@@ -655,7 +655,7 @@ The techniques described in this post can be applied to just about any C library
 
 A little bit of annotation work on your favorite C library can make for a safer, more ergonomic, more Swifty experience of working with that library.
 
-## Postscript: Thoughts for improving the generated `webgpu.h`
+## Postscript: Thoughts for improving the generated webgpu.h
 
 The regular structure of `webgpu.h` helped considerably when trying to expose the API nicely in Swift. That said, there are a few ways in which `webgpu.h` could be improved to require less annotation for this purpose:
 


### PR DESCRIPTION
Hovering over the "Postscript: Thoughts for improving the generated webgpu.h" section of the blog post results in this mangling of the header in Safari and Chromium browsers:

<img width="1331" height="976" alt="Screenshot 2026-01-22 at 21 41 01" src="https://github.com/user-attachments/assets/29948afb-69ec-46c9-b112-c5d3831b8816" />

The problem seems to be how the hover link code is generated. It results in:

```
<a title="Permalink for Postscript: Thoughts for improving the generated &lt;code class=" language-plaintext="" highlighter-rouge"="">webgpu.h section" href="#postscript-thoughts-for-improving-the-generated-webgpuh"&gt;
```

The `<code>` block is literally inlined into the title, which results in this ugliness.

This PR simply removes the backticks from "webgpu.h" in order to remove the creation of the `<code>` block, which should avoid this problem.

Ideally, the Javascript responsible for mangling this would be fixed, but this PR serves as a quick fix to the glitch.