### PR TITLE
Add SPM Template VS Code Extension GSoC Project Idea

### DIFF
--- a/gsoc2026/index.md
+++ b/gsoc2026/index.md
@@ -221,7 +221,7 @@ Live preview could be further improved by providing language features such as go
 
 **Description**
 
-Add first-class support for the new Swift Package Manager (SPM) template system in the official Swift VS Code extension. To increase adoption of the feature and provide an intuitive experience for users, the VS Code extension should be updated to interface with the template system without requiring the user to leave the VS Code experience by falling back to the command line.
+Add first-class support for the new Swift Package Manager (SwiftPM) template system in the official Swift VS Code extension. To increase adoption of the feature and provide an intuitive experience for users, the VS Code extension should be updated to interface with the template system without requiring the user to leave the VS Code experience by falling back to the command line.
 
 For more details on how templates work in SPM, please review [the accepted proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0500-package-manager-templates.md) on the Swift forums.
 


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

We want to contribute a new project idea for GSOC 2026 for a contributor to add support for the upcoming [Swift Package Manager templates](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0500-package-manager-templates.md) to the Swift VS Code extension.

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

Added a new idea to the list of GSoC 2026 projects.

* Support SPM Templates in VS Code

### Result:

After this change, the GSoC 2026 page will list this new project idea.
