### PR TITLE
Fix Wasm Getting Started broken links for issue #1388

### DIFF
--- a/documentation/articles/wasm-getting-started.md
+++ b/documentation/articles/wasm-getting-started.md
@@ -124,7 +124,7 @@ This section shows you how to configure your development environment for Swift W
 
 ### Visual Studio Code
 
-If you haven't set up VSCode for Swift development yet, see the [Configuring VS Code for Swift Development guide](/documentation/articles/getting-started-with-vscode-swift/).
+If you haven't set up VSCode for Swift development yet, see the [Configuring VS Code for Swift Development guide](/documentation/articles/getting-started-with-vscode-swift.html).
 
 **Configure VSCode for WebAssembly:**
 
@@ -169,5 +169,5 @@ For other editors (Vim, Neovim, Emacs, etc.) with LSP support already configured
    Replace `{{ tag }}_wasm` with your Swift SDK ID from `swift sdk list`. Use `{{ tag }}_wasm-embedded` for Embedded Swift.
 
 For initial Swift LSP setup guides, see:
-- [Zero to Swift with Neovim](/documentation/articles/zero-to-swift-nvim/)
-- [Zero to Swift with Emacs](/documentation/articles/zero-to-swift-emacs/)
+- [Zero to Swift with Neovim](/documentation/articles/zero-to-swift-nvim.html)
+- [Zero to Swift with Emacs](/documentation/articles/zero-to-swift-emacs.html)


### PR DESCRIPTION
URLs on page were directories and not the .html files. Documentation was returning 404 errors when user clicks links.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

Fulfills issue #1388 where links were directories and not .html links.

### Modifications:

Changed the directory links to .html links

### Result:

No more 404 error.
