### PR TITLE
Add Compiler Diagnostics link to documentation page

### DIFF
--- a/_data/documentation.yaml
+++ b/_data/documentation.yaml
@@ -99,6 +99,10 @@
       url: /documentation/swift-compiler/
       description: |
        Overview of the Swift compiler architecture.
+    - title: Compiler Diagnostics
+      url: https://docs.swift.org/compiler/documentation/diagnostics
+      description: |
+        Documentation on diagnostics emitted by the Swift compiler and settings that control them.
     - title: Monthly Non-Darwin Swift Releases
       url: /documentation/monthly-non-darwin-release/
       description: |


### PR DESCRIPTION
Added documentation for Swift compiler diagnostics.The compiler diagnostics documentation at docs.swift.org/compiler/documentation/diagnostics wasn't linked from the main /documentation page at all - noticed it while looking through the docs. Added it to the Contributing section next to Compiler Architecture since it's closely related.

Closes #1090

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
