### PR TITLE
Remove zip from Ubuntu 22.04, 23.10, and 24.04 dependency lists

### DIFF
--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -15,7 +15,6 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}

--- a/_includes/linux/ubuntu2310.html
+++ b/_includes/linux/ubuntu2310.html
@@ -15,7 +15,6 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}

--- a/_includes/linux/ubuntu2404.html
+++ b/_includes/linux/ubuntu2404.html
@@ -15,7 +15,6 @@ $ apt-get install \
           libz3-dev \
           pkg-config \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
### Motivation:

While cross-checking the other Ubuntu pages against the official Swift Docker images, I noticed that ubuntu2204.html, ubuntu2310.html, and ubuntu2404.html all list `zip` alongside `unzip` as required packages. The official Swift Docker images for Ubuntu 22.04, 23.10, and 24.04 only include `unzip` - `zip` isn't needed to install or run the Swift toolchain. This is the same issue that was already fixed for Ubuntu 20.04.

### Modifications:

Removed the `zip \` line from `_includes/linux/ubuntu2204.html`, `_includes/linux/ubuntu2310.html`, and `_includes/linux/ubuntu2404.html`.