### PR TITLE
Fix Fedora 39 package list to match Swift 6.1 Docker image

### DIFF
--- a/_includes/linux/fedora39.html
+++ b/_includes/linux/fedora39.html
@@ -10,6 +10,7 @@ $ yum install \
       libxml2-devel \
       python3-devel \
       sqlite-devel \
-      zip \
+      libstdc++-devel \
+      libstdc++-static \
       unzip
 {% endhighlight %}


### PR DESCRIPTION
While cross-checking the Linux distro pages against the official Swift Docker images (following up on #954), I noticed the Fedora 39 page has `zip` listed as a required package, but the Swift 6.1 Fedora 39 Docker image only uses `unzip`. I also noticed `libstdc++-devel` and `libstdc++-static` are both in the Docker image but missing from the page. This updates the package list to match.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
