### PR TITLE
Update Fedora installation documentation for 6.4.x.

### DIFF
--- a/install/linux/fedora/39/index.md
+++ b/install/linux/fedora/39/index.md
@@ -3,21 +3,6 @@ layout: new-layouts/install-linux-version
 title: Install Swift
 ---
 
-{% include /new-includes/assigns/linux-platform-builds.html
-    platform="Fedora 39"
-    aarch64="true"
-    branch_dir="development"
-    development="main"
-    docker_tag="nightly-fedora-39"
-    development_builds=site.data.builds.development.fedora39
-    aarch64_development_builds=site.data.builds.development.fedora39-aarch64
-    development_2="release/6.4.x"
-    docker_tag_2="nightly-6.4.x-fedora39"
-    development_builds_2=site.data.builds.swift-6_4_x-branch.fedora41
-    aarch64_development_builds_2=site.data.builds.swift-6_4_x-branch.fedora41-aarch64
-    branch_dir_2="swift-6.4.x-branch"
-%}
-
 {% include /new-includes/components/linux-releases.html
   docker_tag=docker_tag
   development_builds=development_builds

--- a/install/linux/fedora/41/index.md
+++ b/install/linux/fedora/41/index.md
@@ -11,6 +11,11 @@ title: Install Swift
     docker_tag="nightly-fedora-41"
     development_builds=site.data.builds.development.fedora41
     aarch64_development_builds=site.data.builds.development.fedora41-aarch64
+    development_2="release/6.4.x"
+    docker_tag_2="nightly-6.4.x-fedora41"
+    development_builds_2=site.data.builds.swift-6_4_x-branch.fedora41
+    aarch64_development_builds_2=site.data.builds.swift-6_4_x-branch.fedora41-aarch64
+    branch_dir_2="swift-6.4.x-branch"
 %}
 
 {% include /new-includes/components/linux-releases.html


### PR DESCRIPTION
Fedora 39 builds are not published for Swift 6.4.x, but are published for Fedora 41.

rdar://184540762