### PR TITLE
Reorders blog categories to feature the recent Swift 6.3 release post.

### DIFF
--- a/_data/new-data/blog/page-data.yml
+++ b/_data/new-data/blog/page-data.yml
@@ -1,8 +1,8 @@
 headline: Latest Swift News
 read-more: Read more
 category_titles:
-  - 'Community'
   - 'Language'
+  - 'Community'
   - 'Developer Tools'
   - 'Adopters'
   - 'Digest'


### PR DESCRIPTION
A screenshot of the new ordering is attached.

<img width="1269" height="1060" alt="Screenshot 2026-03-24 at 15 30 26" src="https://github.com/user-attachments/assets/f6d0dc4f-41d7-40b3-afd8-6b78750cd58e" />
