### PR TITLE
Update Swift SDK for Android 6.3 install instructions

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -17,70 +17,121 @@ To cross-compile Swift code for Android, you need three separate components:
 2. **The Swift SDK for Android**: the set of libraries, headers, and other resources needed to generate and run Swift code for the Android target.
 3. **The Android NDK**: the "Native Development Kit" for Android includes cross-compilation tools like `clang` and `lld` that are used by the host toolchain to cross-compile and link.
 
+### Installing the SDK
 
-#### 1. Install the Host Toolchain
+#### (1) Prerequisites
 
-While `swift` may already be installed on your system (such as through an Xcode installation on macOS), using a cross-compilation Swift SDK requires that the host toolchain and the Swift SDK versions match exactly. For this reason, you will need to install the specific version of the host toolchain for the given Swift SDK version.
+Before starting, please note the following requirements:
 
-The easiest and recommended way to manage host toolchains on macOS and Linux is to use [the swiftly command](/swiftly/documentation/swiftly/getting-started) command. Once that has been setup, you can install the host toolchain with:
+* You need to install an open-source [Swift toolchain](/install/) from
+  swift.org.
+
+* If you are using macOS, note that you cannot use the toolchain
+  provided with Xcode to build programs using the SDK. Instead, you
+  must use the Swift compiler from the open-source toolchain (see
+  above).
+
+
+#### (2) Pre-Installation Notes
+
+Please be aware of:
+
+* Version compatibility: The Swift toolchain must match the version of
+  the Swift SDK for Android that you install.
+
+* Clean installation: If you previously installed an SDK for a
+  different Swift toolchain version, remove the old one before
+  installing the new one (see management commands below).
+
+* Checksum verification: When installing Swift SDKs from remote URLs,
+  you must pass a `--checksum` option with the corresponding checksum
+  provided by the SDK author.
+
+* Command pattern: The installation follows the pattern described in
+  the next sections.
+
+
+#### (3) Download and Install the Swift SDK for Android
+
+To obtain the Swift SDK for Android:
+
+* Visit the swift.org [installation
+  page](https://www.swift.org/install) for complete Swift SDK for Android
+  installation instructions, where you can download directly or click
+  "Copy install command".
+
+* For previous releases, navigate to "Previous Releases" on the
+  installation page.
+
+#### (4) Installation Commands Pattern
+
+The basic installation command follows this pattern:
 
 ```console
-$ swiftly install latest
-Fetching the latest stable Swift release...
-Installing Swift 6.3
-
-Installing package in user home directory...
-Swift 6.3 is installed successfully!
-$ swiftly use latest
-The global default toolchain has been set to `Swift 6.3` (was 6.2.4)
-
-$ swift -version
-Apple Swift version 6.3 (swift-6.3-RELEASE)
-Target: arm64-apple-macosx26.0
-Build config: +assertions
+$ swift sdk install <URL-or-filename-here> [--checksum <checksum-for-archive-URL>]
 ```
-Alternately, you can install the latest test snapshot toolchains with `swiftly install 6.3-snapshot` or `swiftly install main-snapshot`, and then pick which one you want to use.
 
-#### 2. Install the Swift SDK for Android
+You can provide either a URL (with corresponding checksum) or a local
+filename where the SDK can be found.
 
-Next, download and install the Swift SDK bundle using the `swift sdk` command:
+<!--
+{% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Android SDK'| first %}
+{% assign tag = site.data.builds.swift_releases.last.tag %}
+{% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
+{% assign base_url = "https://download.swift.org/" | append: tag_downcase | append: "/android-sdk/" | append: tag | append: "/" | append: tag %}
+{% assign command = "swift sdk install " | append: base_url | append: "_android" | append: ".artifactbundle.tar.gz --checksum " | append: platform.checksum %}
+
+{% comment %} Generate branch information - ONLY major.minor {% endcomment %}
+-->
+
+For example, if you have installed the {{ tag }} toolchain, you would enter:
 
 ```console
-$ swift sdk install https://download.swift.org/swift-6.3-release/android-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_android.artifactbundle.tar.gz --checksum 2f2942c4bcea7965a08665206212c66991dabe23725aeec7c4365fc91acad088
-
-Swift SDK bundle at `https://download.swift.org/swift-6.3-release/android-sdk/swift-6.3-RELEASE/swift-6.3-RELEASE_android.artifactbundle.tar.gz` successfully installed as swift-6.3-RELEASE_android.artifactbundle.
+$ {{ command }}
 ```
 
-Similarly, you can install the latest snapshot by copy-pasting [the install commands shown
-for the various test SDK bundles](/install/macos/#swift-sdk-buindles-dev) on the install pages.
+This will download and install the corresponding Swift SDK for Android on
+your system.
 
-You should now see the Android Swift SDK included in the `swift sdk list` command:
+#### (5) Managing Installed SDKs
+
+After installation, you can manage your SDKs using these commands:
+
+List all installed SDKs:
 
 ```console
 $ swift sdk list
-swift-6.3-RELEASE_android
 ```
 
-#### 3. Install and configure the Android NDK
+Remove an SDK:
+
+```console
+$ swift sdk remove <name-of-SDK>
+```
+
+#### (6) Install and configure the Android NDK
 
 The Swift SDK for Android depends on the Android NDK, LTS version 27d or later, to provide the headers and tools necessary for cross-compiling to Android architectures. There are a variety of ways to [install the Android NDK](https://developer.android.com/ndk/guides), but the simplest is to just download and unzip the archive from the [NDK Downloads page](https://developer.android.com/ndk/downloads/#lts-downloads) directly.
 
-You can automate this with the following commands in a directory of your choosing:
+You can automate this with the following commands by first changing to the installation directory of the Swift SDK for Android. For macOS:
 
 ```console
-$ mkdir ~/android-ndk
-$ cd ~/android-ndk
-$ curl -fSLO https://dl.google.com/android/repository/android-ndk-r27d-$(uname -s).zip
-$ unzip -q android-ndk-r27d-*.zip
-$ export ANDROID_NDK_HOME=$PWD/android-ndk-r27d
+$ cd ~/Library/org.swift.swiftpm/swift-sdks/{{ tag }}_android.artifactbundle/swift-android/
 ```
 
-Once you have downloaded and unpacked the NDK, you must link it to the Swift SDK for Android by running the `setup-android-sdk.sh` utility script included with the Swift SDK bundle:
+or for Linux:
 
 ```console
-$ cd ~/Library/org.swift.swiftpm || cd ~/.swiftpm
-$ ./swift-sdks/swift-6.3-RELEASE_android.artifactbundle/swift-android/scripts/setup-android-sdk.sh
-setup-android-sdk.sh: success: ndk-sysroot linked to Android NDK at android-ndk-r27d/toolchains/llvm/prebuilt
+$ cd ~/.swiftpm/swift-sdks/{{ tag }}_android.artifactbundle/swift-android/
+```
+
+Then run:
+
+```console
+$ curl -fSL -o ndk.zip https://dl.google.com/android/repository/android-ndk-r27d-$(uname -s).zip
+$ unzip -qo ndk.zip
+$ export ANDROID_NDK_HOME=$PWD/android-ndk-r27d
+$ ./scripts/setup-android-sdk.sh
 ```
 
 *If you have already installed the NDK in a different location, you can simply set the `ANDROID_NDK_HOME` environment variable to that location and run the `setup-android-sdk.sh` script.*
@@ -151,7 +202,7 @@ Hello, world!
 
 Congratulations, you have built and run your first Swift program on Android!
 
-Android applications are typically not deployed as command-line executable tools. Rather, they are assembled into an `.apk` archive and launched as an app from the home screen. To support this, Swift modules can be built as shared libraries for each supported architecture and included in an app archive. Swift code can then be accessed from the Android app — which is typically written in Java or Kotlin — through [the Java Native Interface (JNI)](https://developer.android.com/training/articles/perf-jni) by using [the swift-java interoperability library and tools](https://github.com/swiftlang/swift-java).
+Android applications are typically not deployed as command-line executable tools. Rather, they are assembled into an `.apk` archive and launched as an app from the home screen. To support this, Swift modules can be built as shared libraries for each supported architecture and included in an app archive. Swift code can then be accessed from the Android app — which is typically written in Java or Kotlin — through [the Java Native Interface (JNI)](https://developer.android.com/training/articles/perf-jni) by using the low-level [swiftlang/swift-java-jni-core](https://github.com/swiftlang/swift-java-jni-core) and higher-level [swiftlang/swift-java](https://github.com/swiftlang/swift-java) interoperability library and tools.
 
 Visit [the Android Examples repository](https://github.com/swiftlang/swift-android-examples) to see a variety of projects that demonstrate how to build full Android applications that utilize the Swift SDK for Android.
 


### PR DESCRIPTION
### Motivation:

Update installation instructions for the Swift SDK for Android for the 6.3 release. Follow-up to https://github.com/swiftlang/swift-org-website/pull/1358

### Modifications:

Update the instructions to dynamically update based on the current Swift release, mostly based on the Static Linux SDK instruction template at https://github.com/swiftlang/swift-org-website/blob/main/documentation/articles/static-linux-getting-started.md.

### Result:

The installation instructions for the Android SDK will be updated for 6.3, and will automatically be updated for subsequent releases.