### PR TITLE
Update Apple bug reporter link to Feedback Assistant

### DIFF
--- a/contributing/_reporting-bugs.md
+++ b/contributing/_reporting-bugs.md
@@ -5,7 +5,7 @@ Reporting bugs is a great way for anyone to help improve Swift. The open source 
 <div class="info" markdown="1">
 If a bug can be reproduced only within an Xcode project or a playground,
 or if the bug is associated with an Apple NDA,
-please file a report to Apple's [bug reporter][apple-bugtracker] instead.
+please file a report to Apple's [Feedback Assistant][apple-bugtracker] instead.
 </div>
 
 When opening an issue, please include the following:
@@ -26,5 +26,5 @@ Before filing an issue requesting a new language feature, see the [Swift Evoluti
 </div>
 
 [bugtracker]: http://github.com/swiftlang/swift/issues
-[apple-bugtracker]: https://bugreport.apple.com
+[apple-bugtracker]: https://feedbackassistant.apple.com
 [evolution-repo]: https://github.com/swiftlang/swift-evolution "Link to the Swift evolution repository on GitHub"


### PR DESCRIPTION
### Motivation:

The contributing guide referenced Apple's bug reporter at bugreport.apple.com, but Apple replaced that with Feedback Assistant (feedbackassistant.apple.com). I noticed this while reading through the contributing docs - the old URL redirects anyway, but the link text and URL in the source were still pointing to the old name.

### Modifications:

- Updated link text from "bug reporter" to "Feedback Assistant" in the NDA/Xcode note
- Updated the `[apple-bugtracker]` reference URL from `https://bugreport.apple.com` to `https://feedbackassistant.apple.com`

### Result:

The contributing guide now correctly names and links to Feedback Assistant.

Closes #1325