### PR TITLE
Add 2 DocC related project GSoC ideas

### DIFF
--- a/gsoc2026/index.md
+++ b/gsoc2026/index.md
@@ -270,6 +270,63 @@ The approach is to generalize the mechanism by splitting out the Swift core libr
 
 - [Max Desiatov](https://github.com/MaxDesiatov)
 
+
+### Improved documentation for command line tools
+
+**Project size**: 175 hours (medium)
+
+**Estimated difficulty**: Intermediate
+
+**Recommended skills**
+
+- Basic proficiency in Swift.
+
+**Description**
+
+Swift Argument Parser has a [command plugin](https://github.com/apple/swift-argument-parser/pull/694) that generates documentation markup for a command line tool.
+This plugin could be improved by providing support for generating separate pages for each command and by leveraging additional markdown syntax to organize command line flags into sections and display possible values and default values.
+
+Beyond the markdown output, this plugin could be further improved by generating a ["symbol graph"](https://github.com/swiftlang/swift-docc-symbolkit/tree/main) that describe each command and its flags, options, and subcommands. By describing the commands' structure, tools like [Swift DocC](https://github.com/swiftlang/swift-docc/tree/main) can further customize the display of command line tool documentation, support links to individual flags, and allow developers to extend or override the documentation for individual flags in ways that isn't overwritten when regenerating the documentation markup from the plugin. If time allows, prototype some enhancement to command line documentation in Swift DocC that leverage the information from the command symbol graph file.
+
+**Expected outcomes/benefits/deliverables**
+
+- A richer markdown output from the plugin.
+- Support for generating separate pages for each command.
+- Output a supplementary symbol graph file that describe the commands' structure.
+
+**Potential mentors**
+
+- [David Rönnqvist](https://github.com/d-ronnqvist)
+
+
+### Documentation coverage
+
+**Project size**: 90 hours (small)
+
+**Estimated difficulty**: Intermediate
+
+**Recommended skills**
+
+- Basic proficiency in Swift.
+
+**Description**
+
+Enhance Swift DocC's experimental documentation coverage feature to write coverage metrics in a new extensible file format that other tools can read and display. 
+Define a few types of metrics—for example Boolean (has documentation: true/false), Fraction (2/3 parameters are documented), Integer (page has 2 code examples), Percentage, etc.—for this format. 
+
+Explore ideas for what documentation coverage information would be useful to have and ideas for how another tool could present that information by prototyping a tool using your technology of choise.
+Iterativelt refine the documentation coverage file format based on what you learn from consuming and displaying this data in your protype tool. 
+
+**Expected outcomes/benefits/deliverables**
+
+- Land the documentation coverage output format changes for the experimental feature in DocC.
+- Submit a pitch to the community and the Documentation Workgroup to suggest formally enabling the updated documentation coverage feature in DocC.
+- Summarize your effort with a demo of the new metrics and examples of how another tool could display that information.
+
+**Potential mentors**
+
+- [David Rönnqvist](https://github.com/d-ronnqvist)
+
 ---
 
 


### PR DESCRIPTION
### Motivation:

There were some interests in these project ideas last year but the resulting proposals ultimately weren't selected.

The ideas are still relevant and I'd be happy to mentor them.

### Modifications:

Added 2 new project ideas (both from last year with minor updates to their descriptions):

- Outputting documentation coverage information in DocC
- Improving the documentation that Swift Argument Parser can generate for common line tools.

### Result:

After this change, the GSoC 2026 page will list these 2 project ideas.
