### PR TITLE
[cxx-interop] Update C++ interop documentation for shared reference types + others

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1376,7 +1376,7 @@ These annotations tell the Swift compiler whether the type is returned as `+1` (
 SharedObject* _Nonnull makeOwnedObject() SWIFT_RETURNS_RETAINED;
 
 // Returns +0 ownership.
-SharedObject* _Nonnull getUnOwnedObject() SWIFT_RETURNS_UNRETAINED;
+SharedObject* _Nonnull getUnownedObject() SWIFT_RETURNS_UNRETAINED;
 ```
 
 These annotations are necessary to ensure that appropriate `retain`/`release` operations are inserted at the boundary:
@@ -1386,9 +1386,9 @@ let owned = makeOwnedObject()
 owned.doSomething()
 // `owned` is already at +1, so no further retain is needed here
 
-let unOwned = getUnOwnedObject()
+let unowned = getUnownedObject()
 // Swift inserts a retain operation on `unowned` here to bring it to +1.
-unOwned.doSomething()
+unowned.doSomething()
 ```
 
 Calling a function that returns a shared reference without a known ownership convention is memory unsafe and will eventually be treated as an error.

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1233,10 +1233,9 @@ let vector = createCxxVectorOfInt()
 takesVectorType(vector) // 'vector' is copied here.
 ```
 
-Swift's upcoming
-[parameter ownership modifiers](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0377-parameter-ownership-modifiers.md),
-which will be provided in an upcoming Swift release, will let you avoid copies
-when passing immutable values to functions. Mutable values can be passed
+Swift's
+[parameter ownership modifiers](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0377-parameter-ownership-modifiers.md)
+let you avoid copies when passing immutable values to functions. Mutable values can be passed
 by `inout` to a Swift function, which lets you avoid a deep copy of
 the C++ container:
 
@@ -2187,6 +2186,8 @@ that are outlined in the documentation above.
 | `SWIFT_NONCOPYABLE` | [C++ Structures and Classes are Value Types by Default](#c-structures-and-classes-are-value-types-by-default) |
 | `SWIFT_SELF_CONTAINED` | [Annotating C++ Structures or Classes as Self Contained](#annotating-c-structures-or-classes-as-self-contained) |
 | `SWIFT_PRIVATE_FILEID` | [Accessing Private C++ Members in Swift](#accessing-private-c-members-in-swift) |
+| `SWIFT_RETURNS_RETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
+| `SWIFT_RETURNS_UNRETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
 
 ## Document Revision History
 

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1391,7 +1391,6 @@ let unOwned = getUnOwnedObject()
 unOwned.doSomething()
 ```
 
-Note that the Swift compiler will automatically infer the ownership conventons for Swift functions returning `SWIFT_SHARED_REFERENCE` types.
 See [Exposing C++ Shared Reference Types back from Swift](#exposing-c-shared-reference-types-back-from-swift) for calling Swift functions returning `SWIFT_SHARED_REFERENCE` types from C++.
 
 #### Calling conventions when passing Shared Reference Types from Swift to C++

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -1391,6 +1391,25 @@ let unOwned = getUnOwnedObject()
 unOwned.doSomething()
 ```
 
+Calling a function that returns a shared reference without a known ownership convention is memory unsafe and will eventually be treated as an error.
+
+Shared reference types that are always returned as unretained can be annotated with `SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT`. When this annotation is present, functions without explicit return ownership annotations are treated as if they were annotated with `SWIFT_RETURNS_RETAINED`:
+
+```c++
+class CallerRetainedObject : IntrusiveReferenceCounted<CallerRetainedObject> {
+    ...
+} SWIFT_SHARED_REFERENCE(retainCallerRetainedObject, releaseCallerRetainedObject)
+  SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
+
+// Returns +0 ownership.
+CallerRetainedObject* _Nonnull getCallerRetainedObject();
+
+// Returns +1 ownership.
+CallerRetainedObject* _Nonnull makeCallerRetainedObject() SWIFT_RETURNS_RETAINED;
+```
+
+Note that there is not an equivalent annotation for objects that are returned as retained by default.
+
 See [Exposing C++ Shared Reference Types back from Swift](#exposing-c-shared-reference-types-back-from-swift) for calling Swift functions returning `SWIFT_SHARED_REFERENCE` types from C++.
 
 #### Calling conventions when passing Shared Reference Types from Swift to C++
@@ -2187,6 +2206,7 @@ that are outlined in the documentation above.
 | `SWIFT_PRIVATE_FILEID` | [Accessing Private C++ Members in Swift](#accessing-private-c-members-in-swift) |
 | `SWIFT_RETURNS_RETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
 | `SWIFT_RETURNS_UNRETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
+| `SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
 
 ## Document Revision History
 

--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -2207,6 +2207,9 @@ that are outlined in the documentation above.
 | `SWIFT_RETURNS_RETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
 | `SWIFT_RETURNS_UNRETAINED` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
 | `SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT` | [Calling conventions when returning Shared Reference Types from C++ to Swift](#calling-conventions-when-returning-shared-reference-types-from-c-to-swift) |
+| `SWIFT_NONESCAPABLE` | [(Safely Mixing Swift and C/C++) Escapability Annotations in Detail](safe-interop#escapability-annotations-in-detail) |
+| `SWIFT_ESCAPABLE` | [(Safely Mixing Swift and C/C++) Escapability Annotations in Detail](safe-interop#escapability-annotations-in-detail) |
+| `SWIFT_ESCAPABLE_IF` | [(Safely Mixing Swift and C/C++) Escapability Annotations in Detail](safe-interop#escapability-annotations-in-detail) |
 
 ## Document Revision History
 


### PR DESCRIPTION
### Motivation:

This documentation was outdated in several areas.

### Modifications:

I updated the documentation. I added some missing annotations to the annotations index, and added some writing discussing `SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT`

### Result:

This documentation is no longer outdated in said areas.