### PR TITLE
Fix Amazon Linux 2 package list: remove zip, add unzip

### DIFF
--- a/_includes/linux/amazonlinux2.html
+++ b/_includes/linux/amazonlinux2.html
@@ -4,7 +4,6 @@ $ yum install \
       gcc \
       git \
       glibc-static \
-      zip \
       gzip \
       libbsd \
       libcurl \
@@ -15,5 +14,6 @@ $ yum install \
       libuuid \
       libxml2 \
       tar \
-      tzdata
+      tzdata \
+      unzip
 {% endhighlight %}


### PR DESCRIPTION
### Motivation:

Noticed the Amazon Linux 2 package list had `zip` which isn't in the Swift Docker image for that distro, and was missing `unzip` which is needed. Small cleanup to keep the install docs in sync with what's actually required.

### Modifications:

- Removed `zip` (not present in the Swift Docker image for Amazon Linux 2)
- Added `unzip`

### Result:

The Amazon Linux 2 package list now matches the Swift Docker image.

Part of #954