### PR TITLE
Add WebAssembly `wasip1-threads` Swift SDK GSoC 2026 project proposal

### DIFF
--- a/gsoc2026/index.md
+++ b/gsoc2026/index.md
@@ -172,7 +172,7 @@ As a stretch goal, we'd like this project to include a review of the existing te
 
 - New Swift SDK with `wasm32-unknown-wasip1-threads` triple added to the existing Wasm Swift SDK bundle;
 - Running Swift stdlib tests compiled for the new triple;
-- (Stretch) CI jobs for core Swift libraries building with the new Swift SDK.
+- (Stretch) CI setup for core Swift libraries building with the new Swift SDK.
 
 **Potential mentors**
 


### PR DESCRIPTION
Added a compiler build script project for enabling the multi-threading triple in existing Swift SDK bundles.