### PR TITLE
Update swift-corelibs-libdispatch URLs to swiftlang org

### DIFF
--- a/documentation/core-libraries/_libdispatch.md
+++ b/documentation/core-libraries/_libdispatch.md
@@ -4,4 +4,4 @@ Grand Central Dispatch (GCD or libdispatch) provides comprehensive support for c
 
 libdispatch is currently available on all Darwin platforms. This project aims to make a modern version of libdispatch available on all other Swift platforms. To do this, we will implement as much of the portable subset of the API as possible, using the existing open source C implementation.
 
-More information about libdispatch for Linux is available on our [GitHub project page](http://www.github.com/apple/swift-corelibs-libdispatch).
+More information about libdispatch for Linux is available on our [GitHub project page](https://github.com/swiftlang/swift-corelibs-libdispatch).

--- a/documentation/source-code/index.md
+++ b/documentation/source-code/index.md
@@ -24,7 +24,7 @@ file](https://github.com/swiftlang/swift/blob/main/README.md).
 [swift-corelibs-foundation](https://github.com/swiftlang/swift-corelibs-foundation)
 : The source code for Foundation, which provides common functionality for all applications.
 
-[swift-corelibs-libdispatch](https://github.com/apple/swift-corelibs-libdispatch)
+[swift-corelibs-libdispatch](https://github.com/swiftlang/swift-corelibs-libdispatch)
 : The source code for libdispatch, which provides concurrency primitives for working on multicore hardware.
 
 [swift-corelibs-xctest](https://github.com/swiftlang/swift-corelibs-xctest)


### PR DESCRIPTION
Update swift-corelibs-libdispatch repository URLs from apple org to swiftlang org.

### Motivation:

The swift-corelibs-libdispatch repository moved from github.com/apple to github.com/swiftlang. The source-code page already had the correct URL for swift-corelibs-foundation and swift-corelibs-xctest, but libdispatch was missed. The core-libraries page also had an outdated URL using http://www instead of https://.

### Modifications:

- `documentation/source-code/index.md`: Updated libdispatch link from apple/swift-corelibs-libdispatch to swiftlang/swift-corelibs-libdispatch
- - `documentation/core-libraries/_libdispatch.md`: Updated link from http://www.github.com/apple/swift-corelibs-libdispatch to https://github.com/swiftlang/swift-corelibs-libdispatch