### PR TITLE
Update the Android intro for the 6.3 release

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -134,7 +134,7 @@ $ file .build/aarch64-unknown-linux-android28/debug/hello
 .build/aarch64-unknown-linux-android28/debug/hello: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /system/bin/linker64, with debug_info, not stripped
 ```
 
-Employing a connected Android device that has [USB debugging enabled](https://developer.android.com/studio/debug/dev-options#Enable-debugging) or [a locally-running Android emulator](https://developer.android.com/studio/run/emulator#get-started), you can now copy the executable over, along with the required `libc++_shared.so` dependency from the Android NDK, and run it with [the `adb` utility](https://developer.android.com/tools/adb):
+Using a connected Android device that has [USB debugging enabled](https://developer.android.com/studio/debug/dev-options#Enable-debugging) or [a locally-running Android emulator](https://developer.android.com/studio/run/emulator#get-started), you can now copy the executable over, along with the required `libc++_shared.so` dependency from the Android NDK, and run it with [the `adb` utility](https://developer.android.com/tools/adb):
 
 ```console
 $ adb push .build/aarch64-unknown-linux-android28/debug/hello /data/local/tmp


### PR DESCRIPTION
This can only be updated after the release has been tagged, so mainly looking for review on the text right now.

Should we add the steps to run the cross-compiled tests using adb?