### PR TITLE
OpenAPI: Document the Android Swift SDK dev-toolchain endpoint

### DIFF
--- a/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
+++ b/openapi/TestSwiftOrgClient/swiftorgClient/Tool.swift
@@ -112,6 +112,26 @@ struct Tool {
         )
       )
     }
+    // Android dev SDKs are published for `main` and every release branch from 6.3
+    // onward; the pre-Android branches (6.0–6.2) return 404. Iterate all known
+    // branches and skip those, mirroring the `excluded` deny-matrix above so a new
+    // branch is covered automatically once it appears in KnownSourceBranch.
+    let androidUnsupportedBranches: Set<Components.Schemas.KnownSourceBranch> = [
+      ._6_0, ._6_1, ._6_2,
+    ]
+    for branch in Components.Schemas.KnownSourceBranch.allCases
+    where !androidUnsupportedBranches.contains(branch) {
+      tests.append(
+        .init(
+          name: "listAndroidSDKDevToolchains(\(branch.rawValue))",
+          work: {
+            _ = try await client.listAndroidSDKDevToolchains(
+              .init(path: .init(branch: .init(value1: branch)))
+            ).ok.body.json
+          }
+        )
+      )
+    }
     tests.append(
       .init(
         name: "getCurrentSwiftlyRelease",

--- a/openapi/swiftorg.yaml
+++ b/openapi/swiftorg.yaml
@@ -93,6 +93,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DevToolchainsForArch'
+  /install/dev/{branch}/android-sdk.json:
+    parameters:
+      - name: branch
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/SourceBranch'
+    get:
+      operationId: listAndroidSDKDevToolchains
+      summary: Fetch all development Swift SDKs for Android
+      tags:
+        - Toolchains
+      responses:
+        '200':
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DevToolchainsForArch'
   /swiftly.json:
     get:
       operationId: getCurrentSwiftlyRelease
@@ -196,6 +215,11 @@ components:
         - Swift Development Snapshot
         - Swift Static SDK Development Snapshot
         - Swift Wasm SDK Development Snapshot
+        # The Android SDK is published under two names: `main` uses the first, while
+        # release branches (6.3, 6.4.x, …) use the second. Both are live — keep both;
+        # neither is a removable duplicate.
+        - Swift SDK for Android Development Snapshot
+        - Swift Android SDK Development Snapshot
     DevToolchainKind:
       anyOf:
         - $ref: '#/components/schemas/KnownDevToolchainKind'


### PR DESCRIPTION
The swift.org API serves Android dev SDKs at `/install/dev/{branch}/android-sdk.json`, but the endpoint and its toolchain-kind names were absent from the OpenAPI document. This adds the path (mirroring `wasm-sdk.json`, returning `DevToolchainsForArch`) and both Android names to `KnownDevToolchainKind`.