### PR TITLE
Fix an issue where author information was being show incorrectly/differently when specified in front-matter as `authors: [name]` vs `authors: name`.

### DIFF
--- a/_layouts/new-layouts/post.html
+++ b/_layouts/new-layouts/post.html
@@ -8,8 +8,16 @@ layout: new-layouts/base
   <div class="content">
     <h1>{{ page.title }}</h1>
 
+    {% if page.author.first %}
+      {% assign authors_count = page.author.size %}
+    {% elsif page.author %}
+      {% assign authors_count = 1 %}
+    {% else %}
+      {% assign authors_count = 0 %}
+    {% endif %}
+
     {% assign compact_flag = false %}
-    {% if page.author.size > 1 %}
+    {% if authors_count > 1 %}
       {% assign compact_flag = true %}
     {% endif %}
     {% include authors.html authors=page.author compact=compact_flag fullwidth=true %}
@@ -33,16 +41,10 @@ layout: new-layouts/base
     />
     {% endif %}
     <div class="details">
-      {{ content }} {% if page.author %}
-      
-      {% assign authors = page.author | array %}
-
-      {% if authors.size > 1 %}
+      {{ content }} {% if authors_count > 1 %}
         <hr />
         <h2>Authors</h2>
-        {% include authors.html authors=authors %}
-      {% endif %}
-
+        {% include authors.html authors=page.author %}
       {% endif %}
 
       <hr />

--- a/atom.xml
+++ b/atom.xml
@@ -12,14 +12,22 @@
   {% for post in posts limit: 20 %}
   <entry>
     <title>{{ post.title }}</title>
-    {% assign author = site.data.authors[post.author] %}
-    <author>
-    {% if author.name %}
-      <name>{{ author.name }}</name>
+    {% if post.author %}
+      {% for author_key in post.author %}
+        {% assign author = site.data.authors[author_key] %}
+        <author>
+        {% if author.name %}
+          <name>{{ author.name }}</name>
+        {% else %}
+          <name>Swift.org</name>
+        {% endif %}
+        </author>
+      {% endfor %}
     {% else %}
-      <name>Swift.org</name>
+      <author>
+        <name>Swift.org</name>
+      </author>
     {% endif %}
-    </author>
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.url }}</id>


### PR DESCRIPTION
Single-author posts could be shown with bios at the top or in an Authors section at the bottom depending on how they were specified. This PR normalizes both forms to produce the same page (bio at top, no separate Authors section).

### Motivation:

Noticed while developing the STTI blog post but didn't feel like folding it in.

### Modifications:

Post template tracks number of authors properly, whether specified in front matter as a string or a list and atom feed loops over authors instead of emitting just one.

### Result:

Post generates top bio and/or Authors section as appropriate. Authors in atom feed are emitted in a loop so everyone gets even billing.