### PR TITLE
Fix Debian 12 package list to match Swift 6.1 Docker image

### DIFF
--- a/_includes/linux/debian12.html
+++ b/_includes/linux/debian12.html
@@ -1,6 +1,6 @@
 {% highlight bash %}
 $ apt install \
-      binutils-gold \
+      binutils \
       gcc \
       git \
       libcurl4-openssl-dev \
@@ -9,6 +9,7 @@ $ apt install \
       libncurses-dev \
       libpython3-dev \
       libsqlite3-dev \
+      libstdc++-12-dev \
       libxml2-dev \
       pkg-config \
       tzdata \


### PR DESCRIPTION
I was checking the Debian 12 install page against the official swiftlang/swift-docker Dockerfile (6.1/debian/12). Two issues: the page lists `binutils-gold` but the Docker image installs `binutils`, and `libstdc++-12-dev` is missing entirely from the page even though it's a required dependency.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

Fixes `binutils-gold` → `binutils` and adds missing `libstdc++-12-dev` to the Debian 12 apt package list.

Part of #954