### PR TITLE
Android getting started: try to finally fix the name of the previous SDK

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -30,8 +30,9 @@ Cross-compilation for Android requires installing three separate components:
 {% assign platform = site.data.builds.swift_releases.last.platforms | where: 'name', 'Android SDK'| first %}
 {% assign tag = site.data.builds.swift_releases.last.tag %}
 {% assign version = site.data.builds.swift_releases.last.name %}
-{% assign previous_releases = site.data.builds.swift_releases | offset:1 %}
-{% assign previous_sdk_name = previous_releases.last.name | append: "_android" %}
+{% assign release_count = site.data.builds.swift_releases.size %}
+{% assign previous_release = site.data.builds.swift_releases | slice: release_count - 2 %}
+{% assign previous_sdk_name = previous_release.tag | append: "_android" %}
 {% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
 {% assign base_url = "https://download.swift.org/" | append: tag_downcase | append: "/android-sdk/" | append: tag | append: "/" | append: tag %}
 {% assign command = "swift sdk install " | append: base_url | append: "_android" | append: ".artifactbundle.tar.gz --checksum " | append: platform.checksum %}


### PR DESCRIPTION
@federicobucchi, please take a look, I see you used `slice` in the `index.md`, as I'm a Jekyll noob.