### PR TITLE
Add prerequisites section to Windows install page

### DIFF
--- a/install/windows/index.md
+++ b/install/windows/index.md
@@ -13,7 +13,14 @@ title: Install Swift - Windows
 {% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Windows 10' | first %}
 
 <div class="content">
-  <h3 id="winget" class="header-with-anchor">1. Install Swift via WinGet</h3>
+  <div class="release-box section">
+    <div class="content">
+      <h2 id="prerequisites" class="header-with-anchor">Prerequisites</h2>
+      {% include install/_windows_dependencies.md %}
+      <p class="body-copy"><strong>Important:</strong> The WinGet command in step 1 below will automatically install Visual Studio for you. If you prefer to use the manual installer, you must install these prerequisites separately before installing Swift.</p>
+    </div>
+  </div>
+  <h3 id="winget" class="header-with-anchor">1. Install Swift and Dependencies via WinGet</h3>
   <div class="release-box section">
     <div class="content">
       {% include new-includes/components/code-box.html content = site.data.new-data.install.windows.releases.latest-release.winget %}


### PR DESCRIPTION
Add prerequisites section to Windows install page

Make Visual Studio requirement more prominent by adding a dedicated prerequisites section at the top of the Windows installation page. This helps prevent build errors from users installing Swift without required dependencies.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.
-->

### Motivation:

The Windows install page did not make it sufficiently obvious that Visual Studio is a required prerequisite for Swift. Users who missed this requirement encountered cryptic build errors like 'stdint.h' file not found when attempting to compile Swift code. Issue #666 documented this problem where new users could easily skip the Visual Studio installation, especially when using the manual installer route.

### Modifications:

- Added a prominent "Prerequisites" section at the top of /install/windows/index.md before the installation steps
- Included the existing _windows_dependencies.md content that lists all required dependencies (Git, Python, Windows SDK, Visual Studio)
- Added an important note clarifying that WinGet automatically installs Visual Studio, but manual installer users must install prerequisites separately
- Updated the section 1 heading from "Install Swift via WinGet" to "Install Swift and Dependencies via WinGet" to make it clear both are included

### Result:

Users visiting the Windows installation page will now immediately see the prerequisites section with Visual Studio clearly listed as a required dependency. This prevents confusion and reduces support burden from users who attempt to use Swift without the necessary platform dependencies installed.

Fixes #763

