### PR TITLE
Fix Follow Swift section mobile layout

### DIFF
--- a/assets/stylesheets/core/_maps.scss
+++ b/assets/stylesheets/core/_maps.scss
@@ -38,7 +38,7 @@
     }
     $map: map.get($map, $key);
   }
-  @return if(sass($map): $map; else: $default);
+  @return if($map, $map, $default);
 }
 
 ////

--- a/assets/stylesheets/new-stylesheets/pages/_community.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_community.scss
@@ -302,7 +302,7 @@
                 height: 40px;
                 width: auto;
                 margin-bottom: 20px;
-                border-radius: 8px;
+                border-radius: 0;
             }
 
             .link-card-text {

--- a/assets/stylesheets/new-stylesheets/pages/_community.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_community.scss
@@ -323,30 +323,34 @@
 
             @media only screen and (max-width: 768px) {
                 .community-section-links {
-                    flex-direction: row !important;
-                    flex-wrap: wrap !important;
+                    flex-wrap: nowrap !important;
                     height: auto !important;
-                    gap: 0px !important;
-                    max-width: 324px !important;
-                    margin: 0 auto !important
+                    max-width: none !important;
+                    margin: 0 !important;
                 }
 
                 .community-section-links li {
-                    width: 108px !important;
+                    flex: 1 !important;
+                    width: auto !important;
                     padding: 16px 0 !important;
-                    flex: none !important;
                     justify-content: center !important;
                 }
 
-                .community-section-links li:nth-child(3)::after {
-                    content: none !important;
+                .community-section-links li:not(:last-child)::after {
+                    content: "" !important;
+                    position: absolute !important;
+                    right: 0 !important;
+                    top: 12% !important;
+                    bottom: 12% !important;
+                    width: 1px !important;
+                    background-color: #999 !important;
                 }
 
                 .link-card {
                     flex-direction: column !important;
                     justify-content: center !important;
                     align-items: center !important;
-                    gap: 12px !important;
+                    gap: 0 !important;
                 }
 
                 .link-card-image {
@@ -354,8 +358,7 @@
                 }
 
                 .link-card-text {
-                    text-align: center !important;
-                    font-size: 14px !important;
+                    display: none !important;
                 }
             }
         }

--- a/assets/stylesheets/new-stylesheets/pages/_community.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_community.scss
@@ -332,7 +332,8 @@
                 .community-section-links li {
                     flex: 1 !important;
                     width: auto !important;
-                    padding: 16px 0 !important;
+                    height: 50px !important;
+                    padding: 0 !important;
                     justify-content: center !important;
                 }
 
@@ -354,6 +355,7 @@
                 }
 
                 .link-card-image {
+                    height: 25px !important;
                     margin-bottom: 0 !important;
                 }
 

--- a/community/index.md
+++ b/community/index.md
@@ -64,10 +64,10 @@ title: Community
       </div>
    </div>
    <div class="section community-section-grid">
-      <h2 class="community-section-grid-headline">
-         {{ site.data.new-data.community.page-data.section5.headline }}
-      </h2>
       <div class="content links">
+         <h2 class="community-section-grid-headline">
+            {{ site.data.new-data.community.page-data.section5.headline }}
+         </h2>
          <ul class="community-section-links">
          {% for card in site.data.new-data.community.page-data.section5.links %}
             <li>


### PR DESCRIPTION
  - Show all icons in a single row on mobile
  - Hide text labels on mobile
  - Add dividers between all icons on mobile
  - Move "Follow Swift" heading inside the card
  - Fix broken Sass if() syntax in _maps.scss

  https://github.com/swiftlang/swift-org-website/issues/1408

<img width="2880" height="7276" alt="community-desktop" src="https://github.com/user-attachments/assets/e8ec3196-1009-4ee6-9d69-0762f0bb46b3" />
<img width="750" height="10578" alt="community-mobile" src="https://github.com/user-attachments/assets/dc155bad-96be-4ad4-9368-054ea502acf9" />
