### PR TITLE
Updated windows install instructions

### DIFF
--- a/_data/new-data/install/windows/releases.yml
+++ b/_data/new-data/install/windows/releases.yml
@@ -4,11 +4,11 @@ latest-release:
       Install Swift via the Windows Package Manager (also known as WinGet).
     after-code-text: |
       First, install Windows platform dependencies:
-      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"</code></pre>
+      <pre><code>winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64" --source winget</code></pre>
       <br />
       Next, install Swift and other dependencies:
       <br /><br />
-      <pre><code>winget install --id Swift.Toolchain -e</code></pre>
+      <pre><code>winget install --id Swift.Toolchain -e --source winget</code></pre>
     links:
       - href: "/install/windows/winget/"
         copy: "Additional details included in Instructions"

--- a/install/windows/_winget.md
+++ b/install/windows/_winget.md
@@ -9,7 +9,7 @@
    The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    ~~~ batch
-   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64" --source winget
    ~~~
 
 0. Install Swift and other dependencies:
@@ -17,5 +17,5 @@
    Install the latest Swift developer package, as well as compatible Git and Python tools if necessary.
 
    ~~~ batch
-   winget install --id Swift.Toolchain -e
+   winget install --id Swift.Toolchain -e --source winget
    ~~~

--- a/install/windows/winget/index.md
+++ b/install/windows/winget/index.md
@@ -14,7 +14,7 @@ title: Installation via Windows Package Manager
    The required C++ toolchain and Windows SDK are installed as part of Visual Studio 2022. The instructions below are for the Community edition, but you may want to [use a different Visual Studio edition](https://visualstudio.microsoft.com/vs/compare/) based on your usage and team size.
 
    ~~~ batch
-   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+   winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64" --source winget 
    ~~~
 
 0. Install Swift and other dependencies:
@@ -22,5 +22,5 @@ title: Installation via Windows Package Manager
    Install the latest Swift developer package, as well as compatible Git and Python tools if they don't exist.
 
    ~~~ batch
-   winget install --id Swift.Toolchain -e
+   winget install --id Swift.Toolchain -e --source winget 
    ~~~


### PR DESCRIPTION
There is now a copy of Visual Studio available on the MS Store. As a result, the Swift installation command for Windows doesn't work anymore because `winget` doesn't know which source to pull from. This PR updates the installation command so that the source (`winget`) is specified.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

The instructions to install Swift on Windows fail with this error: 

```
$ winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64"

Failed when searching source: msstore
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.

The following packages were found among the working sources.
Please specify one of them using the --source option to proceed.
Name                         Id                                    Source
-------------------------------------------------------------------------
Visual Studio Community 2022 Microsoft.VisualStudio.2022.Community winget
```

When I add `--source winget`, the installation completed successfully. 

I was only able to reproduce this error on a fresh version of Windows. Once I had installed Swift, running `winget install --id Swift.Toolchain -e` did not throw the error.

### Modifications:

`--source winget` has been added to all the Windows installation commands:

```
winget install --id Microsoft.VisualStudio.2022.Community --exact --force --custom "--add Microsoft.VisualStudio.Component.Windows11SDK.22000 --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Tools.ARM64" --source winget 
```

and...

```
winget install --id Swift.Toolchain -e --source winget
```

### Result:

The installation commands work: the user is not prompted to specify a source. 
