### PR TITLE
Fix Fedora 39 package list to match Swift Docker image

### DIFF
--- a/_includes/linux/fedora39.html
+++ b/_includes/linux/fedora39.html
@@ -6,10 +6,11 @@ $ yum install \
       libcurl-devel \
       libedit-devel \
       libicu-devel \
+      libstdc++-devel \
+      libstdc++-static \
       libuuid-devel \
       libxml2-devel \
       python3-devel \
       sqlite-devel \
-      zip \
       unzip
 {% endhighlight %}


### PR DESCRIPTION
### Motivation:

I was comparing the packages listed on the install page against the swift-docker Dockerfile for Fedora 39 and found a few differences. The `zip` package isn't in the Docker image, and `libstdc++-devel` and `libstdc++-static` are required but missing from the website list.

### Modifications:

- Removed `zip` (not present in the Swift Docker image for Fedora 39)
- Added `libstdc++-devel` and `libstdc++-static` in alphabetical order

### Result:

The Fedora 39 package list on the install page now matches what's in the official Swift Docker image.

Part of #954