### PR TITLE
Flip blog categories drop down arrow to point down by default

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_blog.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_blog.scss
@@ -312,6 +312,7 @@
         display: block;
         margin: 1px 0 0 18px;
         display: inline-block;
+        transform: rotate(180deg);
       }
     }
 
@@ -342,7 +343,7 @@
       }
 
       .dropdown-toggle-arrow {
-        transform: rotate(180deg);
+        transform: rotate(0deg);
       }
 
       .dropdown-toggle,


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

>A button should show what will happen when it is next clicked - not point to something else.
>
>When the button above a closed menu is clicked, the content will drop down - so the should point down (to where the content will appear)

Reference: https://ux.stackexchange.com/a/87356

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

- Flipped the arrow so that it points down by default, toward the content that will be opened, and up when drop down is visible

### Result:

<!-- _[After your change, what will change.]_ -->

<img width="300" alt="CleanShot 2026-02-24 at 20 38 16" src="https://github.com/user-attachments/assets/5c4fa4ef-323c-45f2-972f-46817d5d08c6" />

<img width="300" alt="CleanShot 2026-02-24 at 20 38 30" src="https://github.com/user-attachments/assets/48140b7a-0fda-43d7-88a6-492e7ec952e0" />
