### PR TITLE
Fix Swift examples for value and reference types swiftlang issue #1268

### DIFF
--- a/documentation/articles/value-and-reference-types.md
+++ b/documentation/articles/value-and-reference-types.md
@@ -42,14 +42,21 @@ Since it is an independent instance, changing the `text` of `friendDoc` does not
 struct Document {
   var text: String
 }
+```
+Example
+```swift
+class UseStructDocument {
+  var myDoc = Document(text: "Great new article")
 
-var myDoc = Document(text: "Great new article")
-var friendDoc = myDoc
+  init() {
+    var friendDoc = myDoc
 
-friendDoc.text = "Blah blah blah"
+    friendDoc.text = "Blah blah blah"
 
-print(friendDoc.text) // prints "Blah blah blah"
-print(myDoc.text) // prints "Great new article"
+    print(friendDoc.text) // prints "Blah blah blah"
+    print(myDoc.text) // prints "Great new article"
+  }
+}
 ```
 
 When you send your friend a copy of a document, you are in complete control of when *your* copy changes. You never have to worry about your friend making some unexpected change to your copy of the document.
@@ -73,16 +80,26 @@ Since it is a reference to the same instance, changing the `text` of `friendDoc`
 
 ```swift
 class Document {
-  var text: String
+  var text: String = ""
+
+  init(text: String) {
+    self.text = text
+  }
 }
+```
+Example
+```swift
+class UseClassDocument {
+  var myDoc = Document(text: "Great new article")
 
-var myDoc = Document(text: "Great new article")
-var friendDoc = myDoc
+  init() {
+    let friendDoc = myDoc
+    friendDoc.text = "Blah blah blah"
 
-friendDoc.text = "Blah blah blah"
-
-print(friendDoc.text) // prints "Blah blah blah"
-print(myDoc.text) // prints "Blah blah blah"
+    print(friendDoc.text) // prints "Blah blah blah"
+    print(myDoc.text) // prints "Blah blah blah"
+  }
+}
 ```
 
 When you send your friend a link to a shared document, your friend can make changes to the document without you knowing about it. You might be relying on your document staying the same.


### PR DESCRIPTION
Fix examples to clarify value and reference types in Swift to address issue #1268.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
--> Change to value-and-reference-types.md to address a problem raised in swiftlang issue #1268 

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->As mentioned in the associated swiftlang issue #1268, the 'reference' example is incorrect in that classes do not have an implicit initializer as is the case for structs.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->As suggest in the issue, I modified the class Document definition to add an initializer and set the value of the String variable 'text' to an empty string.
I have added some additional boilerplate in the form of classes that further the example given.  I am of the opinion that someone learning Swift from this article should be able to copy and paste the example code into Xcode or an IDE and have the code compile and run.  However, the existing example code, while clearly demonstrating the difference between value and reference types, will fail to compile as the print functions will produce a "Expressions are not allowed at the top level" error.  I am not wedded to these additions and will revert them to just modify the problem raised in issue #1268, but I hope you will consider the ergonomic aspect of providing code that compiles and runs as opposed to example code that merely demonstrates a point.

### Result:

<!-- _[After your change, what will change.]_ -->The modifications to value-and-reference-types.md will address the fact that the reference example with a class type presents an incorrect usage of class semantics.
