### PR TITLE
Update available 6.3/6.4 snapshot branches in OpenAPI spec

### DIFF
--- a/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
@@ -59,6 +59,12 @@ struct Tool {
       .init(branch: ._6_0, platform: .debian12),
       .init(branch: ._6_0, platform: .fedora39),
       .init(branch: ._6_0, platform: .ubuntu2404),
+      .init(branch: ._6_3, platform: .centos7),
+      .init(branch: ._6_3, platform: .fedora39),
+      .init(branch: ._6_3, platform: .ubuntu2004),
+      .init(branch: ._6_4_x, platform: .centos7),
+      .init(branch: ._6_4_x, platform: .fedora39),
+      .init(branch: ._6_4_x, platform: .ubuntu2004),
     ]
     for branch in Components.Schemas.KnownSourceBranch.allCases {
       for platform in Components.Schemas.KnownPlatformIdentifier.allCases {

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -262,6 +262,8 @@ components:
         - '6.0'
         - '6.1'
         - '6.2'
+        - '6.3'
+        - '6.4.x'
     SourceBranch:
       anyOf:
         - $ref: '#/components/schemas/KnownSourceBranch'


### PR DESCRIPTION
https://www.swift.org/openapi/openapi.html#/Toolchains/listWasmSDKDevToolchains endpoint currently doesn't have 6.3/6.4 branches listed even though those are available. Let's update the OpenAPI spec sources to fix this.