### PR TITLE
Add missing aarch64 PGP signature link for Swiftly installer

### DIFF
--- a/_data/new-data/install/linux/releases.yml
+++ b/_data/new-data/install/linux/releases.yml
@@ -21,7 +21,9 @@ latest-release:
       - href: 'https://raw.githubusercontent.com/swiftlang/swiftly/refs/heads/main/LICENSE.txt'
         copy: 'License: Apache-2.0'
       - href: 'https://download.swift.org/swiftly/linux/swiftly-x86_64.tar.gz.sig'
-        copy: 'PGP: Signature'
+        copy: 'PGP: Signature (x86_64)'
+      - href: 'https://download.swift.org/swiftly/linux/swiftly-aarch64.tar.gz.sig'
+        copy: 'PGP: Signature (aarch64)'
       - href: 'https://www.swift.org/install/linux/swiftly'
         copy: 'Instructions'
   container:


### PR DESCRIPTION
While checking the Linux install page, I noticed the PGP signature section under the Swiftly installer only linked the x86_64 signature file. Since Swiftly supports both x86_64 and aarch64 on Linux and the download command already uses `$(uname -m)` to handle both architectures, the missing aarch64 signature link seemed like an oversight.

This adds the aarch64 signature alongside the existing x86_64 one, and adds architecture labels to both links so users know which file to verify.

Fixes #1135

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
