### PR TITLE
Remove zip from Ubuntu 22.04 package list

### DIFF
--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -15,7 +15,6 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
I was looking at the Ubuntu 22.04 installation page and noticed zip is listed as a required package. Checking the official swiftlang/swift-docker Dockerfile for 6.1/ubuntu/22.04, zip isn't actually installed - only unzip is. This removes the incorrect entry to keep the docs consistent with what Swift actually needs.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

Removes `zip` from the Ubuntu 22.04 apt package list - it's not in the Swift Docker image, only `unzip` is needed.

Part of #954