### PR TITLE
Fix Document class example missing initializer

### DIFF
--- a/documentation/articles/value-and-reference-types.md
+++ b/documentation/articles/value-and-reference-types.md
@@ -74,6 +74,10 @@ Since it is a reference to the same instance, changing the `text` of `friendDoc`
 ```swift
 class Document {
   var text: String
+
+  init(text: String) {
+    self.text = text
+  }
 }
 
 var myDoc = Document(text: "Great new article")


### PR DESCRIPTION
The reference-type example uses `Document(text:)` but classes don't get a synthesized memberwise initializer the way structs do - so the code doesn't actually compile. Added an explicit `init(text:)` to fix it.

Closes #1268

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
