### PR TITLE
Fix missing quotation marks around the title of the latest blog post

### DIFF
--- a/_posts/2026-03-06-building-privacy-first-analytics-with-swift.md
+++ b/_posts/2026-03-06-building-privacy-first-analytics-with-swift.md
@@ -2,7 +2,7 @@
 layout: new-layouts/post
 published: true
 date: 2026-03-06 11:00:00
-title: Swift at scale: building the TelemetryDeck analytics service
+title: "Swift at scale: building the TelemetryDeck analytics service"
 author: [danieljilg]
 category: 'Adopters'
 ---


### PR DESCRIPTION
The blog post I just submitted doesn't build properly because of the colon in he title. This update wraps the title in quotation marks to make it yaml-compatible

This change is in line with other tittles with colons, e.g. 

```
title: "What's new in Swift: December 2025 Edition"
```