### PR TITLE
Fixed typo in author bio

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -627,7 +627,7 @@ gbraden:
   name: Gabe Braden
   email: g_braden@apple.com
   github: thePianoKid
-  about: "Gabe is a developer on the cross platforom IDE team at Apple"
+  about: "Gabe is a developer on the cross platform IDE team at Apple"
 
 vladimir_kukushkin:
   name: Vladimir Kukushkin


### PR DESCRIPTION
Fixed typo in my bio `platform` was mis-typed as `platforom`.
