### PR TITLE
Remove zip from RHEL UBI 9 package list

### DIFF
--- a/_includes/linux/rhelubi9.html
+++ b/_includes/linux/rhelubi9.html
@@ -10,6 +10,5 @@ yum install         \
   python3-devel     \
   rsync             \
   sqlite-devel      \
-  unzip             \
-  zip
+  unzip
 {% endhighlight %}


### PR DESCRIPTION
Spotted that the RHEL UBI 9 install instructions include zip in the package list, but it's not in the Swift Docker image dependencies. Removing it to match the actual requirements.

Part of #954

<!--
**Note**: Please ensure that any PRs follow the Swift.org [governance process](https://www.swift.org/website-governance/). If the PR involves a blog post we have a [separate governance process](https://www.swift.org/website-governance/#blog-posts-governance) for this. You must submit your post to the Website Workgroup for approval first. Any posts that have not followed this process will automatically be rejected.

_[One line description of your change]_
-->

### Motivation:

<!-- _[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_ -->

### Modifications:

<!-- _[Describe the modifications you've done.]_ -->

### Result:

<!-- _[After your change, what will change.]_ -->
