### PR TITLE
style(): Fix chevron to correct on/off direction.

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_blog.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_blog.scss
@@ -336,13 +336,17 @@
       padding: 23px 0 20px;
     }
 
+    .dropdown-toggle-arrow {
+      transform: rotate(180deg);
+    }
+
     &.active {
       .dropdown-menu {
         display: block;
       }
 
       .dropdown-toggle-arrow {
-        transform: rotate(180deg);
+        transform: rotate(0);
       }
 
       .dropdown-toggle,


### PR DESCRIPTION
<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Chevron on blog page is pointing in the wrong on/off direction.

### Modifications:

Added CSS to flip the direction of the chevron.

### Result:
<img width="482" height="472" alt="Screenshot 2026-02-24 at 2 21 39 PM" src="https://github.com/user-attachments/assets/1c284ca8-d741-456f-b419-30d3a9fbef6e" />
<img width="398" height="466" alt="Screenshot 2026-02-24 at 2 21 43 PM" src="https://github.com/user-attachments/assets/cffca3ad-afc3-4ebf-bc9b-77313ba8a275" />


<!-- _[After your change, what will change.]_ -->
