### PR TITLE
Centers title of above featured blog posts.

### DIFF
--- a/assets/stylesheets/new-stylesheets/pages/_blog.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_blog.scss
@@ -116,7 +116,7 @@
         font-weight: 500;
         margin-bottom: 16px;
         color: var(--site-text-color);
-        text-align: left;
+        text-align: center;
 
         @media only screen and (max-width: 768px) {
           font-size: 32px;


### PR DESCRIPTION
Simple one-line change, which would adjust the title so "Latest Swift News" is centered on [swift.org/blog](https://www.swift.org/blog/).

Screenshot after the change:
<img width="1266" height="1110" alt="Screenshot 2026-06-04 at 15 55 52" src="https://github.com/user-attachments/assets/1e0a4b03-b435-4388-9f5f-41a24f0df384" />
