### PR TITLE
[cxx-interop] Remove quotation marks from SWIFT_NAME argument

### DIFF
--- a/documentation/cxx-interop/index.md
+++ b/documentation/cxx-interop/index.md
@@ -800,7 +800,7 @@ the following C++ class gets renamed to `CxxLibraryError` structure in Swift:
 ```c++
 class Error {
   ...
-} SWIFT_NAME("CxxLibraryError");
+} SWIFT_NAME(CxxLibraryError);
 ```
 
 When renaming a function, you need to specify the Swift function name


### PR DESCRIPTION
The real annotation stringifies its argument, so the argument should be unquoted.
