### PR TITLE
Update LLVM URLs from http to https on source-code page

### DIFF
--- a/documentation/source-code/index.md
+++ b/documentation/source-code/index.md
@@ -71,7 +71,7 @@ file](https://github.com/swiftlang/swift/blob/main/README.md).
 ## Cloned Repositories
 
 Swift builds upon several other open-source projects, most notably
-[the LLVM Compiler Infrastructure](http://llvm.org). Swift's clones of
+[the LLVM Compiler Infrastructure](https://llvm.org). Swift's clones of
 the repositories of those open-source projects contain Swift-specific
 changes and are merged regularly from their upstream sources. 
 For more information about the clone of the LLVM repository, see
@@ -79,7 +79,7 @@ For more information about the clone of the LLVM repository, see
 in the [project-operations](https://github.com/swiftlang/project-operations/) repository.
 
 [llvm-project](https://github.com/swiftlang/llvm-project)
-: The source code for [LLVM](http://llvm.org), with a handful of Swift-specific additions. Merged regularly from the [LLVM sources at llvm.org](https://github.com/llvm/llvm-project).
+: The source code for [LLVM](https://llvm.org), with a handful of Swift-specific additions. Merged regularly from the [LLVM sources at llvm.org](https://github.com/llvm/llvm-project).
 
 [swift-cmark](https://github.com/swiftlang/swift-cmark)
 : The source code for [CommonMark](https://github.com/jgm/cmark), which is used in the Swift compiler.


### PR DESCRIPTION
The LLVM website supports HTTPS. Updated the two references to http://llvm.org to use https://llvm.org instead.

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
