### PR TITLE
Add CSS styling for tables in blog posts.

### DIFF
--- a/assets/stylesheets/new-stylesheets/_themes.scss
+++ b/assets/stylesheets/new-stylesheets/_themes.scss
@@ -40,6 +40,8 @@
   --blog-page-time-text-color: #8d8d8d;
   --blog-page-code-bg: #f2f2f2;
   --blog-divider-border: #979797;
+  --blog-table-border-color: #e2e2e2;
+  --blog-table-header-bg: #f2f2f2;
 
   --get-started-page-bg: #fafafa;
   --get-started-card-primary-bg: rgba(255, 255, 255, 0.9);
@@ -175,6 +177,8 @@
   --blog-page-time-text-color: #8d8d8d;
   --blog-page-code-bg: #111727;
   --blog-divider-border: #979797;
+  --blog-table-border-color: #384461;
+  --blog-table-header-bg: #111727;
 
   --get-started-page-bg: rgb(5, 20, 35);
   --get-started-card-primary-bg: rgba(35, 52, 74, 0.9);

--- a/assets/stylesheets/new-stylesheets/pages/_post.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_post.scss
@@ -91,9 +91,11 @@
       table {
         width: 100%;
         margin-bottom: 1.5em;
-        border-collapse: collapse;
+        border-collapse: separate;
+        border-spacing: 0;
         border: 1px solid var(--blog-table-border-color);
         border-radius: 10px;
+        overflow: hidden;
 
         th,
         td {
@@ -104,14 +106,6 @@
         th {
           background: var(--blog-table-header-bg);
           font-weight: 600;
-
-          &:first-child {
-            border-top-left-radius: 10px;
-          }
-
-          &:last-child {
-            border-top-right-radius: 10px;
-          }
         }
 
         tr:last-child td {

--- a/assets/stylesheets/new-stylesheets/pages/_post.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_post.scss
@@ -87,6 +87,43 @@
         border-radius: 10px;
         margin-bottom: 1em;
       }
+
+      table {
+        width: 100%;
+        margin-bottom: 1.5em;
+        border-collapse: collapse;
+        border: 1px solid var(--blog-table-border-color);
+        border-radius: 10px;
+
+        th,
+        td {
+          padding: 10px 16px;
+          border-bottom: 1px solid var(--blog-table-border-color);
+        }
+
+        th {
+          background: var(--blog-table-header-bg);
+          font-weight: 600;
+
+          &:first-child {
+            border-top-left-radius: 10px;
+          }
+
+          &:last-child {
+            border-top-right-radius: 10px;
+          }
+        }
+
+        tr:last-child td {
+          border-bottom: none;
+        }
+
+        @media (max-width: 768px) {
+          display: block;
+          overflow-x: auto;
+          white-space: nowrap;
+        }
+      }
     }
 
     .card-grid {

--- a/assets/stylesheets/new-stylesheets/pages/_post.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_post.scss
@@ -95,7 +95,6 @@
         border-spacing: 0;
         border: 1px solid var(--blog-table-border-color);
         border-radius: 10px;
-        overflow: hidden;
 
         th,
         td {
@@ -106,6 +105,14 @@
         th {
           background: var(--blog-table-header-bg);
           font-weight: 600;
+
+          &:first-child {
+            border-top-left-radius: 10px;
+          }
+
+          &:last-child {
+            border-top-right-radius: 10px;
+          }
         }
 
         tr:last-child td {

--- a/assets/stylesheets/new-stylesheets/pages/_post.scss
+++ b/assets/stylesheets/new-stylesheets/pages/_post.scss
@@ -113,7 +113,6 @@
         }
 
         @media (max-width: 768px) {
-          display: block;
           overflow-x: auto;
           white-space: nowrap;
         }


### PR DESCRIPTION
Adds CSS styling for tables in blog posts, which is currently very bare.

Before:

<img width="354" height="220" alt="before" src="https://github.com/user-attachments/assets/8c368af2-78bc-48bd-a5ac-60a40f72d97a" />

After:

<img width="1023" height="365" alt="light" src="https://github.com/user-attachments/assets/4aa3852c-cf9f-4700-9692-f9ea11e69d80" />

<img width="1023" height="365" alt="dark" src="https://github.com/user-attachments/assets/258a232e-b96e-49f6-b328-637ac763aab0" />

Fixes #1476