### PR TITLE
Fix spacing on GSoC 2026 proposal page

### DIFF
--- a/gsoc2026/index.md
+++ b/gsoc2026/index.md
@@ -359,6 +359,7 @@ Iterativelt refine the documentation coverage file format based on what you lear
 ### Globally Scoped Traits for Swift Testing via runtime configuration schema
 
 **Project size**: 80 hours
+
 **Estimated difficulty**: Intermediate
 
 **Recommended skills**


### PR DESCRIPTION
I missed a newline when drafting my original changes D:

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Make the GSoC proposal page formatting more consistent

### Modifications:

Fix missing newline

### Result:

Estimated Difficulty will appear on its own line
