### PR TITLE
Add backtrace integration note for Swift 5.9+ in deployment.html

### DIFF
--- a/documentation/server/guides/deployment.md
+++ b/documentation/server/guides/deployment.md
@@ -24,4 +24,4 @@ If you are deploying to your own servers (e.g. bare metal, VMs or Docker) there 
 
     instead of `./my-program` to get something akin to a 'crash report' on crash.
 
-- If you don't have `--privileged` (or `--security-opt seccomp=unconfined`) containers (meaning you won't be able to use `lldb`) or you don't want to use lldb, consider using a library like [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) to get stack traces on crash.
+- If you don't have `--privileged` (or `--security-opt seccomp=unconfined`) containers (meaning you won't be able to use `lldb`) or you don't want to use lldb, consider using a library like [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) to get stack traces on crash (important: Swift 5.9+ has built-in backtracing support).


### PR DESCRIPTION
### Motivation:

Webpage https://www.swift.org/documentation/server/guides/deployment.html contains outdated information about backtracing support.

See: https://github.com/swift-server/swift-backtrace

### Modifications:

Added small swift-backtrace integration note to reflect that Swift 5.9+ has built-in backtracing support.

### Result:

Up-to-date information about backtracing support to users.