### PR TITLE
Update backtrace integration note for Swift 5.9+ in building.html

### DIFF
--- a/documentation/server/guides/building.md
+++ b/documentation/server/guides/building.md
@@ -42,4 +42,4 @@ SwiftPM can show you the full binary path using `swift build --show-bin-path -c 
 
 - For best performance in Swift 5.2 or later, pass `-Xswiftc -cross-module-optimization` (this won't work in Swift versions before 5.2) - enabling this should be verified with performance tests (as any optimization changes) as it may sometimes cause performance regressions.
 
-- Integrate [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) into your application to make sure backtraces are printed on crash. Backtraces do not work out-of-the-box on Linux, and this library helps to fill the gap. Eventually this will become a language feature and not require a discrete library.
+- Integrate [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) into your application to make sure backtraces are printed on crash. Backtraces do not work out-of-the-box on Linux, and this library helps to fill the gap. Swift 5.9+ has built-in backtracing support.


### PR DESCRIPTION
### Motivation:

Webpage https://www.swift.org/documentation/server/guides/building.html contains outdated information about backtracing support: "Eventually this will become a language feature and not require a discrete library.", but backtracing is built into Swift 5.9+.

See: https://github.com/swift-server/swift-backtrace

### Modifications:

Updated the swift-backtrace integration note to reflect that Swift 5.9+ has built-in backtracing support.

### Result:

Up-to-date information about backtracing support to users.