### PR TITLE
Remove zip from Ubuntu 24.04 package list

### DIFF
--- a/_includes/linux/ubuntu2404.html
+++ b/_includes/linux/ubuntu2404.html
@@ -15,7 +15,6 @@ $ apt-get install \
           libz3-dev \
           pkg-config \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
Same issue as Ubuntu 22.04 - the Ubuntu 24.04 installation page lists zip as a required package, but the swiftlang/swift-docker Dockerfile for 6.1/ubuntu/24.04 doesn't install it. Only unzip is needed. Removing the incorrect entry.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

Removes `zip` from the Ubuntu 24.04 apt package list - it's not in the Swift Docker image, only `unzip` is needed.

Part of #954