### PR TITLE
Use consistent separator for proposal date ranges

### DIFF
--- a/assets/javascripts/swift-evolution.js
+++ b/assets/javascripts/swift-evolution.js
@@ -528,7 +528,7 @@ function renderReviewPeriod (status) {
   if (startMonth === endMonth) {
     detailNodes.push(
       start.getUTCDate().toString(),
-      '–',
+      ' – ',
       end.getUTCDate().toString()
     )
   } else {


### PR DESCRIPTION
Proposals under active review include the date range of the review.

At present, the separator is not consistent.

For ranges that cross month boundaries:

'April 28 - May 12'

For ranges within the same month:

'April 3-17'

This PR makes the separator consistent, using \<space>\<hyphen>\<space> across both:

'April 3 - 17'