### PR TITLE
Fix: Swift System Metrics 1.0 - Run OTel Service

### DIFF
--- a/_posts/2026-02-20-swift-system-metrics-1.0-released.md
+++ b/_posts/2026-02-20-swift-system-metrics-1.0-released.md
@@ -73,7 +73,7 @@ struct Application {
 
     // Create the service
     let serviceGroup = ServiceGroup(
-      services: [service, systemMetricsMonitor],
+      services: [otelService, service, systemMetricsMonitor],
       gracefulShutdownSignals: [.sigint],
       cancellationSignals: [.sigterm],
       logger: logger


### PR DESCRIPTION
### Motivation:

The recent post on Swift System Metrics 1.0 doesn't add OTel's service to the service group in the example snippet, potentially confusing readers that want to copy-and-paste the snippet.

### Modifications:

I added the `otelService` to the front of the service group. This is Swift OTel's recommended placement as it ensure telemetry to still be exported while gracefully shutting down all other services in the group.

### Result:

Blog post readers are able to copy-and-paste the snippet included in this post.
