### PR TITLE
Update Ubuntu 20.04 package list to match Swift 6.1 requirements

### DIFF
--- a/_includes/linux/ubuntu2004.html
+++ b/_includes/linux/ubuntu2004.html
@@ -1,19 +1,20 @@
 {% highlight bash %}
 $ apt-get install \
-          binutils \
-          git \
-          gnupg2 \
-          libc6-dev \
-          libcurl4 \
-          libedit2 \
-          libgcc-9-dev \
-          libpython2.7 \
-          libsqlite3-0 \
-          libstdc++-9-dev \
-          libxml2 \
-          libz3-dev \
-          pkg-config \
-          tzdata \
-          uuid-dev \
-          zlib1g-dev
+  binutils \
+  git \
+  unzip \
+  gnupg2 \
+  libc6-dev \
+  libcurl4-openssl-dev \
+  libedit2 \
+  libgcc-9-dev \
+  libpython3.8 \
+  libsqlite3-0 \
+  libstdc++-9-dev \
+  libxml2-dev \
+  libz3-dev \
+  pkg-config \
+  tzdata \
+  uuid-dev \
+  zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
While checking the tarball install instructions for Ubuntu 20.04, I noticed the package list is out of sync with what the official Swift Docker image installs for 6.1.

Specifically:
- `libcurl4` should be `libcurl4-openssl-dev` (the dev headers package)
- `libpython2.7` should be `libpython3.8` (Python 2 is EOL)
- `libxml2` should be `libxml2-dev` (the dev headers package)
- `unzip` is missing entirely

Reference: https://github.com/swiftlang/swift-docker/blob/main/6.1/ubuntu/20.04/Dockerfile

Closes #954