### PR TITLE
Fix SIMD16 type inference in homepage Fast example

### DIFF
--- a/_data/new-data/landing/callouts.yml
+++ b/_data/new-data/landing/callouts.yml
@@ -5,7 +5,7 @@
     // Vectorized check that a utf8 buffer is all ASCII
     func isASCII(utf8: Span<SIMD16<UInt8>>) -> Bool {
       // combine all the code units into a single entry
-      utf8.indices.reduce(into: SIMD16()) {
+      utf8.indices.reduce(into: SIMD16<UInt8>()) {
         // fold each set of code units into the result
         $0 |= utf8[$1]
       }


### PR DESCRIPTION
Fixes #1072

### Motivation:

The "Fast" example in `_data/new-data/landing/callouts.yml` uses `reduce(into: SIMD16())` without an explicit type annotation. This causes a "generic parameter 'Scalar' could not be inferred" compiler error when someone tries to run the snippet.

I noticed this while looking at issue #1072 - the example showed up as broken in the Swift REPL. The `Span` type that was missing before Swift 6.2 is now available, but the bare `SIMD16()` initializer still requires an explicit type in some contexts.

### Modifications:

Changed `SIMD16()` to `SIMD16<UInt8>()` to make the element type explicit. This matches the element type of the `Span<SIMD16<UInt8>>` parameter and removes the ambiguity.

### Result:

The `isASCII` function compiles cleanly. No other changes.