### PR TITLE
Update link in Swift 6.3 blog post

### DIFF
--- a/_posts/2026-03-24-swift-6.3-released.md
+++ b/_posts/2026-03-24-swift-6.3-released.md
@@ -111,7 +111,7 @@ Swift 6.3 also brings the following Swift Package Manager improvements:
 * **Flexible inherited documentation:** Control whether inherited documentation is included in command plugins that generate symbol graphs.
 * **Discoverable package traits:** Discover the traits supported by a package using the new `swift package show-traits` command.
 
-For more information on changes to Swift Package Manager, see the [SwiftPM 6.3 Release Notes](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/ReleaseNotes/6.3.md).
+For more information on changes to Swift Package Manager, see the [SwiftPM 6.3 Release Notes](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/6.3).
 
 ## Core Library Updates
 
@@ -169,7 +169,7 @@ To learn more and try out Swift for Android development in your own projects, se
 
 ## Thank You
 
-Swift 6.3 reflects the contributions of many people across the Swift community — through code, proposals, forum discussions, and feedback from real-world experience. A special thank you to the Android Workgroup, whose months of effort — building on many years of grassroots community work — brought the Swift SDK for Android from nightly previews to an official release in Swift 6.3. 
+Swift 6.3 reflects the contributions of many people across the Swift community — through code, proposals, forum discussions, and feedback from real-world experience. A special thank you to the Android Workgroup, whose months of effort — building on many years of grassroots community work — brought the Swift SDK for Android from nightly previews to an official release in Swift 6.3.
 
 If you'd like to get involved in what comes next, the [Swift Forums](http://forums.swift.org/) are a great place to start.
 


### PR DESCRIPTION
A PR in Swift Package Manager makes a change that will cause a link in the "Swift 6.3 Released" blog post to be broken.  Update the URL to the correct location.

Depends on: https://github.com/swiftlang/swift-package-manager/pull/9851
Depends on: https://github.com/swiftlang/swift-package-manager/issues/10095