### PR TITLE
Remove zip from Ubuntu 24.04 package list

### DIFF
--- a/_includes/linux/ubuntu2404.html
+++ b/_includes/linux/ubuntu2404.html
@@ -15,7 +15,6 @@ $ apt-get install \
           libz3-dev \
           pkg-config \
           tzdata \
-          zip \
           unzip \
           zlib1g-dev
 {% endhighlight %}


### PR DESCRIPTION
### Motivation:

Noticed `zip` is still listed in the Ubuntu 24.04 install instructions but it's not in the Swift Docker image for this distro. Same cleanup that's been done for the other Ubuntu versions.

### Modifications:

- Removed `zip` from the Ubuntu 24.04 package list

### Result:

The Ubuntu 24.04 package list no longer includes `zip`, consistent with the Swift Docker image and other Ubuntu version pages.

Part of #954