### PR TITLE
Update core team membership.

### DIFF
--- a/_data/core_team.yml
+++ b/_data/core_team.yml
@@ -1,7 +1,5 @@
 - name: Ben Cohen
 - name: Holly Borla
-- name: Marc Aupont
 - name: Mishal Shah
-- name: Paris Pittman
 - name: Saleem Abdulrasool
 - name: Ted Kremenek

--- a/_data/core_team_emeriti.yml
+++ b/_data/core_team_emeriti.yml
@@ -4,4 +4,6 @@
 - name: Joe Groff 
 - name: Joe Pamer 
 - name: John McCall
+- name: Marc Aupont
+- name: Paris Pittman
 - name: Tom Doron


### PR DESCRIPTION
Paris and Marc are stepping down from the Swift Core Team after three years of service.

Many thanks to them for their contributions and dedication to the Swift project and community.