### PR TITLE
Remove zip from Ubuntu 22.04 package list

### DIFF
--- a/_includes/linux/ubuntu2204.html
+++ b/_includes/linux/ubuntu2204.html
@@ -15,7 +15,6 @@ $ apt-get install \
           pkg-config \
           python3-lldb-13 \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
### Motivation:

The `zip` package isn't required for Swift on Ubuntu 22.04 - I cross-checked against the swift-docker image for this distro and it's not listed there. The same cleanup has already been done for other Ubuntu versions.

### Modifications:

- Removed `zip` from the Ubuntu 22.04 package list

### Result:

The Ubuntu 22.04 package list no longer includes `zip`, consistent with the Swift Docker image and other Ubuntu version pages.

Part of #954