### PR TITLE
fixes a warning in the Android getting started Liquid 

### DIFF
--- a/documentation/articles/swift-sdk-for-android-getting-started.md
+++ b/documentation/articles/swift-sdk-for-android-getting-started.md
@@ -31,7 +31,8 @@ Cross-compilation for Android requires installing three separate components:
 {% assign tag = site.data.builds.swift_releases.last.tag %}
 {% assign version = site.data.builds.swift_releases.last.name %}
 {% assign release_count = site.data.builds.swift_releases.size %}
-{% assign previous_release = site.data.builds.swift_releases | slice: release_count - 2 %}
+{% assign previous_index = release_count | minus: 2 %}
+{% assign previous_release = site.data.builds.swift_releases | slice: previous_index %}
 {% assign previous_sdk_name = previous_release.tag | append: "_android" %}
 {% assign tag_downcase = site.data.builds.swift_releases.last.tag | downcase %}
 {% assign base_url = "https://download.swift.org/" | append: tag_downcase | append: "/android-sdk/" | append: tag | append: "/" | append: tag %}


### PR DESCRIPTION
Article uses inline arithmetic- which is working, but throwing a warning. This updates is to use a liquid template mechanism as a replacement to achieve the same result.
