### PR TITLE
GHA: Add PR dependency check

### DIFF
--- a/.github/workflows/pull_request_dependency_check.yaml
+++ b/.github/workflows/pull_request_dependency_check.yaml
@@ -1,0 +1,13 @@
+name: "Dependencies"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+    uses: swiftlang/github-workflows/.github/workflows/github_actions_dependencies.yml@0.0.11


### PR DESCRIPTION
Add a workflow that will check if dependent PRs/Issues are merged. If not, fail the build.