### PR TITLE
[API] Add Debian 13 and Ubuntu 26.04 to the v1 install API

### DIFF
--- a/api/v1/install/dev/main/debian13.json
+++ b/api/v1/install/dev/main/debian13.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.development.debian13 | jsonify }},
+  "aarch64": {{ site.data.builds.development.debian13-aarch64 | jsonify }}
+}

--- a/api/v1/install/dev/main/ubuntu2604.json
+++ b/api/v1/install/dev/main/ubuntu2604.json
@@ -1,0 +1,6 @@
+---
+layout: none
+---
+{ "x86_64": {{ site.data.builds.development.ubuntu2604 | jsonify }},
+  "aarch64": {{ site.data.builds.development.ubuntu2604-aarch64 | jsonify}}
+}


### PR DESCRIPTION
This is needed for swiftlang/swiftly#569.

### Motivation:

This change is required to allow running `swiftly install main-snapshot` on Debian 13 and Ubuntu 26.04.

### Modifications:

I added Debian 13 and Ubuntu 26.04 to the v1 install API.

The following data already exist on this repository.

- [`site.data.builds.development.debian13`](https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/debian13.yml)
- [`site.data.builds.development.debian13-aarch64`](https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/debian13-aarch64.yml)
- [`site.data.builds.development.ubuntu2604`](https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/ubuntu2604.yml)
- [`site.data.builds.development.ubuntu2604-aarch64`](https://github.com/swiftlang/swift-org-website/blob/main/_data/builds/development/ubuntu2604-aarch64.yml)

references:

- #948 
- #949 

### Result:

The following endpoints should be available and return a list of snapshots.

- `https://swift.org/api/v1/install/dev/main/debian13.json`
- `https://swift.org/api/v1/install/dev/main/ubuntu2604.json`