### PR TITLE
macOS install: deemphasize packages for debugging symbols

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_get-started.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_get-started.scss
@@ -525,6 +525,10 @@
   p,
   a {
     font-size: 17px;
+
+    &.debug {
+      font-size: 12px;
+    }
   }
 
   p {

--- a/install/macos/index.md
+++ b/install/macos/index.md
@@ -109,10 +109,10 @@ title: Install Swift - macOS
             Toolchain package installer (.pkg)
           </p>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/development/xcode/{{ xcode_dev_builds.first.dir }}/{{ xcode_dev_builds.first.debug_info }}" class="body-copy">Debugging Symbols</a>
+            <a href="https://download.swift.org/development/xcode/{{ xcode_dev_builds.first.dir }}/{{ xcode_dev_builds.first.download }}" class="body-copy">Download Toolchain</a>
           </div>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/development/xcode/{{ xcode_dev_builds.first.dir }}/{{ xcode_dev_builds.first.download }}" class="body-copy">Download Toolchain</a>
+            <a href="https://download.swift.org/development/xcode/{{ xcode_dev_builds.first.dir }}/{{ xcode_dev_builds.first.debug_info }}" class="debug">Debugging Symbols</a>
           </div>
         </div>
       </div>
@@ -126,10 +126,10 @@ title: Install Swift - macOS
             Toolchain package installer (.pkg)
           </p>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.debug_info }}" class="body-copy">Debugging Symbols</a>
+            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.download }}" class="body-copy">Download Toolchain</a>
           </div>
           <div class="link-wrapper">
-            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.download }}" class="body-copy">Download Toolchain</a>
+            <a href="https://download.swift.org/swift-6.3-branch/xcode/{{ xcode_6_3_builds.first.dir }}/{{ xcode_6_3_builds.first.debug_info }}" class="debug">Debugging Symbols</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation:

Currently the link for the debugging symbols packages are displayed before the ones for the toolchains -- which does not match the "importance" for the regular user, and it is the opposite order used for the "Previous snapshots" section.

<img width="1023" height="718" alt="Screenshot 2026-03-16 at 1 18 29 PM" src="https://github.com/user-attachments/assets/e1e3e6ae-d1a4-4906-91c1-f43bdb052070" />


This stems from my investigation of https://github.com/swiftlang/swift/issues/87865

### Modifications:

Swap the order of the links, and reduce the font size as well for the debugging symbols (not sure if the way I achieved that is the proper one).

### Result:

<img width="1023" height="718" alt="Screenshot 2026-03-16 at 1 18 39 PM" src="https://github.com/user-attachments/assets/b7e99fb5-9e1f-4ae6-9c66-97b935977ac9" />

