### PR TITLE
[Docs] Fix typos in documentation, including broken `conifg` key in the Neovim guide

### DIFF
--- a/documentation/articles/wasm-getting-started.md
+++ b/documentation/articles/wasm-getting-started.md
@@ -29,7 +29,7 @@ The distributed artifact bundles also include support for the experimental Embed
 
 Note that these steps are required on macOS even if you already have latest Xcode installed. Cross-compilation with Swift SDKs on Windows hosts is [not supported yet](https://github.com/swiftlang/swift-package-manager/issues/9148).
 
-1. [Install `swiftly` per the instructions](https://www.swift.org/install/) for the platform that you're bulding on.
+1. [Install `swiftly` per the instructions](https://www.swift.org/install/) for the platform that you're building on.
 
 2. Install Swift {{ release_name }} with `swiftly install {{ release_name }}`.
 

--- a/documentation/articles/wrapping-c-cpp-library-in-swift.md
+++ b/documentation/articles/wrapping-c-cpp-library-in-swift.md
@@ -7,7 +7,7 @@ author: [etcwilde, ktoso, yim-lee]
 
 There are many great libraries out there that are written in C/C++. It is possible to
 make use of these libraries in your Swift code without having to rewrite any of them
-in Swift. This article will explain a couple of ways to acheive this and best practices
+in Swift. This article will explain a couple of ways to achieve this and best practices
 when working with C/C++ in Swift.
 
 ## Package

--- a/documentation/articles/zero-to-swift-nvim.md
+++ b/documentation/articles/zero-to-swift-nvim.md
@@ -148,7 +148,7 @@ those directories now.
 
 See [lazy.nvim Configuration](https://lazy.folke.io/configuration) for details on configuring _lazy.nvim_.
 
-![_lazy.nvim_ package manger](/assets/images/zero-to-swift-nvim/Lazy.png)
+![_lazy.nvim_ package manager](/assets/images/zero-to-swift-nvim/Lazy.png)
 
 Note that your configuration won't look exactly like this.
 We have only installed _lazy.nvim_, so that is the only plugin that is listed on
@@ -390,7 +390,7 @@ Create a new file in your plugins directory for configuring the snippet plugin.
 return {
     {
         'L3MON4D3/LuaSnip',
-        conifg = function(opts)
+        config = function(opts)
             require('luasnip').setup(opts)
             require('luasnip.loaders.from_snipmate').load({ paths = "./snippets" })
         end,

--- a/documentation/cxx-interop/safe-interop/index.md
+++ b/documentation/cxx-interop/safe-interop/index.md
@@ -434,7 +434,7 @@ type `T` is transformed to `MutableSpan<T>` on the Swift side.
 If an API uses raw pointers rather than `std::span` - perhaps because it's written in C or Objective-C,
 or because it's an older C++ API that doesn't want to break backwards compatibility -
 it can still receive the same interop safety as `std::span`. This added bounds safety doesn't break
-source compatiblity, nor does it affect ABI. Instead it leverages bounds annotations to express the
+source compatibility, nor does it affect ABI. Instead it leverages bounds annotations to express the
 pointer bounds in terms of other parameters in the function signature.
 
 #### Annotating Pointers with Bounds Annotations

--- a/documentation/server/guides/deploying/heroku.md
+++ b/documentation/server/guides/deploying/heroku.md
@@ -112,7 +112,7 @@ You can use this command in terminal to set the file
 echo "web: NIOHTTP1Server 0.0.0.0 $PORT" > Procfile
 ```
 
-The contents of this file may vary depending on your server framework. For Vapor apps, the default Procfile content is the follwowing:
+The contents of this file may vary depending on your server framework. For Vapor apps, the default Procfile content is the following:
 
 ```bash
 web: Run serve --env production --hostname 0.0.0.0 --port $PORT


### PR DESCRIPTION
Fixes six typos across the documentation.

### Functional fix
- `documentation/articles/zero-to-swift-nvim.md` — the LuaSnip plugin spec in the Snippets section uses `conifg = function(opts)` instead of `config`. lazy.nvim silently ignores the misspelled key, so readers following the guide never get the LuaSnip `setup` / snipmate loader callback to run. The four other plugin specs in the same article already spell it `config`.

### Spelling-only fixes
- `documentation/articles/wasm-getting-started.md` — "bulding" → "building"
- `documentation/articles/wrapping-c-cpp-library-in-swift.md` — "acheive" → "achieve"
- `documentation/articles/zero-to-swift-nvim.md` — "package manger" → "package manager" (image alt text)
- `documentation/server/guides/deploying/heroku.md` — "follwowing" → "following"
- `documentation/cxx-interop/safe-interop/index.md` — "compatiblity" → "compatibility"

Wording-only changes to documentation content; no layout or code-behavior impact on the site itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)