### PR TITLE
Add second mentor for DocC project idea

### DIFF
--- a/gsoc2026/index.md
+++ b/gsoc2026/index.md
@@ -206,6 +206,7 @@ Live preview could be further improved by providing language features such as go
 **Potential mentors**
 
 - [Matthew Bastien](https://github.com/matthewbastien)
+- [Prajwal Nadig](https://github.com/snprajwal)
 
 ---
 


### PR DESCRIPTION
I will be co-mentoring the Docc x SourcekitLSP idea for GSoC, this patch adds my GitHub user to the mentor list.