### PR TITLE
Add links to forum discussions for proposals in active review and revision.

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -1258,7 +1258,6 @@ function latestRevisionDiscussionLink(proposal) {
 * @param {string} name - Suffix of discussion name.
 * @returns {?string} URL string
 */
-
 function latestDiscussionLinkForName(proposal, name) {
   let lastReviewDiscussion = proposal.discussions.findLast(e => e.name.endsWith(name))
   if (lastReviewDiscussion) { return lastReviewDiscussion.link }


### PR DESCRIPTION
On the Swift Evolution dashboard, use proposal discussion metadata to allow user to navigate directly to review and revision threads in the Swift forums.

### Motivation:

When a proposal is being reviewed, there is currently friction getting from the listing on the dashboard to the review discussion in the Swift forums. Currently you must click through to the proposal itself, scan to the 'review' link in the "Review" heading of the proposal and click through to the review discussion.

With this change, clicking on the 'Active Review' status value will directly navigate to the review discussion.

For consistency, proposals with the status 'Returned for Revision' will link to the forum discussion thread of the revision.

### Modifications:

- Add methods to find the appropriate discussion link from proposal metadata
- Add link parameter for `renderStatus()` function
- Generate anchor tag for proposal status name detail if link is present

### Result:

For proposals with status "Active Review" and "Returned for Revision" clicking the status value in the list of details will navigate to the corresponding discussion thread in the Swift forums.
